### PR TITLE
Add benches from simulator crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,32 @@ float-cmp = { version = "0.8.0" }
 micromath = { version = "1.0.0", default-features = false }
 nalgebra = { version = "0.19.0", optional = true, default-features = false }
 
+[dev-dependencies]
+arrayvec = { version = "0.5.1", default-features = false }
+criterion = { version = "0.3.3" }
+
 [features]
 default = []
 nalgebra_support = [ "nalgebra" ]
 fixed_point = [ "fixed" ]
 
-[dev-dependencies]
-arrayvec = { version = "0.5.1", default-features = false }
+[[bench]]
+harness = false
+name = "primitives"
+
+[[bench]]
+harness = false
+name = "primitives_fixed_point"
+required-features = ["fixed_point"]
+
+[[bench]]
+harness = false
+name = "fonts"
+
+[[bench]]
+harness = false
+name = "image"
+
+[[bench]]
+harness = false
+name = "contains"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,12 @@ float-cmp = { version = "0.8.0" }
 micromath = { version = "1.0.0", default-features = false }
 nalgebra = { version = "0.19.0", optional = true, default-features = false }
 
+# criterion is not listed as a dev-dependency to work around a problem with no_std compatibility
+# and because dev-dependencies can't be optional
+criterion = { version = "0.3.3", optional = true }
+
 [dev-dependencies]
 arrayvec = { version = "0.5.1", default-features = false }
-criterion = { version = "0.3.3" }
 
 [features]
 default = []
@@ -42,20 +45,24 @@ fixed_point = [ "fixed" ]
 [[bench]]
 harness = false
 name = "primitives"
+required-features = ["criterion"]
 
 [[bench]]
 harness = false
 name = "primitives_fixed_point"
-required-features = ["fixed_point"]
+required-features = ["criterion", "fixed_point"]
 
 [[bench]]
 harness = false
 name = "fonts"
+required-features = ["criterion"]
 
 [[bench]]
 harness = false
 name = "image"
+required-features = ["criterion"]
 
 [[bench]]
 harness = false
 name = "contains"
+required-features = ["criterion"]

--- a/benches/common.rs
+++ b/benches/common.rs
@@ -1,0 +1,58 @@
+use embedded_graphics::prelude::*;
+use std::convert::TryFrom;
+
+const SIZE: usize = 256;
+
+pub struct Framebuffer<C> {
+    pixels: [[C; SIZE]; SIZE],
+}
+
+impl<C> Framebuffer<C>
+where
+    C: PixelColor + Default,
+{
+    pub fn new() -> Self {
+        Self {
+            pixels: [[C::default(); 256]; 256],
+        }
+    }
+
+    fn set_pixel(&mut self, position: Point, color: C) {
+        if let (Ok(x), Ok(y)) = (usize::try_from(position.x), usize::try_from(position.y)) {
+            self.pixels
+                .get_mut(y)
+                .and_then(|row| row.get_mut(x))
+                .map(|pixel| *pixel = color);
+        } else {
+            panic!(
+                "tried to set pixel outside the framebuffer at {:?}",
+                position
+            );
+        }
+    }
+}
+
+impl<C> DrawTarget for Framebuffer<C>
+where
+    C: PixelColor + Default,
+{
+    type Color = C;
+    type Error = core::convert::Infallible;
+
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        for Pixel(position, color) in pixels {
+            self.set_pixel(position, color);
+        }
+
+        Ok(())
+    }
+}
+
+impl<C> OriginDimensions for Framebuffer<C> {
+    fn size(&self) -> Size {
+        Size::new_equal(SIZE as u32)
+    }
+}

--- a/benches/common.rs
+++ b/benches/common.rs
@@ -1,6 +1,11 @@
 use embedded_graphics::prelude::*;
 use std::convert::TryFrom;
 
+#[cfg(not(feature = "criterion"))]
+compile_error!(
+    "The `criterion' feature must be enabled to run the benchmarks. Rerun with `just bench'."
+);
+
 const SIZE: usize = 256;
 
 pub struct Framebuffer<C> {

--- a/benches/contains.rs
+++ b/benches/contains.rs
@@ -1,0 +1,28 @@
+use criterion::*;
+use embedded_graphics::{prelude::*, primitives::*};
+
+fn triangle_contains_inside(c: &mut Criterion) {
+    c.bench_function("triangle contains point (inside)", |b| {
+        let object = Triangle::new(Point::new(5, 10), Point::new(15, 20), Point::new(5, 20));
+        let midpoint = object.bounding_box().center();
+
+        b.iter(|| object.contains(midpoint))
+    });
+}
+
+// Point outside triangle but still within bounding box. If point is outside bounding box, this
+// benchmark doesn't exercise the expensive point-in-triangle code.
+fn triangle_contains_outside(c: &mut Criterion) {
+    c.bench_function("triangle contains point (outside)", |b| {
+        let object = Triangle::new(Point::new(5, 10), Point::new(55, 20), Point::new(30, 40));
+
+        b.iter(|| object.contains(Point::new(50, 13)))
+    });
+}
+
+criterion_group!(
+    contains,
+    triangle_contains_inside,
+    triangle_contains_outside
+);
+criterion_main!(contains);

--- a/benches/fonts.rs
+++ b/benches/fonts.rs
@@ -1,0 +1,35 @@
+use criterion::*;
+use embedded_graphics::{
+    fonts::{Font12x16, Font6x8, Text},
+    geometry::Point,
+    pixelcolor::Gray8,
+    prelude::*,
+    style::TextStyle,
+};
+
+mod common;
+
+use common::Framebuffer;
+
+fn font_6x8(c: &mut Criterion) {
+    c.bench_function("font 6x8 Hello world!", |b| {
+        let object = Text::new("Hello world!", Point::zero())
+            .into_styled(TextStyle::new(Font6x8, Gray8::new(10)));
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| object.draw(&mut framebuffer))
+    });
+}
+
+fn font_12x16(c: &mut Criterion) {
+    c.bench_function("font 12x16 Hello world!", |b| {
+        let object = Text::new("Hello world!", Point::zero())
+            .into_styled(TextStyle::new(Font12x16, Gray8::new(10)));
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| object.draw(&mut framebuffer))
+    });
+}
+
+criterion_group!(fonts, font_6x8, font_12x16);
+criterion_main!(fonts);

--- a/benches/image.rs
+++ b/benches/image.rs
@@ -1,0 +1,25 @@
+use criterion::*;
+use embedded_graphics::{
+    image::{Image, ImageRaw},
+    pixelcolor::BinaryColor,
+    prelude::*,
+};
+
+mod common;
+
+use common::Framebuffer;
+
+fn image_1bpp(c: &mut Criterion) {
+    c.bench_function("image 4x4px", |b| {
+        let bytes = include_bytes!("../assets/patch_1bpp.raw");
+
+        let image: ImageRaw<BinaryColor> = ImageRaw::new(bytes, 4, 4);
+        let object = Image::new(&image, Point::zero());
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| object.draw(&mut framebuffer))
+    });
+}
+
+criterion_group!(images, image_1bpp);
+criterion_main!(images);

--- a/benches/primitives.rs
+++ b/benches/primitives.rs
@@ -1,0 +1,252 @@
+use criterion::*;
+use embedded_graphics::{
+    pixelcolor::Gray8,
+    prelude::*,
+    primitives::*,
+    style::{PrimitiveStyle, PrimitiveStyleBuilder},
+};
+
+mod common;
+
+use common::Framebuffer;
+
+fn filled_circle(c: &mut Criterion) {
+    c.bench_function("filled circle", |b| {
+        let style = PrimitiveStyleBuilder::new()
+            .fill_color(Gray8::new(1))
+            .stroke_color(Gray8::new(10))
+            .stroke_width(1)
+            .build();
+
+        let object = Circle::new(Point::new(100, 100), 100).into_styled(style);
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| object.draw(&mut framebuffer))
+    });
+}
+
+fn filled_rect(c: &mut Criterion) {
+    c.bench_function("filled rectangle", |b| {
+        let style = PrimitiveStyleBuilder::new()
+            .fill_color(Gray8::new(1))
+            .stroke_color(Gray8::new(10))
+            .stroke_width(1)
+            .build();
+
+        let object = Rectangle::new(Point::new(100, 100), Size::new(100, 100)).into_styled(style);
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| object.draw(&mut framebuffer))
+    });
+}
+
+fn empty_rect(c: &mut Criterion) {
+    c.bench_function("unfilled rectangle", |b| {
+        let object = Rectangle::new(Point::new(100, 100), Size::new(100, 100))
+            .into_styled(PrimitiveStyle::with_stroke(Gray8::new(10), 1));
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| object.draw(&mut framebuffer))
+    });
+}
+
+fn line(c: &mut Criterion) {
+    c.bench_function("line", |b| {
+        let object = Line::new(Point::new(100, 100), Point::new(200, 200))
+            .into_styled(PrimitiveStyle::with_stroke(Gray8::new(10), 1));
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| object.draw(&mut framebuffer))
+    });
+}
+
+fn thick_line(c: &mut Criterion) {
+    c.bench_function("thick line 10px wide", |b| {
+        let object = Line::new(Point::new(100, 100), Point::new(150, 200))
+            .into_styled(PrimitiveStyle::with_stroke(Gray8::new(10), 10));
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| object.draw(&mut framebuffer))
+    });
+}
+
+fn thicker_line(c: &mut Criterion) {
+    c.bench_function("thick line 50px wide", |b| {
+        let object = Line::new(Point::new(50, 50), Point::new(150, 200))
+            .into_styled(PrimitiveStyle::with_stroke(Gray8::new(10), 50));
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| object.draw(&mut framebuffer))
+    });
+}
+
+fn triangle(c: &mut Criterion) {
+    c.bench_function("triangle", |b| {
+        let object = Triangle::new(Point::new(5, 10), Point::new(15, 20), Point::new(5, 20))
+            .into_styled(PrimitiveStyle::with_stroke(Gray8::new(10), 1));
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| object.draw(&mut framebuffer))
+    });
+}
+
+fn filled_triangle(c: &mut Criterion) {
+    c.bench_function("filled_triangle", |b| {
+        let object = Triangle::new(Point::new(5, 10), Point::new(15, 20), Point::new(5, 20))
+            .into_styled(PrimitiveStyle::with_fill(Gray8::new(1)));
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| object.draw(&mut framebuffer))
+    });
+}
+
+fn ellipse(c: &mut Criterion) {
+    c.bench_function("ellipse", |b| {
+        let object = Ellipse::new(Point::new(10, 10), Size::new(50, 30))
+            .into_styled(PrimitiveStyle::with_stroke(Gray8::new(1), 1));
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| object.draw(&mut framebuffer))
+    });
+}
+
+fn filled_ellipse(c: &mut Criterion) {
+    c.bench_function("filled_ellipse", |b| {
+        let object = Ellipse::new(Point::new(10, 10), Size::new(50, 30))
+            .into_styled(PrimitiveStyle::with_fill(Gray8::new(1)));
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| object.draw(&mut framebuffer))
+    });
+}
+
+fn arc(c: &mut Criterion) {
+    c.bench_function("arc", |b| {
+        let object = Arc::new(Point::new(100, 100), 100, -30.0.deg(), 150.0.deg())
+            .into_styled(PrimitiveStyle::with_stroke(Gray8::new(1), 1));
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| object.draw(&mut framebuffer))
+    });
+}
+
+fn sector(c: &mut Criterion) {
+    c.bench_function("sector", |b| {
+        let object = Sector::new(Point::new(100, 100), 100, -30.0.deg(), 150.0.deg())
+            .into_styled(PrimitiveStyle::with_stroke(Gray8::new(1), 1));
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| object.draw(&mut framebuffer))
+    });
+}
+
+fn filled_sector(c: &mut Criterion) {
+    c.bench_function("filled_sector", |b| {
+        let object = Sector::new(Point::new(100, 100), 100, -30.0.deg(), 150.0.deg())
+            .into_styled(PrimitiveStyle::with_fill(Gray8::new(1)));
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| object.draw(&mut framebuffer))
+    });
+}
+
+fn polyline(c: &mut Criterion) {
+    c.bench_function("polyline", |b| {
+        let points = [
+            Point::new(105, 110),
+            Point::new(115, 120),
+            Point::new(105, 120),
+            Point::new(130, 150),
+            Point::new(200, 200),
+        ];
+
+        let object =
+            Polyline::new(&points).into_styled(PrimitiveStyle::with_stroke(Gray8::new(1), 1));
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| object.draw(&mut framebuffer))
+    });
+}
+
+fn thick_polyline(c: &mut Criterion) {
+    c.bench_function("thick polyline", |b| {
+        let points = [
+            Point::new(105, 110),
+            Point::new(115, 120),
+            Point::new(105, 120),
+            Point::new(130, 150),
+            Point::new(200, 200),
+        ];
+
+        let object =
+            Polyline::new(&points).into_styled(PrimitiveStyle::with_stroke(Gray8::new(1), 10));
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| object.draw(&mut framebuffer))
+    });
+}
+
+fn rounded_rectangle(c: &mut Criterion) {
+    c.bench_function("rounded_rectangle", |b| {
+        let object = RoundedRectangle::new(
+            Rectangle::new(Point::new(10, 10), Size::new(50, 40)),
+            CornerRadii::new(Size::new(10, 12)),
+        )
+        .into_styled(
+            PrimitiveStyleBuilder::new()
+                .stroke_width(5)
+                .fill_color(Gray8::new(10))
+                .stroke_color(Gray8::new(60))
+                .build(),
+        );
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| object.draw(&mut framebuffer))
+    });
+}
+
+fn rounded_rectangle_corners(c: &mut Criterion) {
+    c.bench_function("rounded_rectangle_corners", |b| {
+        let object = &RoundedRectangle::new(
+            Rectangle::new(Point::new(10, 10), Size::new(50, 40)),
+            CornerRadii {
+                top_left: Size::new(10, 12),
+                top_right: Size::new(14, 16),
+                bottom_right: Size::new(18, 20),
+                bottom_left: Size::new(22, 24),
+            },
+        )
+        .into_styled(
+            PrimitiveStyleBuilder::new()
+                .stroke_width(5)
+                .fill_color(Gray8::new(10))
+                .stroke_color(Gray8::new(60))
+                .build(),
+        );
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| object.draw(&mut framebuffer))
+    });
+}
+
+criterion_group!(
+    primitives,
+    filled_circle,
+    filled_rect,
+    empty_rect,
+    line,
+    thick_line,
+    thicker_line,
+    triangle,
+    filled_triangle,
+    ellipse,
+    filled_ellipse,
+    polyline,
+    thick_polyline,
+    rounded_rectangle,
+    rounded_rectangle_corners,
+    arc,
+    sector,
+    filled_sector
+);
+criterion_main!(primitives);

--- a/benches/primitives_fixed_point.rs
+++ b/benches/primitives_fixed_point.rs
@@ -1,0 +1,41 @@
+use criterion::*;
+use embedded_graphics::{
+    geometry::AngleUnit, pixelcolor::Gray8, prelude::*, primitives::*, style::PrimitiveStyle,
+};
+
+mod common;
+
+use common::Framebuffer;
+
+fn arc(c: &mut Criterion) {
+    c.bench_function("arc", |b| {
+        let object = &Arc::new(Point::new(100, 100), 100, -30.0.deg(), 150.0.deg())
+            .into_styled(PrimitiveStyle::with_stroke(Gray8::new(1), 1));
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| object.draw(&mut framebuffer))
+    });
+}
+
+fn sector(c: &mut Criterion) {
+    c.bench_function("sector", |b| {
+        let object = &Sector::new(Point::new(100, 100), 100, -30.0.deg(), 150.0.deg())
+            .into_styled(PrimitiveStyle::with_stroke(Gray8::new(1), 1));
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| object.draw(&mut framebuffer))
+    });
+}
+
+fn filled_sector(c: &mut Criterion) {
+    c.bench_function("filled_sector", |b| {
+        let object = &Sector::new(Point::new(100, 100), 100, -30.0.deg(), 150.0.deg())
+            .into_styled(PrimitiveStyle::with_fill(Gray8::new(1)));
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| object.draw(&mut framebuffer))
+    });
+}
+
+criterion_group!(primitives_fixed_point, arc, sector, filled_sector);
+criterion_main!(primitives_fixed_point);

--- a/justfile
+++ b/justfile
@@ -16,7 +16,11 @@ build: check-formatting test test-all build-benches check-readme check-links
 
 # Build the benches
 build-benches:
-    cargo bench --no-run
+    cargo bench --features "criterion" --no-run
+
+# Run the benches
+bench:
+    cargo bench --features "criterion"
 
 # Run cargo test in release mode
 test:

--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@ ci_build_image := "jamwaffles/circleci-embedded-graphics:1.40.0-cimg"
 # Building
 #----------
 
-build: check-formatting test test-all check-readme check-links
+build: check-formatting test test-all build-benches check-readme check-links
 
 # Build the benches
 build-benches:

--- a/justfile
+++ b/justfile
@@ -19,8 +19,8 @@ build-benches:
     cargo bench --features "criterion" --no-run
 
 # Run the benches
-bench:
-    cargo bench --features "criterion"
+bench *args:
+    cargo bench --features "criterion" {{args}}
 
 # Run cargo test in release mode
 test:

--- a/justfile
+++ b/justfile
@@ -30,7 +30,8 @@ check-formatting:
 # Cross compiles embedded-graphics for a target
 build-target target *args:
     cargo build --target {{target}} {{args}}
-    cargo build --target {{target}} --all-features {{args}}
+    cargo build --target {{target}} --features nalgebra {{args}}
+    cargo build --target {{target}} --features fixed {{args}}
 
 # Cross compiles embedded-graphics for all targets
 build-targets *args:

--- a/justfile
+++ b/justfile
@@ -5,6 +5,9 @@ target_dir := "target"
 # when upgrading the tag next time.
 ci_build_image := "jamwaffles/circleci-embedded-graphics:1.40.0-cimg"
 
+# list of all features except criterion
+all_features := "nalgebra fixed"
+
 #----------
 # Building
 #----------
@@ -21,7 +24,7 @@ test:
 
 # Run cargo test in release mode with all features enabled
 test-all:
-    cargo test --release --all-features
+    cargo test --release --features "{{all_features}}"
 
 # Check the formatting
 check-formatting:
@@ -30,11 +33,13 @@ check-formatting:
 # Cross compiles embedded-graphics for a target
 build-target target *args:
     cargo build --target {{target}} {{args}}
-    cargo build --target {{target}} --features nalgebra {{args}}
-    cargo build --target {{target}} --features fixed {{args}}
+    cargo build --target {{target}} --features "{{all_features}}" {{args}}
 
 # Cross compiles embedded-graphics for all targets
 build-targets *args:
+    #!/usr/bin/env bash
+    set -e
+
     for target in {{targets}}; do just build-target $target {{args}}; done
 
 # Install all targets used in the `build-targets` command
@@ -59,7 +64,7 @@ install-targets:
 # Generates the docs
 generate-docs:
     cargo clean --doc
-    cargo doc --all-features
+    cargo doc --features "{{all_features}}"
 
 # Runs cargo-deadlinks on the docs
 check-links: generate-docs


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR adds the benches from the simulator create to this crate. I'm not sure why we originally had to move them into the simulator crate, but it seems to work at the moment. IMO they belong in this crate, so I would like to try if this works and only move them somewhere else when we encounter problems again.

I also made some changes to the benches:

I've replaced the `tinybmp` image test by an `ImageRaw` one to remove the `tinybmp` dependency. IMO it would be better to add e-g drawing benches to `tinybmp` and `tinytga` anyway.

The benches used to collect pixels in a `Vec` which isn't the most accurate representation of actual drawing. Because the `Vec` size isn't known in advance the `Vec` might need to increase the capacity several times. The effect of this reallocation isn't huge, but I was able to measure it. This PR instead implements a simple framebuffer that is similar to what an display with an in memory framebuffer would use.