### PR TITLE
Some cleanup of primitives module

### DIFF
--- a/src/primitives/common/line_join.rs
+++ b/src/primitives/common/line_join.rs
@@ -155,8 +155,12 @@ impl LineJoin {
         ) {
             // Check if the inside end point of the second line lies inside the first segment.
             let self_intersection = match outer_side {
-                LineSide::Right => first_edge_left.side(second_edge_left.end) <= 0,
-                LineSide::Left => first_edge_right.side(second_edge_right.end) >= 0,
+                LineSide::Right => {
+                    first_edge_left.check_side(second_edge_left.end, LineSide::Right)
+                }
+                LineSide::Left => {
+                    first_edge_right.check_side(second_edge_right.end, LineSide::Left)
+                }
             };
 
             // Normal line: non-overlapping line end caps

--- a/src/primitives/common/line_join.rs
+++ b/src/primitives/common/line_join.rs
@@ -3,8 +3,8 @@
 use crate::{
     geometry::Point,
     primitives::{
-        common::StrokeOffset,
-        line::{Intersection, Side},
+        common::{LineSide, StrokeOffset},
+        line::Intersection,
         Line,
     },
 };
@@ -18,7 +18,7 @@ pub enum JoinKind {
     /// Bevelled (flattened point)
     Bevel {
         /// Left side or right side?
-        outer_side: Side,
+        outer_side: LineSide,
     },
 
     /// Degenerate (angle between lines is too small to properly render stroke).
@@ -26,7 +26,7 @@ pub enum JoinKind {
     /// Degenerate corners are rendered with a bevel.
     Degenerate {
         /// Left side or right side?
-        outer_side: Side,
+        outer_side: LineSide,
     },
 
     /// Lines are colinear.
@@ -155,8 +155,8 @@ impl LineJoin {
         ) {
             // Check if the inside end point of the second line lies inside the first segment.
             let self_intersection = match outer_side {
-                Side::Right => first_edge_left.side(second_edge_left.end) <= 0,
-                Side::Left => first_edge_right.side(second_edge_right.end) >= 0,
+                LineSide::Right => first_edge_left.side(second_edge_left.end) <= 0,
+                LineSide::Left => first_edge_right.side(second_edge_right.end) >= 0,
             };
 
             // Normal line: non-overlapping line end caps
@@ -165,8 +165,8 @@ impl LineJoin {
                 let miter_length_squared = Line::new(
                     mid,
                     match outer_side {
-                        Side::Left => l_intersection,
-                        Side::Right => r_intersection,
+                        LineSide::Left => l_intersection,
+                        LineSide::Right => r_intersection,
                     },
                 )
                 .delta()
@@ -189,7 +189,7 @@ impl LineJoin {
                 // Miter is too long, chop it into bevel-style corner
                 else {
                     match outer_side {
-                        Side::Right => Self {
+                        LineSide::Right => Self {
                             kind: JoinKind::Bevel { outer_side },
                             first_edge_end: EdgeCorners {
                                 left: l_intersection,
@@ -200,7 +200,7 @@ impl LineJoin {
                                 right: second_edge_right.start,
                             },
                         },
-                        Side::Left => Self {
+                        LineSide::Left => Self {
                             kind: JoinKind::Bevel { outer_side },
                             first_edge_end: EdgeCorners {
                                 left: first_edge_left.end,
@@ -218,8 +218,8 @@ impl LineJoin {
             else {
                 Self {
                     kind: match outer_side {
-                        Side::Left => JoinKind::Degenerate { outer_side },
-                        Side::Right => JoinKind::Degenerate { outer_side },
+                        LineSide::Left => JoinKind::Degenerate { outer_side },
+                        LineSide::Right => JoinKind::Degenerate { outer_side },
                     },
                     first_edge_end: EdgeCorners {
                         left: first_edge_left.end,
@@ -253,8 +253,10 @@ impl LineJoin {
         match self.kind {
             JoinKind::Bevel { outer_side, .. } | JoinKind::Degenerate { outer_side, .. } => {
                 let line = match outer_side {
-                    Side::Left => Line::new(self.first_edge_end.left, self.second_edge_start.left),
-                    Side::Right => {
+                    LineSide::Left => {
+                        Line::new(self.first_edge_end.left, self.second_edge_start.left)
+                    }
+                    LineSide::Right => {
                         Line::new(self.first_edge_end.right, self.second_edge_start.right)
                     }
                 };

--- a/src/primitives/common/linear_equation.rs
+++ b/src/primitives/common/linear_equation.rs
@@ -57,7 +57,6 @@ impl LinearEquation<Real> {
         let t = self.a * point.x.into() + self.b * point.y.into() + self.c;
 
         match side {
-            // TODO: check
             LineSide::Right => t <= Real::from(0.0),
             LineSide::Left => t >= Real::from(0.0),
         }

--- a/src/primitives/common/linear_equation.rs
+++ b/src/primitives/common/linear_equation.rs
@@ -1,4 +1,7 @@
-use crate::geometry::{Angle, Point, Real, Trigonometry};
+use crate::{
+    geometry::{Angle, Point, Real, Trigonometry},
+    primitives::Line,
+};
 
 /// Define one side of a line
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
@@ -11,13 +14,23 @@ pub enum LineSide {
 ///
 /// The equation is stored as the a, b and c coefficients of the ax + by + c = 0 equation
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
-pub struct LinearEquation {
-    a: Real,
-    b: Real,
-    c: Real,
+pub struct LinearEquation<T> {
+    pub a: T,
+    pub b: T,
+    pub c: T,
 }
 
-impl LinearEquation {
+impl LinearEquation<i32> {
+    pub const fn from_line(line: &Line) -> Self {
+        Self {
+            a: line.end.y - line.start.y,
+            b: line.start.x - line.end.x,
+            c: line.end.x * line.start.y - line.start.x * line.end.y,
+        }
+    }
+}
+
+impl LinearEquation<Real> {
     /// Create a new linear equation based on one point and one angle
     pub fn from_point_angle(point: Point, angle: Angle) -> Self {
         // FIXME: angle.tan() for 180.0 degrees isn't exactly 0 which causes problems when drawing

--- a/src/primitives/common/linear_equation.rs
+++ b/src/primitives/common/linear_equation.rs
@@ -1,14 +1,7 @@
 use crate::{
     geometry::{Angle, Point, Real, Trigonometry},
-    primitives::Line,
+    primitives::{common::LineSide, Line},
 };
-
-/// Define one side of a line
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub enum LineSide {
-    Above,
-    Below,
-}
 
 /// Linear equation representation
 ///
@@ -64,8 +57,9 @@ impl LinearEquation<Real> {
         let t = self.a * point.x.into() + self.b * point.y.into() + self.c;
 
         match side {
-            LineSide::Below => t <= Real::from(0.0),
-            LineSide::Above => t >= Real::from(0.0),
+            // TODO: check
+            LineSide::Right => t <= Real::from(0.0),
+            LineSide::Left => t >= Real::from(0.0),
         }
     }
 }

--- a/src/primitives/common/mod.rs
+++ b/src/primitives/common/mod.rs
@@ -2,6 +2,7 @@ mod closed_thick_segment_iter;
 mod line_join;
 mod linear_equation;
 mod plane_sector;
+mod scanline;
 mod thick_segment;
 mod thick_segment_iter;
 
@@ -9,7 +10,8 @@ pub use closed_thick_segment_iter::ClosedThickSegmentIter;
 pub use line_join::{JoinKind, LineJoin};
 pub use linear_equation::LinearEquation;
 pub use plane_sector::{PlaneSector, PlaneSectorIterator};
-pub use thick_segment::{bresenham_scanline_intersection, ThickSegment};
+pub use scanline::Scanline;
+pub use thick_segment::ThickSegment;
 pub use thick_segment_iter::ThickSegmentIter;
 
 use crate::style::StrokeAlignment;

--- a/src/primitives/common/mod.rs
+++ b/src/primitives/common/mod.rs
@@ -7,7 +7,7 @@ mod thick_segment_iter;
 
 pub use closed_thick_segment_iter::ClosedThickSegmentIter;
 pub use line_join::{JoinKind, LineJoin};
-pub use linear_equation::{LineSide, LinearEquation};
+pub use linear_equation::LinearEquation;
 pub use plane_sector::{PlaneSector, PlaneSectorIterator};
 pub use thick_segment::{bresenham_scanline_intersection, ThickSegment};
 pub use thick_segment_iter::ThickSegmentIter;
@@ -32,6 +32,29 @@ impl From<StrokeAlignment> for StrokeOffset {
             StrokeAlignment::Inside => Self::Right,
             StrokeAlignment::Outside => Self::Left,
             StrokeAlignment::Center => Self::None,
+        }
+    }
+}
+
+/// Which side of the center line to draw on.
+///
+/// Imagine standing on `start`, looking ahead to where `end` is. `Left` is to your left, `Right` to
+/// your right.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub enum LineSide {
+    /// Left side of the line
+    Left,
+
+    /// Right side of the line
+    Right,
+}
+
+impl LineSide {
+    /// Swap side.
+    pub fn swap(self) -> Self {
+        match self {
+            Self::Left => Self::Right,
+            Self::Right => Self::Left,
         }
     }
 }

--- a/src/primitives/common/plane_sector.rs
+++ b/src/primitives/common/plane_sector.rs
@@ -30,15 +30,15 @@ impl PlaneSector {
         let negative_sweep = angle_sweep < Angle::zero();
 
         let side_a = if (angle_start_norm < ANGLE_90DEG) ^ negative_sweep {
-            LineSide::Above
+            LineSide::Left
         } else {
-            LineSide::Below
+            LineSide::Right
         };
 
         let side_b = if (angle_end_norm >= ANGLE_90DEG) ^ negative_sweep {
-            LineSide::Above
+            LineSide::Left
         } else {
-            LineSide::Below
+            LineSide::Right
         };
 
         Self {
@@ -54,8 +54,8 @@ impl PlaneSector {
         Self {
             line_a: LinearEquation::new_horizontal(),
             line_b: LinearEquation::new_horizontal(),
-            side_a: LineSide::Above,
-            side_b: LineSide::Above,
+            side_a: LineSide::Left,
+            side_b: LineSide::Left,
             sweep: Angle::zero(),
         }
     }

--- a/src/primitives/common/plane_sector.rs
+++ b/src/primitives/common/plane_sector.rs
@@ -1,5 +1,5 @@
 use crate::{
-    geometry::{angle_consts::*, Angle, Dimensions, Point},
+    geometry::{angle_consts::*, Angle, Dimensions, Point, Real},
     primitives::{
         common::{LineSide, LinearEquation},
         rectangle, Primitive, Rectangle,
@@ -14,8 +14,8 @@ use crate::{
 /// half-planes.
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
 pub struct PlaneSector {
-    line_a: LinearEquation,
-    line_b: LinearEquation,
+    line_a: LinearEquation<Real>,
+    line_b: LinearEquation<Real>,
     side_a: LineSide,
     side_b: LineSide,
     sweep: Angle,

--- a/src/primitives/common/scanline.rs
+++ b/src/primitives/common/scanline.rs
@@ -1,8 +1,9 @@
 use core::ops::Range;
 
 use crate::{
-    geometry::{Dimensions, Point},
-    primitives::{ContainsPoint, Line, Primitive, Rectangle},
+    geometry::Point,
+    prelude::Primitive,
+    primitives::{Line, Rectangle},
 };
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -38,21 +39,27 @@ impl Scanline {
     /// Intersection lines produced by this function are sorted so that the start always lies to the
     /// left of the end.
     pub fn bresenham_intersection(&mut self, line: &Line) {
-        if !line
-            .bounding_box()
-            .contains(Point::new(line.start.x, self.y))
-        {
+        // Check if the scanline is in the y range of the line.
+        let y_range = if line.start.y <= line.end.y {
+            line.start.y..=line.end.y
+        } else {
+            line.end.y..=line.start.y
+        };
+
+        if !y_range.contains(&self.y) {
             return;
         }
 
         let y = self.y;
-        let mut points = line.points().filter(|p| p.y == y);
+        let mut points = line.points();
 
-        if let Some(first) = points.next() {
+        // Find the first point with the same y coordinate.
+        while let Some(first) = points.find(|p| p.y == y) {
             self.extend(first.x);
         }
 
-        if let Some(last) = points.last() {
+        // Check points until the y coordinate changes.
+        if let Some(last) = points.take_while(|p| p.y == y).last() {
             self.extend(last.x);
         }
     }

--- a/src/primitives/common/scanline.rs
+++ b/src/primitives/common/scanline.rs
@@ -6,6 +6,7 @@ use crate::{
     primitives::{Line, Rectangle},
 };
 
+/// Scanline.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Scanline {
     pub y: i32,
@@ -13,15 +14,18 @@ pub struct Scanline {
 }
 
 impl Scanline {
+    /// Creates a new empty scanline.
     pub const fn new(y: i32) -> Self {
         Self { y, x: 0..0 }
     }
 
+    /// Returns `true` if the x range of the scanline is empty.
     pub fn is_empty(&self) -> bool {
         // MSRV: use `Range::is_empty` on version >= 1.47.0
         !(self.x.start < self.x.end)
     }
 
+    /// Extends the scanline to include the given x coordinate.
     fn extend(&mut self, x: i32) {
         if self.is_empty() {
             self.x = x..x + 1;
@@ -114,7 +118,10 @@ impl Scanline {
         Rectangle::new(Point::new(self.x.start, self.y), Size::new(width, 1))
     }
 
-    /// Renamed to try_take to because of conflict with Iterator::take
+    /// Returns a clone of the scanline if it isn't empty.
+    ///
+    /// This method is used similar to `Option::take`, but was renamed to `try_take` because
+    /// of a naming conflict with `Iterator::take`.
     pub fn try_take(&mut self) -> Option<Self> {
         if !self.is_empty() {
             let ret = self.clone();

--- a/src/primitives/common/scanline.rs
+++ b/src/primitives/common/scanline.rs
@@ -1,0 +1,161 @@
+use core::ops::Range;
+
+use crate::{
+    geometry::{Dimensions, Point},
+    primitives::{ContainsPoint, Line, Primitive, Rectangle},
+};
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct Scanline {
+    pub y: i32,
+    pub x: Range<i32>,
+}
+
+impl Scanline {
+    pub const fn new(y: i32) -> Self {
+        Self { y, x: 0..0 }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        // MSRV: use `Range::is_empty` on version >= 1.47.0
+        !(self.x.start < self.x.end)
+    }
+
+    fn extend(&mut self, x: i32) {
+        if self.is_empty() {
+            self.x = x..x + 1;
+        } else {
+            if x < self.x.start {
+                self.x.start = x;
+            } else if x >= self.x.end {
+                self.x.end = x + 1;
+            }
+        }
+    }
+
+    /// Intersect a horizontal scan line with the Bresenham representation of this line segment.
+    ///
+    /// Intersection lines produced by this function are sorted so that the start always lies to the
+    /// left of the end.
+    pub fn bresenham_intersection(&mut self, line: &Line) {
+        if !line
+            .bounding_box()
+            .contains(Point::new(line.start.x, self.y))
+        {
+            return;
+        }
+
+        let y = self.y;
+        let mut points = line.points().filter(|p| p.y == y);
+
+        if let Some(first) = points.next() {
+            self.extend(first.x);
+        }
+
+        if let Some(last) = points.last() {
+            self.extend(last.x);
+        }
+    }
+
+    /// Check for lines that are adjacent or overlapping.
+    ///
+    /// This assumes that both lines have the same y coordinate.
+    fn touches(&self, other: &Scanline) -> bool {
+        debug_assert_eq!(
+            self.y, other.y,
+            "try_extend must be called with scanlines with equal y coordinate"
+        );
+
+        if self.is_empty() || other.is_empty() {
+            return false;
+        }
+
+        let range = self.x.start - 1..self.x.end + 1;
+        range.contains(&(other.x.start)) || range.contains(&(other.x.end - 1))
+    }
+
+    /// Tries to extend this line by another line.
+    ///
+    /// The line is only extended when the other line overlaps this line or is directly adjacent
+    /// to this line.
+    ///
+    /// Returns `true` if the line was extended and `false` otherwise.
+    pub fn try_extend(&mut self, other: &Scanline) -> bool {
+        debug_assert_eq!(
+            self.y, other.y,
+            "try_extend must be called with scanlines with equal y coordinate"
+        );
+
+        if self.touches(other) {
+            self.x.start = self.x.start.min(other.x.start);
+            self.x.end = self.x.end.max(other.x.end);
+
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn try_to_rectangle(&self) -> Option<Rectangle> {
+        if !self.is_empty() {
+            Some(Rectangle::with_corners(
+                Point::new(self.x.start, self.y),
+                Point::new(self.x.end - 1, self.y),
+            ))
+        } else {
+            None
+        }
+    }
+
+    /// Renamed to try_take to because of conflict with Iterator::take
+    pub fn try_take(&mut self) -> Option<Self> {
+        if !self.is_empty() {
+            let ret = self.clone();
+            self.x = 0..0;
+            Some(ret)
+        } else {
+            None
+        }
+    }
+}
+
+impl Iterator for Scanline {
+    type Item = Point;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.x.next().map(|x| Point::new(x, self.y))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run_touches_test(s1: i32, e1: i32, s2: i32, e2: i32, expected: bool, ident: &str) {
+        let mut l1 = Scanline::new(0);
+        l1.extend(s1);
+        l1.extend(e1);
+
+        let mut l2 = Scanline::new(0);
+        l2.extend(s2);
+        l2.extend(e2);
+
+        assert_eq!(l1.touches(&l2), expected, "{}", ident);
+    }
+
+    #[test]
+    fn check_touches() {
+        run_touches_test(30, 40, 5, 15, false, "Reversed");
+        run_touches_test(0, 6, 5, 10, true, "Contained");
+        run_touches_test(11, 13, 11, 14, true, "Contained 2");
+        run_touches_test(10, 15, 25, 35, false, "Separated");
+        run_touches_test(10, 10, 10, 10, true, "Zero size");
+        run_touches_test(10, 20, 10, 20, true, "Equal");
+        run_touches_test(10, 20, 20, 10, true, "Equal reversed");
+        run_touches_test(79, 82, 82, 92, true, "Overlapping lines 1");
+        run_touches_test(82, 92, 79, 82, true, "Overlapping lines 1, reversed");
+        run_touches_test(80, 83, 83, 94, true, "Overlapping lines 2");
+        run_touches_test(83, 94, 80, 83, true, "Overlapping lines 2, reversed");
+        run_touches_test(83, 94, 94, 100, true, "Adjacent");
+    }
+}

--- a/src/primitives/common/scanline.rs
+++ b/src/primitives/common/scanline.rs
@@ -1,7 +1,7 @@
 use core::ops::Range;
 
 use crate::{
-    geometry::Point,
+    geometry::{Point, Size},
     prelude::Primitive,
     primitives::{Line, Rectangle},
 };
@@ -103,15 +103,15 @@ impl Scanline {
         }
     }
 
-    pub fn try_to_rectangle(&self) -> Option<Rectangle> {
-        if !self.is_empty() {
-            Some(Rectangle::with_corners(
-                Point::new(self.x.start, self.y),
-                Point::new(self.x.end - 1, self.y),
-            ))
+    /// Converts the scanline into a 1px high rectangle.
+    pub fn to_rectangle(&self) -> Rectangle {
+        let width = if self.x.end >= self.x.start {
+            (self.x.end - self.x.start) as u32
         } else {
-            None
-        }
+            0
+        };
+
+        Rectangle::new(Point::new(self.x.start, self.y), Size::new(width, 1))
     }
 
     /// Renamed to try_take to because of conflict with Iterator::take

--- a/src/primitives/common/scanline.rs
+++ b/src/primitives/common/scanline.rs
@@ -55,17 +55,13 @@ impl Scanline {
         }
 
         let y = self.y;
-        let mut points = line.points();
 
-        // Find the first point with the same y coordinate.
-        while let Some(first) = points.find(|p| p.y == y) {
-            self.extend(first.x);
-        }
-
-        // Check points until the y coordinate changes.
-        if let Some(last) = points.take_while(|p| p.y == y).last() {
-            self.extend(last.x);
-        }
+        line.points()
+            .skip_while(|p| p.y != y)
+            .take_while(|p| p.y == y)
+            .for_each(|p| {
+                self.extend(p.x);
+            });
     }
 
     /// Check for lines that are adjacent or overlapping.

--- a/src/primitives/line/mod.rs
+++ b/src/primitives/line/mod.rs
@@ -8,7 +8,7 @@ mod thick_points;
 use crate::{
     geometry::{Dimensions, Point},
     primitives::{
-        common::{LinearEquation, StrokeOffset},
+        common::{LineSide, LinearEquation, StrokeOffset},
         line::thick_points::{ParallelLineType, ParallelsIterator},
         Primitive, Rectangle,
     },
@@ -17,7 +17,7 @@ use crate::{
 };
 pub use points::Points;
 pub use styled::StyledPixels;
-pub(in crate::primitives) use thick_points::{Side, ThickPoints};
+pub(in crate::primitives) use thick_points::ThickPoints;
 
 /// Line primitive
 ///
@@ -91,7 +91,7 @@ pub enum Intersection {
         /// ```
         ///
         /// This is used to find the outside edge of a corner.
-        outer_side: Side,
+        outer_side: LineSide,
     },
 
     /// No intersection: lines are colinear or parallel.
@@ -246,7 +246,11 @@ impl Line {
 
         Intersection::Point {
             point: Point::new(x, y),
-            outer_side: if denom > 0 { Side::Right } else { Side::Left },
+            outer_side: if denom > 0 {
+                LineSide::Right
+            } else {
+                LineSide::Left
+            },
         }
     }
 }

--- a/src/primitives/line/mod.rs
+++ b/src/primitives/line/mod.rs
@@ -202,19 +202,22 @@ impl Line {
         self.end - self.start
     }
 
-    /// Get which side of a line a point lies on.
+    /// Checks if the point lies on the given side of the line.
     ///
-    /// If the result is zero, the point lies on the line. Otherwise, values greater than zero
-    /// denote that the point is on the left side of the line. Values less than zero denote the
-    /// point lies to the right.
-    pub(in crate::primitives) fn side(&self, point: Point) -> i32 {
+    /// Returns `true` if the point lies on the correct side or on the line.
+    pub(in crate::primitives) fn check_side(&self, point: Point, side: LineSide) -> bool {
         let Point { x: x1, y: y1 } = self.start;
         let Point { x: x2, y: y2 } = self.end;
 
         let Point { x, y } = point;
 
         // https://math.stackexchange.com/a/274728/4506
-        (x - x1) * (y2 - y1) - (y - y1) * (x2 - x1)
+        let t = (x - x1) * (y2 - y1) - (y - y1) * (x2 - x1);
+
+        match side {
+            LineSide::Left => t >= 0,
+            LineSide::Right => t <= 0,
+        }
     }
 
     /// Integer-only line intersection

--- a/src/primitives/line/mod.rs
+++ b/src/primitives/line/mod.rs
@@ -181,17 +181,6 @@ impl Line {
         (left_line, right_line)
     }
 
-    /// Sort line so start point is to the left of the end point.
-    pub(in crate::primitives) fn sorted_x(&self) -> Self {
-        let (start, end) = if self.start.x > self.end.x {
-            (self.end, self.start)
-        } else {
-            (self.start, self.end)
-        };
-
-        Self::new(start, end)
-    }
-
     /// Compute the midpoint of the line.
     pub fn midpoint(&self) -> Point {
         self.start + (self.end - self.start) / 2

--- a/src/primitives/polyline/scanline_iterator.rs
+++ b/src/primitives/polyline/scanline_iterator.rs
@@ -5,7 +5,9 @@ use core::ops::Range;
 use crate::{
     geometry::Dimensions,
     pixelcolor::PixelColor,
-    primitives::{polyline::scanline_intersections::ScanlineIntersections, Line, Polyline},
+    primitives::{
+        common::Scanline, polyline::scanline_intersections::ScanlineIntersections, Polyline,
+    },
     style::{PrimitiveStyle, Styled},
 };
 
@@ -59,12 +61,14 @@ impl<'a> ScanlineIterator<'a> {
 }
 
 impl<'a> Iterator for ScanlineIterator<'a> {
-    type Item = Line;
+    type Item = Scanline;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(next) = self.intersections.next() {
-                break Some(next);
+                if !next.is_empty() {
+                    break Some(next);
+                }
             } else {
                 self.scanline_y = self.rows.next()?;
 

--- a/src/primitives/polyline/styled.rs
+++ b/src/primitives/polyline/styled.rs
@@ -120,7 +120,9 @@ where
                 ),
                 _ => {
                     for line in ScanlineIterator::new(self) {
-                        if let Some(rect) = line.try_to_rectangle() {
+                        let rect = line.to_rectangle();
+
+                        if !rect.is_zero_sized() {
                             display.fill_solid(&rect, stroke_color)?;
                         }
                     }

--- a/src/primitives/polyline/styled.rs
+++ b/src/primitives/polyline/styled.rs
@@ -5,8 +5,7 @@ use crate::{
     iterator::IntoPixels,
     pixelcolor::PixelColor,
     primitives::{
-        common::{StrokeOffset, ThickSegmentIter},
-        line,
+        common::{Scanline, StrokeOffset, ThickSegmentIter},
         polyline::{self, scanline_iterator::ScanlineIterator, Polyline},
         Primitive, Rectangle,
     },
@@ -18,7 +17,7 @@ enum StyledIter<'a> {
     Thin(polyline::Points<'a>),
     Thick {
         scanline_iter: ScanlineIterator<'a>,
-        line_iter: line::Points,
+        line_iter: Scanline,
     },
 }
 
@@ -41,10 +40,7 @@ where
             StyledIter::Thin(styled.primitive.points())
         } else {
             let mut scanline_iter = ScanlineIterator::new(styled);
-            let line_iter = scanline_iter
-                .next()
-                .map(|line| line.points())
-                .unwrap_or_else(line::Points::empty);
+            let line_iter = scanline_iter.next().unwrap_or_else(|| Scanline::new(0));
 
             StyledIter::Thick {
                 scanline_iter,
@@ -81,8 +77,7 @@ where
                 }
                 // Finished this line. Get the next one from the scanline iterator.
                 else {
-                    let next_line_iter = scanline_iter.next()?;
-                    *line_iter = next_line_iter.points();
+                    *line_iter = scanline_iter.next()?;
 
                     line_iter.next()
                 }
@@ -125,10 +120,9 @@ where
                 ),
                 _ => {
                     for line in ScanlineIterator::new(self) {
-                        display.fill_solid(
-                            &Rectangle::with_corners(line.start, line.end),
-                            stroke_color,
-                        )?;
+                        if let Some(rect) = line.try_to_rectangle() {
+                            display.fill_solid(&rect, stroke_color)?;
+                        }
                     }
 
                     Ok(())

--- a/src/primitives/triangle/mod.rs
+++ b/src/primitives/triangle/mod.rs
@@ -8,7 +8,7 @@ mod styled;
 use crate::{
     geometry::{Dimensions, Point},
     primitives::{
-        common::{bresenham_scanline_intersection, LineJoin, StrokeOffset},
+        common::{bresenham_scanline_intersection, LineJoin, LineSide, StrokeOffset},
         ContainsPoint, Line, Primitive, Rectangle,
     },
     transform::Transform,
@@ -284,7 +284,7 @@ impl Triangle {
 
             // If the inner point is to the left of the opposite side line, the triangle edges self-
             // intersect, so the triangle is collapsed.
-            opposite.side(inner_point) >= 0
+            opposite.check_side(inner_point, LineSide::Left)
         })
     }
 

--- a/src/primitives/triangle/points.rs
+++ b/src/primitives/triangle/points.rs
@@ -1,10 +1,8 @@
 use crate::{
     geometry::{Dimensions, Point},
     primitives::{
-        common::StrokeOffset,
-        line,
+        common::{Scanline, StrokeOffset},
         triangle::{scanline_iterator::ScanlineIterator, Triangle},
-        Primitive,
     },
 };
 
@@ -12,7 +10,7 @@ use crate::{
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct Points {
     scanline_iter: ScanlineIterator,
-    current_line: line::Points,
+    current_line: Scanline,
 }
 
 impl Points {
@@ -25,7 +23,7 @@ impl Points {
             &triangle.bounding_box(),
         );
 
-        let current_line = line::Points::empty();
+        let current_line = Scanline::new(0);
 
         Self {
             scanline_iter,
@@ -39,7 +37,7 @@ impl Iterator for Points {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.current_line.next().or_else(|| {
-            self.current_line = self.scanline_iter.next()?.0.points();
+            self.current_line = self.scanline_iter.next()?.0;
 
             self.current_line.next()
         })

--- a/src/primitives/triangle/scanline_intersections.rs
+++ b/src/primitives/triangle/scanline_intersections.rs
@@ -3,9 +3,9 @@
 use crate::{
     geometry::Point,
     primitives::{
-        common::{LineJoin, StrokeOffset, ThickSegment},
-        polyline::scanline_intersections::{extend, touches},
-        Line, Triangle,
+        common::ThickSegment,
+        common::{LineJoin, Scanline, StrokeOffset},
+        Triangle,
     },
 };
 
@@ -19,15 +19,16 @@ pub enum PointType {
     Fill,
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
 struct LineConfig {
-    first: Option<Line>,
-    second: Option<Line>,
-    internal: Option<(Line, PointType)>,
+    first: Scanline,
+    second: Scanline,
+    internal: Scanline,
+    internal_type: PointType,
 }
 
 /// Triangle scanline intersections iterator.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub(in crate::primitives::triangle) struct ScanlineIntersections {
     lines: LineConfig,
     triangle: Triangle,
@@ -65,7 +66,12 @@ impl ScanlineIntersections {
     /// Empty.
     pub fn empty() -> Self {
         Self {
-            lines: LineConfig::default(),
+            lines: LineConfig {
+                first: Scanline::new(0),
+                second: Scanline::new(0),
+                internal: Scanline::new(0),
+                internal_type: PointType::Fill,
+            },
             has_fill: false,
             triangle: EMPTY,
             stroke_width: 0,
@@ -96,8 +102,8 @@ fn generate_lines(
 ) -> Option<LineConfig> {
     let mut edge_intersections = {
         let mut idx = 0;
-        let mut left = None;
-        let mut right = None;
+        let mut left = Scanline::new(scanline_y);
+        let mut right = Scanline::new(scanline_y);
 
         let t = triangle;
 
@@ -124,37 +130,30 @@ fn generate_lines(
 
                 idx += 1;
 
-                if let Some(next_segment) = ThickSegment::new(start, end).intersection(scanline_y) {
-                    if let Some(line) = left.as_mut() {
-                        if touches(*line, next_segment) {
-                            *line = extend(*line, next_segment);
-                            continue;
-                        }
-                    } else {
-                        left = Some(next_segment);
+                let scanline = ThickSegment::new(start, end).intersection(scanline_y);
+
+                if !left.is_empty() {
+                    if left.try_extend(&scanline) {
                         continue;
                     }
+                } else {
+                    left = scanline;
+                    continue;
+                }
 
-                    if let Some(line) = right.as_mut() {
-                        if touches(*line, next_segment) {
-                            *line = extend(*line, next_segment);
-                        }
-                    } else {
-                        right = Some(next_segment);
-                    }
+                if !right.is_empty() {
+                    right.try_extend(&scanline);
+                } else {
+                    right = scanline;
                 }
             }
 
             // Merge any overlap between final left/right results
-            // MSRV: Use Option::zip once we upgrade to 1.46.0 or greater.
-            if let (Some(l), Some(r)) = (left, right) {
-                if touches(l, r) {
-                    left = Some(extend(l, r));
-                    right = None;
-                }
+            if left.try_extend(&right) {
+                right = Scanline::new(scanline_y);
             }
 
-            left.take().or_else(|| right.take())
+            left.try_take().or_else(|| right.try_take())
         })
     };
 
@@ -163,10 +162,10 @@ fn generate_lines(
     // with the line type being marked as Border so, when rendered, the correct color is used.
     if triangle.is_collapsed(stroke_width, stroke_offset) && stroke_offset == StrokeOffset::Right {
         Some(LineConfig {
-            internal: triangle
-                .scanline_intersection(scanline_y)
-                .map(|l| (l, PointType::Stroke)),
-            ..LineConfig::default()
+            internal: triangle.scanline_intersection(scanline_y),
+            internal_type: PointType::Stroke,
+            first: Scanline::new(0),
+            second: Scanline::new(0),
         })
     } else {
         let first = edge_intersections.next();
@@ -178,22 +177,21 @@ fn generate_lines(
         // triangle (assuming the edge line merging logic is correct). In this case, we need a
         // scanline between the two edge intersections.
         let internal = if has_fill {
-            match (first, second) {
+            match (first.clone(), second.clone()) {
                 // Triangle stroke is non-zero, so the fill line is between the insides of each
                 // stroke.
                 (Some(first), Some(second)) => {
-                    let start_x = first.end.x.min(second.end.x);
-                    let end_x = first.start.x.max(second.start.x);
+                    let start_x = first.x.end.min(second.x.end);
+                    let end_x = first.x.start.max(second.x.start);
 
-                    // Line needs to be shrunk by 1px off each end to prevent overdraw.
-                    // This can only happen if there's enough room to do so.
-                    if (end_x - start_x) > 1 {
-                        Some(Line::new(
-                            Point::new(start_x + 1, scanline_y),
-                            Point::new(end_x - 1, scanline_y),
-                        ))
-                    } else {
-                        None
+                    // TODO: check
+                    //  // Line needs to be shrunk by 1px off each end to prevent overdraw.
+                    //  // This can only happen if there's enough room to do so.
+                    //  if (end_x - start_x) > 1 {
+
+                    Scanline {
+                        x: start_x..end_x,
+                        y: scanline_y,
                     }
                 }
                 // Triangles with no stroke intersections and a fill color.
@@ -201,28 +199,33 @@ fn generate_lines(
                 // Because a triangle is a closed shape, a single intersection here likely means
                 // we're inside one of the borders, so no fill should be returned for this
                 // scanline.
-                _ => None,
+                _ => Scanline::new(scanline_y),
             }
         } else {
-            None
+            Scanline::new(scanline_y)
         };
 
         Some(LineConfig {
-            first,
-            second,
-            internal: internal.map(|l| (l, PointType::Fill)),
+            first: first.unwrap_or(Scanline::new(scanline_y)),
+            second: second.unwrap_or(Scanline::new(scanline_y)),
+            internal,
+            internal_type: PointType::Fill,
         })
     }
 }
 
 impl Iterator for ScanlineIntersections {
-    type Item = (Line, PointType);
+    type Item = (Scanline, PointType);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.lines
-            .internal
-            .take()
-            .or_else(|| self.lines.first.take().map(|l| (l, PointType::Stroke)))
-            .or_else(|| self.lines.second.take().map(|l| (l, PointType::Stroke)))
+        if let Some(internal) = self.lines.internal.try_take() {
+            Some((internal, self.lines.internal_type))
+        } else if let Some(first) = self.lines.first.try_take() {
+            Some((first, PointType::Stroke))
+        } else if let Some(second) = self.lines.second.try_take() {
+            Some((second, PointType::Stroke))
+        } else {
+            None
+        }
     }
 }

--- a/src/primitives/triangle/scanline_intersections.rs
+++ b/src/primitives/triangle/scanline_intersections.rs
@@ -184,11 +184,6 @@ fn generate_lines(
                     let start_x = first.x.end.min(second.x.end);
                     let end_x = first.x.start.max(second.x.start);
 
-                    // TODO: check
-                    //  // Line needs to be shrunk by 1px off each end to prevent overdraw.
-                    //  // This can only happen if there's enough room to do so.
-                    //  if (end_x - start_x) > 1 {
-
                     Scanline {
                         x: start_x..end_x,
                         y: scanline_y,

--- a/src/primitives/triangle/scanline_iterator.rs
+++ b/src/primitives/triangle/scanline_iterator.rs
@@ -1,9 +1,9 @@
 //! Scanline iterator.
 
 use crate::primitives::{
-    common::StrokeOffset,
+    common::{Scanline, StrokeOffset},
     triangle::scanline_intersections::{PointType, ScanlineIntersections},
-    Line, Rectangle, Triangle,
+    Rectangle, Triangle,
 };
 use core::ops::Range;
 
@@ -57,7 +57,7 @@ impl ScanlineIterator {
 }
 
 impl Iterator for ScanlineIterator {
-    type Item = (Line, PointType);
+    type Item = (Scanline, PointType);
 
     fn next(&mut self) -> Option<Self::Item> {
         self.intersections.next().or_else(|| {

--- a/src/primitives/triangle/styled.rs
+++ b/src/primitives/triangle/styled.rs
@@ -122,7 +122,9 @@ where
                 };
 
                 if let Some(color) = color {
-                    if let Some(rect) = line.try_to_rectangle() {
+                    let rect = line.to_rectangle();
+
+                    if !rect.is_zero_sized() {
                         display.fill_solid(&rect, color)?;
                     }
                 }

--- a/src/primitives/triangle/styled.rs
+++ b/src/primitives/triangle/styled.rs
@@ -5,12 +5,11 @@ use crate::{
     iterator::IntoPixels,
     pixelcolor::PixelColor,
     primitives::{
-        common::{ClosedThickSegmentIter, StrokeOffset},
-        line,
+        common::{ClosedThickSegmentIter, Scanline, StrokeOffset},
         triangle::{
             scanline_intersections::PointType, scanline_iterator::ScanlineIterator, Triangle,
         },
-        Primitive, Rectangle,
+        Rectangle,
     },
     style::{PrimitiveStyle, StrokeAlignment, Styled},
 };
@@ -22,7 +21,7 @@ where
     C: PixelColor,
 {
     lines_iter: ScanlineIterator,
-    current_line: line::Points,
+    current_line: Scanline,
     current_color: Option<C>,
     fill_color: Option<C>,
     stroke_color: Option<C>,
@@ -45,8 +44,7 @@ where
 
         let (current_line, point_type) = lines_iter
             .next()
-            .map(|(l, t)| (l.points(), t))
-            .unwrap_or_else(|| (line::Points::empty(), PointType::Stroke));
+            .unwrap_or_else(|| (Scanline::new(0), PointType::Stroke));
 
         let current_color = match point_type {
             PointType::Stroke => styled.style.effective_stroke_color(),
@@ -76,7 +74,7 @@ where
             } else {
                 let (next_line, next_type) = self.lines_iter.next()?;
 
-                self.current_line = next_line.points();
+                self.current_line = next_line;
 
                 self.current_color = match next_type {
                     PointType::Stroke => self.stroke_color,
@@ -124,7 +122,9 @@ where
                 };
 
                 if let Some(color) = color {
-                    display.fill_solid(&Rectangle::with_corners(line.start, line.end), color)?;
+                    if let Some(rect) = line.try_to_rectangle() {
+                        display.fill_solid(&rect, color)?;
+                    }
                 }
             }
         }

--- a/src/primitives/triangle/styled.rs
+++ b/src/primitives/triangle/styled.rs
@@ -321,7 +321,6 @@ mod tests {
         styled.draw(&mut tri_display).unwrap();
 
         let mut lines_display: MockDisplay<BinaryColor> = MockDisplay::new();
-        lines_display.set_allow_out_of_bounds_drawing(true);
         lines_display.set_allow_overdraw(true);
         Line::new(triangle.p1, triangle.p2)
             .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR contains some cleanup of the primitives module. There will be additional thing that can be merged, but I didn't want to let the PR get even larger.

Summary of the changes:
* I've replaced `Coefficients` with `LinearEquation` which was previously only used by `Arc` and `Sector`.
  I'm sure there will be more code that can be migrated to the `LinearEquation` crate, but I just wanted to get this started in this PR. We might not even need the `Real` and `i32` variants of that type.
* I've removed the old `LineSide` enum and renamed the existing `Side` to `LineSide`.
 They were essentially the same enum and only used different names for the sides. I decided to use `LineSide` as the name, because IMO is a better name if it is shared across multiple primitives.
* I've replaced `Line::side` by `Line::check_side`.
  Instead of returning an integer which needs to be checked by the caller the function now takes a `LineSide` parameter. This way you don't need to remember which side is negative and which one is positive
* I've added a `Scanline` type, which is used to represent a horizontal line.
  This provides a place to put all the scanline related functions and it is a more efficient points iterator than `line::Points`.
* I've done some optimization of the `bresenham_scanline_intersection` method.
  The method now uses the fact that the y coordinate cannot change arbitrarily. After a matching y coordinate was found it only continues checking the iterator until the y coordinate changes.

`thick_polyline` is a bit faster now, but the other benches don't benefit much from the changes:
![grafik](https://user-images.githubusercontent.com/226123/99462643-67b6bf00-2934-11eb-91d1-7d5bb575fcf6.png)

