### PR TITLE
Add improved MockDisplay assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#470](https://github.com/embedded-graphics/embedded-graphics/pull/470) Added support for external text renderers. External text renderers can be implemented using the new `TextStyle` trait.
 - [#475](https://github.com/embedded-graphics/embedded-graphics/pull/475) `Triangle`s can now be drawn with stroke widths greater than 1.
 - [#478](https://github.com/embedded-graphics/embedded-graphics/pull/478) Added `resized`, `anchor_point`, `rows`, `columns` and `is_zero_sized` methods to `Rectangle`.
-- [#493](https://github.com/embedded-graphics/embedded-graphics/pull/493) Added `assert_eq` and `assert_pattern` methods to `MockDisplay`.
+- [#493](https://github.com/embedded-graphics/embedded-graphics/pull/493) Added `assert_eq`, `assert_pattern` and `diff` methods to `MockDisplay`. Improved error messages for failing assertions can be enabled by setting the `EG_FANCY_PANIC` environment variable to `1` at compile time.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#470](https://github.com/embedded-graphics/embedded-graphics/pull/470) Added support for external text renderers. External text renderers can be implemented using the new `TextStyle` trait.
 - [#475](https://github.com/embedded-graphics/embedded-graphics/pull/475) `Triangle`s can now be drawn with stroke widths greater than 1.
 - [#478](https://github.com/embedded-graphics/embedded-graphics/pull/478) Added `resized`, `anchor_point`, `rows`, `columns` and `is_zero_sized` methods to `Rectangle`.
+- [#493](https://github.com/embedded-graphics/embedded-graphics/pull/493) Added `assert_eq` and `assert_pattern` methods to `MockDisplay`.
 
 ### Changed
 

--- a/src/fonts/mod.rs
+++ b/src/fonts/mod.rs
@@ -206,6 +206,8 @@ mod tests {
     };
 
     /// Draws a text using the given font and checks it against the expected pattern.
+    // MSRV: Add `track_caller` attribute for rust version >= 1.46.0
+    // #[track_caller]
     pub(super) fn assert_text_from_pattern<F>(text: &str, font: F, pattern: &[&str])
     where
         F: MonoFont,

--- a/src/mock_display.rs
+++ b/src/mock_display.rs
@@ -26,7 +26,7 @@
 //! Enabling the advanced test output requires a terminal that supports 24 BPP colors and a font
 //! that includes the upper half block character `'\u{2580}'`.
 //!
-//! The color code used to show the difference between the display and the expected output is show
+//! The color code used to show the difference between the display and the expected output is shown
 //! in the documentation of the [`diff`] method.
 //!
 //! # Additional out of bounds and overdraw checks
@@ -535,8 +535,8 @@ where
 
     /// Checks if the displays are equal.
     ///
-    /// An advanced output for failing tests can be enabled, see the [module-level documentation]
-    /// for more details.
+    /// An advanced output for failing tests can be enabled by setting the environment variable
+    /// `EG_FANCY_PANIC=1`. See the [module-level documentation] for more details.
     ///
     /// # Panics
     ///

--- a/src/mock_display.rs
+++ b/src/mock_display.rs
@@ -525,7 +525,7 @@ where
     ///
     /// # Panics
     ///
-    /// Panics if the display aren't equal.
+    /// Panics if the displays aren't equal.
     // MSRV: add track_caller attribute to get better error messages for rust >= 1.46.0
     // #[track_caller]
     pub fn assert_eq(&self, other: &MockDisplay<C>) {
@@ -540,7 +540,7 @@ where
         }
     }
 
-    /// Checks if the displays is equal to to the pattern.
+    /// Checks if the display is equal to the given pattern.
     ///
     /// # Panics
     ///
@@ -658,12 +658,7 @@ fn write_display<C>(
 where
     C: PixelColor + ColorMapping,
 {
-    for y in bounding_box.rows() {
-        if y % 2 != 0 {
-            // Skip all odd y coordinates, because `write_row` outputs two pixel rows with
-            // a single row of characters.
-            continue;
-        }
+    for y in bounding_box.rows().step_by(2) {
 
         write_row(f, display, bounding_box, y, 0)?;
         f.write_char('\n')?
@@ -776,12 +771,7 @@ where
 
             write_header(f, column_width)?;
 
-            for y in bounding_box.rows() {
-                if y % 2 != 0 {
-                    // Skip all odd y coordinates, because `write_row` outputs two pixel rows with
-                    // a single row of characters.
-                    continue;
-                }
+            for y in bounding_box.rows().step_by(2) {
 
                 f.write_str("| ")?;
                 write_row(f, self.display, &bounding_box, y, column_width)?;


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR adds `assert_eq` and `assert_pattern` methods to `MockDisplay`. They make tests a littler shorter, because you can now directly use `display.assert_pattern(&[ "RGB", ... ])` instead of having to create an expected display first.

But the main reason for implementing these function was to improve the output of failing tests. This wouldn't have been be possible by just updating the `Debug` impl for `MockDisplay`. The new output is optional and requires an terminal that supports 24 bpp colors. It can be enabled by setting the an environment variable at compile time: `EG_FANCY_PANIC=1` (any naming suggestions?). The default output remains unchanged to make sure there are no CI problems or if you need to see the pattern to update a pattern in the code.

Here is a comparison of the old and new output of a failing test:

Without `EG_FANCY_PANIC`:
![before](https://user-images.githubusercontent.com/226123/99858010-d8581880-2b8c-11eb-962d-9de1f7ad5db6.png)

With `EG_FANCY_PANIC`:
![after](https://user-images.githubusercontent.com/226123/99858019-db530900-2b8c-11eb-9988-0a4013fc6312.png)
The diff colors are explained in the docs.

I haven't updated the tests to use this new feature yet, because this would cause a lot of noise and I wanted to keep the PR short. And we might also want to wait to update all test until we update to at least Rust 1.46.0, because otherwise we cannot use the `track_caller` attribute and loose the ability to see the location of a failing test without using a backtrace.
