### PR TITLE
Add support for transparent characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#420](https://github.com/embedded-graphics/embedded-graphics/pull/420) Added support for `SubImage`s.
 - [#429](https://github.com/embedded-graphics/embedded-graphics/pull/429) Added `ToBytes` trait to convert colors into byte arrays.
 - [#431](https://github.com/embedded-graphics/embedded-graphics/pull/431) Added `MockDisplay::affected_area` to get the area affected by previous drawing operations.
+- [#439](https://github.com/embedded-graphics/embedded-graphics/pull/439) Added support to render transparent characters.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#420](https://github.com/embedded-graphics/embedded-graphics/pull/420) Added support for `SubImage`s.
 - [#429](https://github.com/embedded-graphics/embedded-graphics/pull/429) Added `ToBytes` trait to convert colors into byte arrays.
 - [#431](https://github.com/embedded-graphics/embedded-graphics/pull/431) Added `MockDisplay::affected_area` to get the area affected by previous drawing operations.
-- [#439](https://github.com/embedded-graphics/embedded-graphics/pull/439) Added support to render transparent characters.
+- [#439](https://github.com/embedded-graphics/embedded-graphics/pull/439) Added support to render transparent characters with a colored background.
 
 ### Changed
 


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [ ] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [ ] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Closes #408 

I think drawing a solid rectangle using the background color is not particularly useful. This PR modifies text rendering so that the text can be transparent in this case.
