### PR TITLE
Sector thick stroke

### DIFF
--- a/src/primitives/line/styled.rs
+++ b/src/primitives/line/styled.rs
@@ -5,6 +5,7 @@ use crate::{
     iterator::IntoPixels,
     pixelcolor::PixelColor,
     primitives::{
+        common::LineSide,
         line::{thick_points::ThickPoints, Line, StrokeOffset},
         Rectangle,
     },
@@ -35,7 +36,7 @@ where
 
         Self {
             stroke_color,
-            line_iter: ThickPoints::new(&primitive, stroke_width),
+            line_iter: ThickPoints::new(&primitive, stroke_width, LineSide::Left),
         }
     }
 }

--- a/src/primitives/line/thick_points.rs
+++ b/src/primitives/line/thick_points.rs
@@ -75,14 +75,14 @@ pub(in crate::primitives::line) struct ParallelsIterator {
 }
 
 impl ParallelsIterator {
-    /// Creates a new parallels iterator, biased to the left for centered strokes with odd
+    /// Creates a new parallels iterator, biased to the left for centered strokes with even
     /// thickness.
     pub fn new(line: &Line, thickness: i32, stroke_offset: StrokeOffset) -> Self {
         Self::new_biased(line, thickness, stroke_offset, LineSide::Left)
     }
 
-    /// Create a parallels iterator with a given side bias if the stroke is centered and has an odd
-    /// width.
+    /// Create a parallels iterator with a given side bias if the stroke is centered and has an even
+    /// thickness.
     pub fn new_biased(
         mut line: &Line,
         thickness: i32,
@@ -111,7 +111,6 @@ impl ParallelsIterator {
         let flip = perpendicular_parameters.position_step.minor
             == -parallel_parameters.position_step.major;
 
-        // Next side, right-biased for center alignment.
         let next_side = match stroke_offset {
             StrokeOffset::None => center_bias.swap(),
             StrokeOffset::Left => LineSide::Left,
@@ -224,8 +223,8 @@ pub struct ThickPoints {
 impl ThickPoints {
     /// Creates a new iterator over the points in the stroke of a thick line.
     ///
-    /// A bias can be provided for centered lines with odd-numbered stroke widths. For consistency,
-    /// this should default to `LineSide::Left` under normal usage.
+    /// A bias can be provided for centered lines with even thickness. For consistency, this should
+    /// default to `LineSide::Left` under normal usage.
     pub(in crate::primitives) fn new(line: &Line, thickness: i32, center_bias: LineSide) -> Self {
         Self {
             parallel: Bresenham::new(line.start),

--- a/src/primitives/sector/styled.rs
+++ b/src/primitives/sector/styled.rs
@@ -327,4 +327,74 @@ mod tests {
         assert_eq!(center.bounding_box(), inside.bounding_box());
         assert_eq!(outside.bounding_box(), inside.bounding_box());
     }
+
+    #[test]
+    fn stroke_center_semicircle() -> Result<(), core::convert::Infallible> {
+        let mut display = MockDisplay::new();
+        display.set_allow_overdraw(true);
+
+        Sector::new(Point::new_equal(1), 15, 0.0.deg(), 180.0.deg())
+            .into_styled(
+                PrimitiveStyleBuilder::new()
+                    .fill_color(BinaryColor::On)
+                    .stroke_color(BinaryColor::Off)
+                    .stroke_width(2)
+                    .stroke_alignment(StrokeAlignment::Center)
+                    .build(),
+            )
+            .draw(&mut display)?;
+
+        display.assert_pattern(&[
+            "      .....      ",
+            "    .........    ",
+            "  ....#####....  ",
+            "  ..#########..  ",
+            " ..###########.. ",
+            " ..###########.. ",
+            "..#############..",
+            ".................",
+            ".................",
+        ]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn stroke_center_semicircle_vertical() -> Result<(), core::convert::Infallible> {
+        let mut display = MockDisplay::new();
+        display.set_allow_overdraw(true);
+
+        Sector::new(Point::new_equal(1), 15, 90.0.deg(), 180.0.deg())
+            .into_styled(
+                PrimitiveStyleBuilder::new()
+                    .fill_color(BinaryColor::On)
+                    .stroke_color(BinaryColor::Off)
+                    .stroke_width(2)
+                    .stroke_alignment(StrokeAlignment::Center)
+                    .build(),
+            )
+            .draw(&mut display)?;
+
+        display.assert_pattern(&[
+            "      ...",
+            "    .....",
+            "  ....#..",
+            "  ..###..",
+            " ..####..",
+            " ..####..",
+            "..#####..",
+            "..#####..",
+            "..#####..",
+            "..#####..",
+            "..#####..",
+            " ..####..",
+            " ..####..",
+            "  ..###..",
+            "  ....#..",
+            "    .....",
+            "      ...",
+        ]);
+
+        Ok(())
+    }
 }

--- a/src/primitives/sector/styled.rs
+++ b/src/primitives/sector/styled.rs
@@ -5,8 +5,8 @@ use crate::{
     iterator::IntoPixels,
     pixelcolor::PixelColor,
     primitives::{
-        circle::DistanceIterator, common::PlaneSectorIterator, line::ThickPoints, OffsetOutline,
-        Rectangle, Sector, Styled,
+        circle::DistanceIterator, common::LineSide, common::PlaneSectorIterator, line::ThickPoints,
+        OffsetOutline, Rectangle, Sector, Styled,
     },
     style::{PrimitiveStyle, StyledPrimitiveAreas},
     SaturatingCast,
@@ -50,8 +50,16 @@ where
         let line_a = stroke_area.line_from_angle(styled.primitive.angle_start);
         let line_b = stroke_area.line_from_angle(styled.primitive.angle_end());
 
-        let line_a_iter = ThickPoints::new(&line_a, styled.style.stroke_width.saturating_cast());
-        let line_b_iter = ThickPoints::new(&line_b, styled.style.stroke_width.saturating_cast());
+        let line_a_iter = ThickPoints::new(
+            &line_a,
+            styled.style.stroke_width.saturating_cast(),
+            LineSide::Left,
+        );
+        let line_b_iter = ThickPoints::new(
+            &line_b,
+            styled.style.stroke_width.saturating_cast(),
+            LineSide::Right,
+        );
 
         let points = if !styled.style.is_transparent() {
             PlaneSectorIterator::new(


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Fixes the following issue from #484:

![](https://user-images.githubusercontent.com/226123/99317584-97979100-2866-11eb-9b10-a419cda1292b.png)

Thick lines with even widths are biased to their left side. Because the sector lines point away from each other, the left side changes. This PR adds the ability to select a bias side for a thick line, fixing the semicircle issue.
