### PR TITLE
Triangle performance

### DIFF
--- a/src/primitives/triangle/scanline_intersections.rs
+++ b/src/primitives/triangle/scanline_intersections.rs
@@ -29,15 +29,13 @@ struct LineConfig {
 
 /// Triangle scanline intersections iterator.
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
-pub(in crate::primitives::triangle) struct ScanlineIntersections {
+pub struct ScanlineIntersections {
     lines: LineConfig,
     triangle: Triangle,
     stroke_width: u32,
     stroke_offset: StrokeOffset,
     has_fill: bool,
 }
-
-static EMPTY: Triangle = Triangle::new(Point::zero(), Point::zero(), Point::zero());
 
 impl ScanlineIntersections {
     /// Create a new thick segments iterator.
@@ -48,23 +46,21 @@ impl ScanlineIntersections {
         has_fill: bool,
         scanline_y: i32,
     ) -> Self {
-        if let Some(lines) =
-            generate_lines(triangle, stroke_width, stroke_offset, has_fill, scanline_y)
-        {
-            Self {
-                lines,
-                has_fill,
-                triangle: *triangle,
-                stroke_width,
-                stroke_offset,
-            }
-        } else {
-            Self::empty()
-        }
+        let mut self_ = Self {
+            has_fill,
+            triangle: *triangle,
+            stroke_offset,
+            stroke_width,
+            ..Self::empty()
+        };
+
+        self_.reset_with_new_scanline(scanline_y);
+
+        self_
     }
 
     /// Empty.
-    pub fn empty() -> Self {
+    pub const fn empty() -> Self {
         Self {
             lines: LineConfig {
                 first: Scanline::new(0),
@@ -73,7 +69,7 @@ impl ScanlineIntersections {
                 internal_type: PointType::Fill,
             },
             has_fill: false,
-            triangle: EMPTY,
+            triangle: Triangle::new(Point::zero(), Point::zero(), Point::zero()),
             stroke_width: 0,
             stroke_offset: StrokeOffset::None,
         }
@@ -81,51 +77,35 @@ impl ScanlineIntersections {
 
     /// Reset with a new scanline.
     pub fn reset_with_new_scanline(&mut self, scanline_y: i32) {
-        if let Some(lines) = generate_lines(
-            &self.triangle,
-            self.stroke_width,
-            self.stroke_offset,
-            self.has_fill,
-            scanline_y,
-        ) {
+        if let Some(lines) = self.generate_lines(scanline_y) {
             self.lines = lines
         }
     }
-}
 
-fn generate_lines(
-    triangle: &Triangle,
-    stroke_width: u32,
-    stroke_offset: StrokeOffset,
-    has_fill: bool,
-    scanline_y: i32,
-) -> Option<LineConfig> {
-    let mut edge_intersections = {
+    fn edge_intersections(&self, scanline_y: i32) -> impl Iterator<Item = Scanline> + '_ {
         let mut idx = 0;
         let mut left = Scanline::new(scanline_y);
         let mut right = Scanline::new(scanline_y);
 
-        let t = triangle;
-
         core::iter::from_fn(move || {
-            if stroke_width == 0 {
+            if self.stroke_width == 0 {
                 return None;
             }
 
             while idx < 3 {
                 let start = LineJoin::from_points(
-                    t.vertex(idx),
-                    t.vertex(idx + 1),
-                    t.vertex(idx + 2),
-                    stroke_width,
-                    stroke_offset,
+                    self.triangle.vertex(idx),
+                    self.triangle.vertex(idx + 1),
+                    self.triangle.vertex(idx + 2),
+                    self.stroke_width,
+                    self.stroke_offset,
                 );
                 let end = LineJoin::from_points(
-                    t.vertex(idx + 1),
-                    t.vertex(idx + 2),
-                    t.vertex(idx + 3),
-                    stroke_width,
-                    stroke_offset,
+                    self.triangle.vertex(idx + 1),
+                    self.triangle.vertex(idx + 2),
+                    self.triangle.vertex(idx + 3),
+                    self.stroke_width,
+                    self.stroke_offset,
                 );
 
                 idx += 1;
@@ -155,57 +135,65 @@ fn generate_lines(
 
             left.try_take().or_else(|| right.try_take())
         })
-    };
+    }
 
-    // Special case: If thick strokes completely fill the triangle interior and the stroke is
-    // inside the triangle, the normal triangle shape can be used to detect the intersection,
-    // with the line type being marked as Border so, when rendered, the correct color is used.
-    if triangle.is_collapsed(stroke_width, stroke_offset) && stroke_offset == StrokeOffset::Right {
-        Some(LineConfig {
-            internal: triangle.scanline_intersection(scanline_y),
-            internal_type: PointType::Stroke,
-            first: Scanline::new(0),
-            second: Scanline::new(0),
-        })
-    } else {
-        let first = edge_intersections.next();
+    fn generate_lines(&self, scanline_y: i32) -> Option<LineConfig> {
+        let mut edge_intersections = self.edge_intersections(scanline_y);
 
-        // For scanlines that are parallel with and are inside one edge, this should be None.
-        let second = edge_intersections.next();
-
-        // If there are two intersections, this must mean we've traversed across the center of the
-        // triangle (assuming the edge line merging logic is correct). In this case, we need a
-        // scanline between the two edge intersections.
-        let internal = if has_fill {
-            match (first.clone(), second.clone()) {
-                // Triangle stroke is non-zero, so the fill line is between the insides of each
-                // stroke.
-                (Some(first), Some(second)) => {
-                    let start_x = first.x.end.min(second.x.end);
-                    let end_x = first.x.start.max(second.x.start);
-
-                    Scanline {
-                        x: start_x..end_x,
-                        y: scanline_y,
-                    }
-                }
-                // Triangles with no stroke intersections and a fill color.
-                (None, None) => triangle.scanline_intersection(scanline_y),
-                // Because a triangle is a closed shape, a single intersection here likely means
-                // we're inside one of the borders, so no fill should be returned for this
-                // scanline.
-                _ => Scanline::new(scanline_y),
-            }
+        // Special case: If thick strokes completely fill the triangle interior and the stroke is
+        // inside the triangle, the normal triangle shape can be used to detect the intersection,
+        // with the line type being marked as Border so, when rendered, the correct color is used.
+        if self
+            .triangle
+            .is_collapsed(self.stroke_width, self.stroke_offset)
+            && self.stroke_offset == StrokeOffset::Right
+        {
+            Some(LineConfig {
+                internal: self.triangle.scanline_intersection(scanline_y),
+                internal_type: PointType::Stroke,
+                first: Scanline::new(0),
+                second: Scanline::new(0),
+            })
         } else {
-            Scanline::new(scanline_y)
-        };
+            let first = edge_intersections.next();
 
-        Some(LineConfig {
-            first: first.unwrap_or(Scanline::new(scanline_y)),
-            second: second.unwrap_or(Scanline::new(scanline_y)),
-            internal,
-            internal_type: PointType::Fill,
-        })
+            // For scanlines that are parallel with and are inside one edge, this should be None.
+            let second = edge_intersections.next();
+
+            // If there are two intersections, this must mean we've traversed across the center of the
+            // triangle (assuming the edge line merging logic is correct). In this case, we need a
+            // scanline between the two edge intersections.
+            let internal = if self.has_fill {
+                match (first.clone(), second.clone()) {
+                    // Triangle stroke is non-zero, so the fill line is between the insides of each
+                    // stroke.
+                    (Some(first), Some(second)) => {
+                        let start_x = first.x.end.min(second.x.end);
+                        let end_x = first.x.start.max(second.x.start);
+
+                        Scanline {
+                            x: start_x..end_x,
+                            y: scanline_y,
+                        }
+                    }
+                    // Triangles with no stroke intersections and a fill color.
+                    (None, None) => self.triangle.scanline_intersection(scanline_y),
+                    // Because a triangle is a closed shape, a single intersection here likely means
+                    // we're inside one of the borders, so no fill should be returned for this
+                    // scanline.
+                    _ => Scanline::new(scanline_y),
+                }
+            } else {
+                Scanline::new(scanline_y)
+            };
+
+            Some(LineConfig {
+                first: first.unwrap_or(Scanline::new(scanline_y)),
+                second: second.unwrap_or(Scanline::new(scanline_y)),
+                internal,
+                internal_type: PointType::Fill,
+            })
+        }
     }
 }
 


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

I've found an easy optimization for the triangle drawing performance. `is_collapsed` was unnecessarily calculated once per scanline. Calculating it only once in the constructor gives a significant performance improvement:
![grafik](https://user-images.githubusercontent.com/226123/99559128-b90e8f00-29c4-11eb-82fa-72a2af5ea30b.png) 