### PR TITLE
Use correct feature for nalgebra in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -6,7 +6,7 @@ target_dir := "target"
 ci_build_image := "jamwaffles/circleci-embedded-graphics:1.40.0-cimg"
 
 # list of all features except criterion
-all_features := "nalgebra fixed"
+all_features := "nalgebra_support fixed"
 
 #----------
 # Building

--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -483,7 +483,7 @@ use nalgebra::{base::Scalar, Vector2};
 #[cfg(feature = "nalgebra_support")]
 impl<N> From<Vector2<N>> for Point
 where
-    N: Into<i32> + Scalar,
+    N: Into<i32> + Scalar + Copy,
 {
     fn from(other: Vector2<N>) -> Self {
         Self::new(other[0].into(), other[1].into())
@@ -493,7 +493,7 @@ where
 #[cfg(feature = "nalgebra_support")]
 impl<N> From<&Vector2<N>> for Point
 where
-    N: Into<i32> + Scalar,
+    N: Into<i32> + Scalar + Copy,
 {
     fn from(other: &Vector2<N>) -> Self {
         Self::new(other[0].into(), other[1].into())

--- a/src/geometry/size.rs
+++ b/src/geometry/size.rs
@@ -358,7 +358,7 @@ use nalgebra::{base::Scalar, Vector2};
 #[cfg(feature = "nalgebra_support")]
 impl<N> From<Vector2<N>> for Size
 where
-    N: Into<u32> + Scalar,
+    N: Into<u32> + Scalar + Copy,
 {
     fn from(other: Vector2<N>) -> Self {
         Self::new(other[0].into(), other[1].into())
@@ -368,7 +368,7 @@ where
 #[cfg(feature = "nalgebra_support")]
 impl<N> From<&Vector2<N>> for Size
 where
-    N: Into<u32> + Scalar,
+    N: Into<u32> + Scalar + Copy,
 {
     fn from(other: &Vector2<N>) -> Self {
         Self::new(other[0].into(), other[1].into())

--- a/src/primitives/line/mod.rs
+++ b/src/primitives/line/mod.rs
@@ -339,7 +339,7 @@ impl Transform for Line {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[allow(dead_code)] // TODO: remove when all variants are used
+#[allow(dead_code)]
 pub(in crate::primitives) enum StrokeOffset {
     /// Stroke is centered around the line skeleton.
     None,

--- a/src/primitives/line/mod.rs
+++ b/src/primitives/line/mod.rs
@@ -339,6 +339,7 @@ impl Transform for Line {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[allow(dead_code)] // TODO: remove when all variants are used
 pub(in crate::primitives) enum StrokeOffset {
     /// Stroke is centered around the line skeleton.
     None,


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

The recent dependency update had broken the `nalgebra` integration. This wasn't noticed because the `justfile` was also broken and used a wrong feature for `nalgebra`. This PR should fix both issues.

I've also added `#[allow(dead_code)]` to the `StrokeOffset` to make it easier to spot new errors and warnings.
