### PR TITLE
Simplify self-intersection checks

### DIFF
--- a/src/primitives/line/mod.rs
+++ b/src/primitives/line/mod.rs
@@ -66,13 +66,6 @@ impl Dimensions for Line {
     }
 }
 
-/// Check signs of two signed numbers
-///
-/// Fastest ASM output compared to other methods. See: https://godbolt.org/z/zVx9cD
-fn same_signs(a: i32, b: i32) -> bool {
-    (a >= 0) == (b >= 0)
-}
-
 /// Intersection test result.
 #[derive(Copy, Clone, Debug)]
 pub enum Intersection {
@@ -222,45 +215,6 @@ impl Line {
         let denom = a1 * b2 - a2 * b1;
 
         (a1, b1, c1, a2, b2, c2, denom)
-    }
-
-    /// Check if two line segments intersect.
-    pub(in crate::primitives) fn segment_intersection(&self, other: &Self) -> bool {
-        // Note: a bounding box check here causes render time regression for thick polylines
-        let (a1, b1, c1, a2, b2, c2, denom) = self.coefficients(other);
-
-        // Lines are colinear or parallel
-        if denom == 0 {
-            return false;
-        }
-
-        let Point { x: x1, y: y1 } = self.start;
-        let Point { x: x2, y: y2 } = self.end;
-        let Point { x: x3, y: y3 } = other.start;
-        let Point { x: x4, y: y4 } = other.end;
-
-        // Sign values for first line
-        let r1 = a2 * x1 + b2 * y1 + c2;
-        let r2 = a2 * x2 + b2 * y2 + c2;
-
-        // Sign values for second line
-        let r3 = a1 * x3 + b1 * y3 + c1;
-        let r4 = a1 * x4 + b1 * y4 + c1;
-
-        // If r1 is 0, the intersection is at the beginning of the first line
-        // If r2 is 0, the intersection is at the end of the first line
-        // If r3 is 0, the intersection is at the beginning of the second line
-        // If r4 is 0, the intersection is at the end of the second line
-
-        // Flag denoting whether intersection point is on given line segments. If this is false,
-        // the intersection occurs somewhere along the two mathematical, infinite lines instead.
-        //
-        // Check signs of r3 and r4.  If both point 3 and point 4 lie on same side of line 1, the
-        // line segments do not intersect.
-        //
-        // Check signs of r1 and r2.  If both point 1 and point 2 lie on same side of second line
-        // segment, the line segments do not intersect.
-        (r3 == 0 || r4 == 0 || !same_signs(r3, r4)) && (r1 == 0 || r2 == 0 || !same_signs(r1, r2))
     }
 
     /// Get which side of a line a point lies on.

--- a/src/primitives/line/mod.rs
+++ b/src/primitives/line/mod.rs
@@ -196,25 +196,9 @@ impl Line {
         self.start + (self.end - self.start) / 2
     }
 
-    const fn coefficients(&self, other: &Self) -> (i32, i32, i32, i32, i32, i32, i32) {
-        let Point { x: x1, y: y1 } = self.start;
-        let Point { x: x2, y: y2 } = self.end;
-        let Point { x: x3, y: y3 } = other.start;
-        let Point { x: x4, y: y4 } = other.end;
-
-        // First line coefficients where "a1 x  +  b1 y  +  c1  =  0"
-        let a1 = y2 - y1;
-        let b1 = x1 - x2;
-        let c1 = x2 * y1 - x1 * y2;
-
-        // Second line coefficients
-        let a2 = y4 - y3;
-        let b2 = x3 - x4;
-        let c2 = x4 * y3 - x3 * y4;
-
-        let denom = a1 * b2 - a2 * b1;
-
-        (a1, b1, c1, a2, b2, c2, denom)
+    /// Compute the delta (`end - start`) of the line.
+    pub fn delta(&self) -> Point {
+        self.end - self.start
     }
 
     /// Get which side of a line a point lies on.
@@ -230,41 +214,6 @@ impl Line {
 
         // https://math.stackexchange.com/a/274728/4506
         (x - x1) * (y2 - y1) - (y - y1) * (x2 - x1)
-    }
-
-    /// Integer-only line intersection
-    ///
-    /// Inspired from https://stackoverflow.com/a/61485959/383609, which links to
-    /// https://webdocs.cs.ualberta.ca/~graphics/books/GraphicsGems/gemsii/xlines.c
-    pub(in crate::primitives) fn line_intersection(&self, other: &Self) -> Intersection {
-        let (a1, b1, c1, a2, b2, c2, denom) = self.coefficients(other);
-
-        // Lines are colinear or parallel
-        if denom == 0 {
-            return Intersection::Colinear;
-        }
-
-        // If we got here, line segments intersect. Compute intersection point using method similar
-        // to that described here: http://paulbourke.net/geometry/pointlineplane/#i2l
-
-        // The denom/2 is to get rounding instead of truncating.
-        let offset = denom.abs() / 2;
-
-        let num = b1 * c2 - b2 * c1;
-        let x = if num < 0 { num - offset } else { num + offset } / denom;
-
-        let num = a2 * c1 - a1 * c2;
-        let y = if num < 0 { num - offset } else { num + offset } / denom;
-
-        Intersection::Point {
-            point: Point::new(x, y),
-            outer_side: if denom > 0 { Side::Right } else { Side::Left },
-        }
-    }
-
-    /// Compute the delta (`end - start`) of the line.
-    pub fn delta(&self) -> Point {
-        self.end - self.start
     }
 }
 

--- a/src/primitives/line_join.rs
+++ b/src/primitives/line_join.rs
@@ -152,19 +152,14 @@ impl LineJoin {
             second_edge_left.line_intersection(&first_edge_left),
             second_edge_right.line_intersection(&first_edge_right),
         ) {
-            let first_segment_start_edge = Line::new(first_edge_left.start, first_edge_right.start);
-            let second_segment_end_edge = Line::new(second_edge_left.end, second_edge_right.end);
-
-            let self_intersection_l = first_segment_start_edge
-                .segment_intersection(&second_edge_left)
-                || second_segment_end_edge.segment_intersection(&first_edge_left);
-
-            let self_intersection_r = first_segment_start_edge
-                .segment_intersection(&second_edge_right)
-                || second_segment_end_edge.segment_intersection(&first_edge_right);
+            // Check if the inside end point of the second line lies inside the first segment.
+            let self_intersection = match outer_side {
+                Side::Right => first_edge_left.side(second_edge_left.end) <= 0,
+                Side::Left => first_edge_right.side(second_edge_right.end) >= 0,
+            };
 
             // Normal line: non-overlapping line end caps
-            if !self_intersection_r && !self_intersection_l {
+            if !self_intersection {
                 // Distance from midpoint to miter outside end point.
                 let miter_length_squared = Line::new(
                     mid,

--- a/src/primitives/line_join.rs
+++ b/src/primitives/line_join.rs
@@ -50,6 +50,17 @@ pub struct EdgeCorners {
     pub right: Point,
 }
 
+/// Line coefficients.
+struct Coefficients {
+    a1: i32,
+    b1: i32,
+    c1: i32,
+    a2: i32,
+    b2: i32,
+    c2: i32,
+    denom: i32,
+}
+
 /// A join between two lines.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub(in crate::primitives) struct LineJoin {
@@ -119,6 +130,73 @@ impl LineJoin {
         }
     }
 
+    const fn coefficients(l1: &Line, l2: &Line) -> Coefficients {
+        let Point { x: x1, y: y1 } = l1.start;
+        let Point { x: x2, y: y2 } = l1.end;
+        let Point { x: x3, y: y3 } = l2.start;
+        let Point { x: x4, y: y4 } = l2.end;
+
+        // First line coefficients where "a1 x  +  b1 y  +  c1  =  0"
+        let a1 = y2 - y1;
+        let b1 = x1 - x2;
+        let c1 = x2 * y1 - x1 * y2;
+
+        // Second line coefficients
+        let a2 = y4 - y3;
+        let b2 = x3 - x4;
+        let c2 = x4 * y3 - x3 * y4;
+
+        let denom = a1 * b2 - a2 * b1;
+
+        Coefficients {
+            a1,
+            b1,
+            c1,
+            a2,
+            b2,
+            c2,
+            denom,
+        }
+    }
+
+    /// Integer-only line intersection
+    ///
+    /// Inspired from https://stackoverflow.com/a/61485959/383609, which links to
+    /// https://webdocs.cs.ualberta.ca/~graphics/books/GraphicsGems/gemsii/xlines.c
+    pub(in crate::primitives) fn line_intersection(l1: &Line, l2: &Line) -> Intersection {
+        let Coefficients {
+            a1,
+            b1,
+            c1,
+            a2,
+            b2,
+            c2,
+            denom,
+        } = Self::coefficients(l1, l2);
+
+        // Lines are colinear or parallel
+        if denom == 0 {
+            return Intersection::Colinear;
+        }
+
+        // If we got here, line segments intersect. Compute intersection point using method similar
+        // to that described here: http://paulbourke.net/geometry/pointlineplane/#i2l
+
+        // The denom/2 is to get rounding instead of truncating.
+        let offset = denom.abs() / 2;
+
+        let num = b1 * c2 - b2 * c1;
+        let x = if num < 0 { num - offset } else { num + offset } / denom;
+
+        let num = a2 * c1 - a1 * c2;
+        let y = if num < 0 { num - offset } else { num + offset } / denom;
+
+        Intersection::Point {
+            point: Point::new(x, y),
+            outer_side: if denom > 0 { Side::Right } else { Side::Left },
+        }
+    }
+
     /// Compute a join.
     pub fn from_points(
         start: Point,
@@ -149,8 +227,8 @@ impl LineJoin {
                 ..
             },
         ) = (
-            second_edge_left.line_intersection(&first_edge_left),
-            second_edge_right.line_intersection(&first_edge_right),
+            Self::line_intersection(&second_edge_left, &first_edge_left),
+            Self::line_intersection(&second_edge_right, &first_edge_right),
         ) {
             // Check if the inside end point of the second line lies inside the first segment.
             let self_intersection = match outer_side {


### PR DESCRIPTION
This is a somewhat noisy PR but the core of it revolves around e04c3fcbeaf2072dbb1ef82f8af8e6ba75fa8dae. Performance doesn't meaningfully change against master which is a shame, but the self-intersection check is a lot simpler now.

The other changes just move some methods out of `Line` as they're only used by `LineJoin`.

The performance difference isn't that surprising. It turns out that a significant amount of time is spent in `Line::extents`, so optimising the code there, and the iterators it calls, would make a good difference I think. @rfuest you mentioned long ago that you hoped never to touch the Bresenham code again. Well... ;)