### PR TITLE
Add OffsetOutline trait to prelude

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -11,7 +11,7 @@ pub use crate::{
         raw::{RawData, ToBytes as _},
         GrayColor, IntoStorage, PixelColor, RgbColor, WebColors,
     },
-    primitives::{ContainsPoint, Primitive},
+    primitives::{ContainsPoint, OffsetOutline, Primitive},
     style::StyledPrimitiveAreas,
     transform::Transform,
     Drawable, Pixel,


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR adds the `OffsetOutline` trait to the prelude. The other traits in the `primitive` module are already included in the prelude, so I think it makes sense to also add this trait.