### PR TITLE
Remove TinyTGA from image examples

### DIFF
--- a/src/image/image_drawable.rs
+++ b/src/image/image_drawable.rs
@@ -80,16 +80,11 @@ pub trait ImageDrawableExt: Sized {
     /// # use embedded_graphics::mock_display::MockDisplay as Display;
     /// let mut display: Display<Rgb565> = Display::default();
     ///
-    /// let data = [
-    ///     0x00, 0x00, 0xF8, 0x00, 0x07, 0xE0, 0xFF, 0xE0, //
-    ///     0x00, 0x1F, 0x07, 0xFF, 0xF8, 0x1F, 0xFF, 0xFF, //
-    ///     // .
-    ///     // .
-    ///     // .
-    ///     0xFF, 0xFF, 0x00, 0x1F, 0x07, 0xFF, 0xF8, 0x1F,
-    /// ];
+    /// let data = [ 0xF8, 0x00, 0x07, 0xE0, 0xFF, 0xE0, /* ... */ ];
+    /// // or: let data = include_bytes!("sprite_atlas.raw");
     ///
-    /// let sprite_atlas: ImageRawBE<Rgb565> = ImageRaw::new(&data, 4, 3);
+    /// # let data = [0u8; 64 * 32 * 2];
+    /// let sprite_atlas: ImageRawBE<Rgb565> = ImageRaw::new(&data, 64, 32);
     ///
     /// let sprite_1 = sprite_atlas.sub_image(&Rectangle::new(Point::new(0, 0), Size::new(32, 32)));
     /// let sprite_2 = sprite_atlas.sub_image(&Rectangle::new(Point::new(32, 0), Size::new(32, 32)));

--- a/src/image/image_drawable.rs
+++ b/src/image/image_drawable.rs
@@ -67,20 +67,29 @@ pub trait ImageDrawableExt: Sized {
     ///
     /// # Examples
     ///
-    /// This example loads an image containing multiple 32x32px sprites and draws two of them to a
-    /// display, with their top-left corners positioned at `(100, 100)` and `(100, 140)`.
+    /// This example loads a raw image containing multiple 32x32px sprites and draws two of them to
+    /// a display, with their top-left corners positioned at `(100, 100)` and `(100, 140)`.
     ///
-    /// ```rust,ignore
-    /// use embedded_graphics::{image::Image, pixelcolor::Rgb888, prelude::*, primitives::Rectangle};
+    /// ```rust
+    /// use embedded_graphics::{
+    ///     image::{Image, ImageRaw, ImageRawBE},
+    ///     pixelcolor::Rgb565,
+    ///     prelude::*,
+    ///     primitives::Rectangle,
+    /// };
     /// # use embedded_graphics::mock_display::MockDisplay as Display;
-    /// use tinytga::Tga;
+    /// let mut display: Display<Rgb565> = Display::default();
     ///
-    /// let mut display: Display<Rgb888> = Display::default();
+    /// let data = [
+    ///     0x00, 0x00, 0xF8, 0x00, 0x07, 0xE0, 0xFF, 0xE0, //
+    ///     0x00, 0x1F, 0x07, 0xFF, 0xF8, 0x1F, 0xFF, 0xFF, //
+    ///     // .
+    ///     // .
+    ///     // .
+    ///     0xFF, 0xFF, 0x00, 0x1F, 0x07, 0xFF, 0xF8, 0x1F,
+    /// ];
     ///
-    /// let sprite_atlas: Tga<Rgb888> = Tga::from_slice(include_bytes!(
-    ///     "../../assets/tiles.tga"
-    /// ))
-    /// .unwrap();
+    /// let sprite_atlas: ImageRawBE<Rgb565> = ImageRaw::new(&data, 4, 3);
     ///
     /// let sprite_1 = sprite_atlas.sub_image(&Rectangle::new(Point::new(0, 0), Size::new(32, 32)));
     /// let sprite_2 = sprite_atlas.sub_image(&Rectangle::new(Point::new(32, 0), Size::new(32, 32)));

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -11,31 +11,38 @@
 //!
 //! # Examples
 //!
-//! ## Load a TGA image and draw it to a display
+//! ## Load an RGB565 raw data imge and display it
 //!
-//! This example loads a TGA-formatted image using the [tinytga] crate and draws it to the display
-//! using an [`Image`] object.
+//! This example loads a small image from a raw data array and displays it. The image is RGB565
+//! encoded, so uses the `Rgb565` color type.
 //!
 //! The `graphics` feature of `tinytga` needs to be enabled in `Cargo.toml` to use the `Tga` object
 //! with embedded-graphics.
 //!
-//! ```rust,ignore
-//! use embedded_graphics::{image::Image, pixelcolor::Rgb888, prelude::*};
+//! ```rust
+//! use embedded_graphics::{
+//!     image::{Image, ImageRaw, ImageRawBE},
+//!     pixelcolor::Rgb565,
+//!     prelude::*,
+//! };
 //! # use embedded_graphics::mock_display::MockDisplay as Display;
-//! use tinytga::Tga;
 //!
-//! let mut display: Display<Rgb888> = Display::default();
+//! let mut display: Display<Rgb565> = Display::default();
 //!
-//! // Load the TGA file.
-//! // Note that the color type is set explicitly to match the format used in the TGA file,
+//! // Raw image data for demonstration purposes.
+//! let data = [
+//!     0x00, 0x00, 0xF8, 0x00, 0x07, 0xE0, 0xFF, 0xE0, //
+//!     0x00, 0x1F, 0x07, 0xFF, 0xF8, 0x1F, 0xFF, 0xFF, /*
+//!            * ... */
+//! ];
+//!
+//! // Load the image file.
+//! // Note that the color type is set explicitly to match the format used in the image file,
 //! // otherwise the compiler might infer an incorrect type.
-//! let tga: Tga<Rgb888> = Tga::from_slice(include_bytes!(
-//!     "../../assets/rust-pride.tga"
-//! ))
-//! .unwrap();
+//! let raw: ImageRawBE<Rgb565> = ImageRaw::new(&data, 4, 2);
 //!
-//! // Create a `Image` object to position the image at `Point::zero()`.
-//! let image = Image::new(&tga, Point::zero());
+//! // Create an `Image` object to position the image at `Point::zero()`.
+//! let image = Image::new(&raw, Point::zero());
 //!
 //! // Draw the image to the display.
 //! image.draw(&mut display)?;
@@ -50,20 +57,31 @@
 //! to get a sub image from an image drawable. [`ImageDrawableExt`] is included in the [`prelude`]
 //! which this example takes advantage of.
 //!
-//! ```rust,ignore
-//! use embedded_graphics::{image::Image, pixelcolor::Rgb888, prelude::*, primitives::Rectangle};
+//! ```rust
+//! use embedded_graphics::{
+//!     image::{Image, ImageRaw, ImageRawBE},
+//!     pixelcolor::Rgb565,
+//!     prelude::*,
+//!     primitives::Rectangle,
+//! };
 //! # use embedded_graphics::mock_display::MockDisplay as Display;
-//! use tinytga::Tga;
 //!
-//! let mut display: Display<Rgb888> = Display::default();
+//! let mut display: Display<Rgb565> = Display::default();
 //!
-//! // Load the TGA file with the sprite atlas.
-//! // Note that the color type is set explicitly to match the format used in the TGA file,
+//! // Raw image data for demonstration purposes.
+//! let data = [
+//!     0x00, 0x00, 0xF8, 0x00, 0x07, 0xE0, 0xFF, 0xE0, //
+//!     0x00, 0x1F, 0x07, 0xFF, 0xF8, 0x1F, 0xFF, 0xFF, //
+//!     // .
+//!     // .
+//!     // .
+//!     0xFF, 0xFF, 0x00, 0x1F, 0x07, 0xFF, 0xF8, 0x1F,
+//! ];
+//!
+//! // Load the image file with the sprite atlas.
+//! // Note that the color type is set explicitly to match the format used in the image file,
 //! // otherwise the compiler might infer an incorrect type.
-//! let sprite_atlas: Tga<Rgb888> = Tga::from_slice(include_bytes!(
-//!     "../../assets/tiles.tga"
-//! ))
-//! .unwrap();
+//! let sprite_atlas: ImageRawBE<Rgb565> = ImageRaw::new(&data, 4, 3);
 //!
 //! // Create individual sub images for each sprite in the sprite atlas.
 //! // The position and size of the sub images is defined by a `Rectangle`.

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -11,10 +11,10 @@
 //!
 //! # Examples
 //!
-//! ## Load an RGB565 raw data imge and display it
+//! ## Display an RGB565 raw data image
 //!
-//! This example loads a small image from a raw data array and displays it. The image is RGB565
-//! encoded, so it uses the `Rgb565` color type.
+//! This example displays a small image created from a raw data array. The image is RGB565 encoded,
+//! so it uses the `Rgb565` color type.
 //!
 //! ```rust
 //! use embedded_graphics::{
@@ -26,16 +26,15 @@
 //!
 //! let mut display: Display<Rgb565> = Display::default();
 //!
-//! // Raw image data for demonstration purposes.
+//! // Raw big endian image data for demonstration purposes. A real image would likely be much
+//! // larger.
 //! let data = [
 //!     0x00, 0x00, 0xF8, 0x00, 0x07, 0xE0, 0xFF, 0xE0, //
-//!     0x00, 0x1F, 0x07, 0xFF, 0xF8, 0x1F, 0xFF, 0xFF, /*
-//!            * ... */
+//!     0x00, 0x1F, 0x07, 0xFF, 0xF8, 0x1F, 0xFF, 0xFF, //
 //! ];
 //!
-//! // Load the image file.
-//! // Note that the color type must be set explicitly to match the format used in the image file,
-//! // otherwise the compiler might infer an incorrect type.
+//! // Create a raw image instance. Other image formats will require different code to load them.
+//! // All code after loading is the same for any image format.
 //! let raw: ImageRawBE<Rgb565> = ImageRaw::new(&data, 4, 2);
 //!
 //! // Create an `Image` object to position the image at `Point::zero()`.
@@ -50,9 +49,9 @@
 //! ## Sub images
 //!
 //! [`SubImage`]s are used to split a larger image drawables into multiple parts, e.g. to draw a
-//! single sprite from a sprite atlas. Use the [`sub_image`] method provided by [`ImageDrawableExt`]
-//! to get a sub image from an image drawable. [`ImageDrawableExt`] is included in the [`prelude`]
-//! which this example takes advantage of.
+//! single sprite from a sprite atlas as in this example. Use the [`sub_image`] method provided by
+//! [`ImageDrawableExt`] to get a sub image from an image drawable. [`ImageDrawableExt`] is included
+//! in the [`prelude`], which this example takes advantage of.
 //!
 //! ```rust
 //! use embedded_graphics::{
@@ -65,20 +64,11 @@
 //!
 //! let mut display: Display<Rgb565> = Display::default();
 //!
-//! // Raw image data for demonstration purposes.
-//! let data = [
-//!     0x00, 0x00, 0xF8, 0x00, 0x07, 0xE0, 0xFF, 0xE0, //
-//!     0x00, 0x1F, 0x07, 0xFF, 0xF8, 0x1F, 0xFF, 0xFF, //
-//!     // .
-//!     // .
-//!     // .
-//!     0xFF, 0xFF, 0x00, 0x1F, 0x07, 0xFF, 0xF8, 0x1F,
-//! ];
+//! let data = [ 0xF8, 0x00, 0x07, 0xE0, 0xFF, 0xE0, /* ... */ ];
+//! // or: let data = include_bytes!("sprite_atlas.raw");
 //!
-//! // Load the image file with the sprite atlas.
-//! // Note that the color type is set explicitly to match the format used in the image file,
-//! // otherwise the compiler might infer an incorrect type.
-//! let sprite_atlas: ImageRawBE<Rgb565> = ImageRaw::new(&data, 4, 3);
+//! # let data = [0u8; 64 * 32 * 2];
+//! let sprite_atlas: ImageRawBE<Rgb565> = ImageRaw::new(&data, 64, 32);
 //!
 //! // Create individual sub images for each sprite in the sprite atlas.
 //! // The position and size of the sub images is defined by a `Rectangle`.

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -14,10 +14,7 @@
 //! ## Load an RGB565 raw data imge and display it
 //!
 //! This example loads a small image from a raw data array and displays it. The image is RGB565
-//! encoded, so uses the `Rgb565` color type.
-//!
-//! The `graphics` feature of `tinytga` needs to be enabled in `Cargo.toml` to use the `Tga` object
-//! with embedded-graphics.
+//! encoded, so it uses the `Rgb565` color type.
 //!
 //! ```rust
 //! use embedded_graphics::{
@@ -37,7 +34,7 @@
 //! ];
 //!
 //! // Load the image file.
-//! // Note that the color type is set explicitly to match the format used in the image file,
+//! // Note that the color type must be set explicitly to match the format used in the image file,
 //! // otherwise the compiler might infer an incorrect type.
 //! let raw: ImageRawBE<Rgb565> = ImageRaw::new(&data, 4, 2);
 //!

--- a/src/mock_display.rs
+++ b/src/mock_display.rs
@@ -160,7 +160,10 @@
 //!
 //! image.draw(&mut display);
 //!
-//! display.assert_pattern(&["KRGY", "BCMW"]);
+//! display.assert_pattern(&[
+    "KRGY", //
+    "BCMW", //
+]);
 //! ```
 //!
 //! [`pixelcolor`]: ../pixelcolor/index.html#structs

--- a/src/mock_display.rs
+++ b/src/mock_display.rs
@@ -149,7 +149,7 @@
 //!
 //! let data = [
 //!     0x00, 0x00, 0xF8, 0x00, 0x07, 0xE0, 0xFF, 0xE0, //
-//!     0x00, 0x1F, 0x07, 0xFF, 0xF8, 0x1F, 0xFF, 0xFF,
+//!     0x00, 0x1F, 0x07, 0xFF, 0xF8, 0x1F, 0xFF, 0xFF, //
 //! ];
 //!
 //! let raw: ImageRawBE<Rgb565> = ImageRaw::new(&data, 4, 2);
@@ -161,9 +161,9 @@
 //! image.draw(&mut display);
 //!
 //! display.assert_pattern(&[
-    "KRGY", //
-    "BCMW", //
-]);
+//!     "KRGY", //
+//!     "BCMW", //
+//! ]);
 //! ```
 //!
 //! [`pixelcolor`]: ../pixelcolor/index.html#structs

--- a/src/mock_display.rs
+++ b/src/mock_display.rs
@@ -132,42 +132,35 @@
 //! ]);
 //! ```
 //!
-//! ## Load and validate a 24BPP TGA image
+//! ## Load and validate a 16BPP image
 //!
 //! This example loads the following test image (scaled 10x to make it visible) and tests the
 //! returned pixels against an expected pattern.
 //!
-//! The `graphics` feature of `tinytga` needs to be enabled in `Cargo.toml` to use the `Tga` object
-//! with embedded-graphics.
+//! ![Test image, scaled 1000%](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAUCAIAAABwJOjsAAAAMUlEQVRIx2NkwAv+45Vl/E++XiaGAQKjFo9aPGrx0LeYhVAJMxrUoxaPWjxq8aCzGAAVwwQnmlfSgwAAAABJRU5ErkJggg==)
 //!
-//! ![TGA test image, scaled 1000%]( data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFoAAAAyBAMAAAAuIdEGAAAAGFBMVEUAAAD/AAAA/wD//wAAAP//AP8A//////8V3DX3AAAACXBIWXMAAC4jAAAuIwF4pT92AAAAB3RJTUUH5AEODTI3wavPmgAAAEtJREFUSMdjKAcBBhAQBAElEHABAWMQCAWBNBCAqBtVPZhVI8Co6qGuejR9D8d8OQqGOkDEKJgFjmVwfINjHpwGwKkBnC5GVQ9m1QAE0rmq9y8gWgAAAABJRU5ErkJggg==)
-//!
-//! ```rust,ignore
+//! ```rust
 //! use embedded_graphics::{
-//!     image::Image,
+//!     image::{Image, ImageRaw, ImageRawBE},
 //!     mock_display::MockDisplay,
-//!     pixelcolor::{Rgb888, RgbColor},
+//!     pixelcolor::{Rgb565, RgbColor},
 //!     prelude::*,
 //! };
-//! use tinytga::Tga;
 //!
-//! let data = include_bytes!("../../tinytga/tests/type1_24bpp_tl.tga");
+//! let data = [
+//!     0x00, 0x00, 0xF8, 0x00, 0x07, 0xE0, 0xFF, 0xE0, //
+//!     0x00, 0x1F, 0x07, 0xFF, 0xF8, 0x1F, 0xFF, 0xFF,
+//! ];
 //!
-//! let tga: Tga<Rgb888> = Tga::from_slice(data).unwrap();
+//! let raw: ImageRawBE<Rgb565> = ImageRaw::new(&data, 4, 2);
 //!
-//! let image = Image::new(&tga, Point::zero());
+//! let image = Image::new(&raw, Point::zero());
 //!
-//! let mut display: MockDisplay<Rgb888> = MockDisplay::new();
+//! let mut display: MockDisplay<Rgb565> = MockDisplay::new();
 //!
 //! image.draw(&mut display);
 //!
-//! display.assert_pattern(&[,
-//!     "WKRGBYMCW",
-//!     "KKRGBYMCW",
-//!     "WKRGBYMCW",
-//!     "KKKKKKKKK",
-//!     "WKWCMYBGR",
-//! ]);
+//! display.assert_pattern(&["KRGY", "BCMW"]);
 //! ```
 //!
 //! [`pixelcolor`]: ../pixelcolor/index.html#structs


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Removes TinyTGA from ignored doc tests, unignores them, and replaces tinytga with some raw images.
