### PR TITLE
Fix drawing of 90 degree args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - **(breaking)** [#470](https://github.com/embedded-graphics/embedded-graphics/pull/470) Support for fonts with variable character width was removed from the internal text renderer.
 - **(breaking)** [#470](https://github.com/embedded-graphics/embedded-graphics/pull/470) `Font6x6` was removed.
 
+### Fixed
+
+- [#477](https://github.com/embedded-graphics/embedded-graphics/pull/477) Drawing a 90° `Arc` is now equal to drawing a quarter of a circle.
+
 ## [0.7.0-alpha.1] - 2020-09-19
 
 ### Added

--- a/src/primitives/arc/linear_equation.rs
+++ b/src/primitives/arc/linear_equation.rs
@@ -20,8 +20,8 @@ pub struct LinearEquation {
 impl LinearEquation {
     /// Create a new linear equation based on one point and one angle
     pub fn from_point_angle(point: Point, angle: Angle) -> Self {
-        // FIXE: angle.tan() for 180.0 degrees isn't exactly 0 which causes problems when drawing
-        //       a single quadrant. Is there a better solution to fix this?
+        // FIXME: angle.tan() for 180.0 degrees isn't exactly 0 which causes problems when drawing
+        //        a single quadrant. Is there a better solution to fix this?
         let (a, b) = if angle == Angle::from_degrees(180.0) {
             (Real::from(0.0), Real::from(-1.0))
         } else {

--- a/src/primitives/arc/linear_equation.rs
+++ b/src/primitives/arc/linear_equation.rs
@@ -20,10 +20,17 @@ pub struct LinearEquation {
 impl LinearEquation {
     /// Create a new linear equation based on one point and one angle
     pub fn from_point_angle(point: Point, angle: Angle) -> Self {
-        let (a, b) = match angle.tan() {
-            None => (Real::from(1.0), Real::from(0.0)),
-            Some(a) => (-a, Real::from(-1.0)),
+        // FIXE: angle.tan() for 180.0 degrees isn't exactly 0 which causes problems when drawing
+        //       a single quadrant. Is there a better solution to fix this?
+        let (a, b) = if angle == Angle::from_degrees(180.0) {
+            (Real::from(0.0), Real::from(-1.0))
+        } else {
+            match angle.tan() {
+                None => (Real::from(1.0), Real::from(0.0)),
+                Some(a) => (-a, Real::from(-1.0)),
+            }
         };
+
         let c = -(a * point.x.into() + b * point.y.into());
         LinearEquation { a, b, c }
     }
@@ -37,12 +44,15 @@ impl LinearEquation {
         }
     }
 
-    /// Check on which side of the line a point is
-    pub fn side(&self, point: Point) -> LineSide {
-        if self.a * point.x.into() + self.b * point.y.into() + self.c < Real::from(0.0) {
-            LineSide::Below
-        } else {
-            LineSide::Above
+    /// Checks if a point is on the given side of the line.
+    ///
+    /// Always returns `true` if the point is on the line.
+    pub fn check_side(&self, point: Point, side: LineSide) -> bool {
+        let t = self.a * point.x.into() + self.b * point.y.into() + self.c;
+
+        match side {
+            LineSide::Below => t <= Real::from(0.0),
+            LineSide::Above => t >= Real::from(0.0),
         }
     }
 }

--- a/src/primitives/arc/mod.rs
+++ b/src/primitives/arc/mod.rs
@@ -113,6 +113,17 @@ impl Arc {
     pub fn center(&self) -> Point {
         self.bounding_box().center()
     }
+
+    /// Returns the center point of the arc scaled by a factor of 2.
+    ///
+    /// This method is used to accurately calculate the outside edge of the arc.
+    /// The result is not equivalent to `self.center() * 2` because of rounding.
+    fn center_2x(&self) -> Point {
+        // The radius scaled up by a factor of 2 is equal to the diameter
+        let radius = self.diameter.saturating_sub(1);
+
+        self.top_left * 2 + Size::new(radius, radius)
+    }
 }
 
 impl Primitive for Arc {

--- a/src/primitives/arc/points.rs
+++ b/src/primitives/arc/points.rs
@@ -21,7 +21,8 @@ impl Points {
         let outer_circle = arc.to_circle();
         let inner_circle = outer_circle.offset(-1);
 
-        let points = PlaneSectorIterator::new(arc, arc.center(), arc.angle_start, arc.angle_sweep);
+        let points =
+            PlaneSectorIterator::new(arc, arc.center_2x(), arc.angle_start, arc.angle_sweep);
 
         Self {
             iter: outer_circle.distances(points),

--- a/src/primitives/sector/mod.rs
+++ b/src/primitives/sector/mod.rs
@@ -123,6 +123,17 @@ impl Sector {
         self.bounding_box().center()
     }
 
+    /// Returns the center point of the sector scaled by a factor of 2.
+    ///
+    /// This method is used to accurately calculate the outside edge of the sector.
+    /// The result is not equivalent to `self.center() * 2` because of rounding.
+    fn center_2x(&self) -> Point {
+        // The radius scaled up by a factor of 2 is equal to the diameter
+        let radius = self.diameter.saturating_sub(1);
+
+        self.top_left * 2 + Size::new(radius, radius)
+    }
+
     /// Return the end angle of the sector
     fn angle_end(&self) -> Angle {
         self.angle_start + self.angle_sweep
@@ -161,7 +172,7 @@ impl Primitive for Sector {
 impl ContainsPoint for Sector {
     fn contains(&self, point: Point) -> bool {
         if self.to_circle().contains(point) {
-            PlaneSector::new(self.center(), self.angle_start, self.angle_sweep).contains(point)
+            PlaneSector::new(self.center_2x(), self.angle_start, self.angle_sweep).contains(point)
         } else {
             false
         }

--- a/src/primitives/sector/points.rs
+++ b/src/primitives/sector/points.rs
@@ -15,7 +15,7 @@ impl Points {
         let circle = sector.to_circle();
         let points = PlaneSectorIterator::new(
             sector,
-            sector.center(),
+            sector.center_2x(),
             sector.angle_start,
             sector.angle_sweep,
         );

--- a/src/primitives/sector/styled.rs
+++ b/src/primitives/sector/styled.rs
@@ -56,7 +56,7 @@ where
         let points = if !styled.style.is_transparent() {
             PlaneSectorIterator::new(
                 &stroke_area,
-                stroke_area.center(),
+                stroke_area.center_2x(),
                 stroke_area.angle_start,
                 stroke_area.angle_sweep,
             )


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR makes drawing of 90° arcs consistent to drawing a quarter of a circle. Maybe this will help with #441. `Sector` will probably also need some tweaks, but that will be another PR.
