### PR TITLE
 Merge LinearEquation variants 

### DIFF
--- a/src/geometry/angle.rs
+++ b/src/geometry/angle.rs
@@ -7,10 +7,10 @@ use float_cmp::{ApproxEq, F32Margin};
 #[allow(unused_imports)]
 use micromath::F32Ext;
 
-#[allow(dead_code)]
 pub(crate) mod angle_consts {
     use super::{real, Angle};
 
+    #[allow(dead_code)]
     pub(crate) const ANGLE_90DEG: Angle = Angle(real::FRAC_PI_2);
     pub(crate) const ANGLE_180DEG: Angle = Angle(real::PI);
     pub(crate) const ANGLE_360DEG: Angle = Angle(real::TAU);

--- a/src/geometry/angle.rs
+++ b/src/geometry/angle.rs
@@ -7,6 +7,7 @@ use float_cmp::{ApproxEq, F32Margin};
 #[allow(unused_imports)]
 use micromath::F32Ext;
 
+#[allow(dead_code)]
 pub(crate) mod angle_consts {
     use super::{real, Angle};
 
@@ -62,12 +63,6 @@ impl Angle {
     /// Normalize the angle to less than one full rotation (ie. in the range 0..360).
     pub fn normalize(self) -> Self {
         Angle(self.0.rem_euclid((2.0 * PI).into()))
-    }
-
-    /// Normalize the angle to less than one full rotation, starting from angle.
-    /// (ie. in the range angle..(angle+360)).
-    pub(crate) fn normalize_from(self, angle: Self) -> Self {
-        Angle((self.0 - angle.0).rem_euclid((2.0 * PI).into()) + angle.0)
     }
 
     /// Return numerical value of the angle in degree

--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -232,6 +232,27 @@ impl Point {
     pub fn component_div(self, other: Self) -> Self {
         Self::new(self.x / other.x, self.y / other.y)
     }
+
+    /// Returns a point that is rotated by 90° relative to the origin.
+    pub(crate) const fn rotate_90(self) -> Self {
+        Self::new(self.y, -self.x)
+    }
+
+    /// Calculates the dot product of two points.
+    pub(crate) const fn dot_product(self, other: Point) -> i32 {
+        self.x * other.x + self.y * other.y
+    }
+
+    /// Calculates the determinant of a 2x2 matrix formed by this and another point.
+    ///
+    /// ```text
+    ///          | self.x  self.y  |
+    /// result = |                 |
+    ///          | other.x other.y |
+    ///
+    pub(crate) const fn determinant(self, other: Point) -> i32 {
+        self.x * other.y - self.y * other.x
+    }
 }
 
 impl Add for Point {
@@ -756,5 +777,13 @@ mod tests {
 
         assert_eq!(a.component_min(b), Point::new(15, 30));
         assert_eq!(a.component_max(b), Point::new(20, 50));
+    }
+
+    #[test]
+    fn rotate_90() {
+        assert_eq!(Point::new(1, 0).rotate_90(), Point::new(0, -1));
+        assert_eq!(Point::new(0, -2).rotate_90(), Point::new(-2, 0));
+        assert_eq!(Point::new(-3, 0).rotate_90(), Point::new(0, 3));
+        assert_eq!(Point::new(0, 4).rotate_90(), Point::new(4, 0));
     }
 }

--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -249,7 +249,7 @@ impl Point {
     ///          | self.x  self.y  |
     /// result = |                 |
     ///          | other.x other.y |
-    ///
+    /// ```
     pub(crate) const fn determinant(self, other: Point) -> i32 {
         self.x * other.y - self.y * other.x
     }

--- a/src/geometry/real.rs
+++ b/src/geometry/real.rs
@@ -15,6 +15,7 @@ pub(crate) use real_impl::{Real, FRAC_PI_2, PI, TAU};
 mod real_impl {
     use core::f32;
 
+    #[allow(dead_code)]
     pub(crate) const FRAC_PI_2: Real = Real(f32::consts::FRAC_PI_2);
     pub(crate) const PI: Real = Real(f32::consts::PI);
     pub(crate) const TAU: Real = Real(2.0 * f32::consts::PI);
@@ -63,6 +64,7 @@ mod real_impl {
 mod real_impl {
     use fixed::types::I16F16;
 
+    #[allow(dead_code)]
     pub(crate) const FRAC_PI_2: Real = Real(I16F16::from_bits(102944));
     pub(crate) const PI: Real = Real(I16F16::from_bits(205887));
     pub(crate) const TAU: Real = Real(I16F16::from_bits(411775));

--- a/src/primitives/common/line_join.rs
+++ b/src/primitives/common/line_join.rs
@@ -3,7 +3,7 @@
 use crate::{
     geometry::Point,
     primitives::{
-        common::{LineSide, StrokeOffset},
+        common::{LineSide, LinearEquation, StrokeOffset},
         line::Intersection,
         Line,
     },
@@ -144,12 +144,10 @@ impl LineJoin {
         ) {
             // Check if the inside end point of the second line lies inside the first segment.
             let self_intersection = match outer_side {
-                LineSide::Right => {
-                    first_edge_left.check_side(second_edge_left.end, LineSide::Right)
-                }
-                LineSide::Left => {
-                    first_edge_right.check_side(second_edge_right.end, LineSide::Left)
-                }
+                LineSide::Right => LinearEquation::from_line(&first_edge_left)
+                    .check_side(second_edge_left.end, LineSide::Right),
+                LineSide::Left => LinearEquation::from_line(&first_edge_right)
+                    .check_side(second_edge_right.end, LineSide::Left),
             };
 
             // Normal line: non-overlapping line end caps

--- a/src/primitives/common/linear_equation.rs
+++ b/src/primitives/common/linear_equation.rs
@@ -59,7 +59,7 @@ impl LinearEquation {
     /// Creates a horizontal line equation.
     pub fn new_horizontal() -> Self {
         LinearEquation {
-            normal_vector: Point::new(0, -16384),
+            normal_vector: Point::new(0, -NORMAL_VECTOR_SCALE),
             origin_distance: 0,
         }
     }

--- a/src/primitives/common/linear_equation.rs
+++ b/src/primitives/common/linear_equation.rs
@@ -3,62 +3,194 @@ use crate::{
     primitives::{common::LineSide, Line},
 };
 
-/// Linear equation representation
+/// Scaling factor for unit length normal vectors.
+const NORMAL_VECTOR_SCALE: i32 = 1 << 10;
+
+/// Linear equation.
 ///
-/// The equation is stored as the a, b and c coefficients of the ax + by + c = 0 equation
+/// The equation is stored as a normal vector and the distance to the origin.
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
-pub struct LinearEquation<T> {
-    pub a: T,
-    pub b: T,
-    pub c: T,
+pub struct LinearEquation {
+    /// Normal vector, perpendicular to the line.
+    ///
+    /// The unit vector is scaled up to increase the resolution.
+    pub normal_vector: Point,
+
+    /// Distance from the origin.
+    ///
+    /// The distance doesn't directly correlate to the distance in pixels, but is
+    /// scaled up by the length of the normal vector.
+    pub origin_distance: i32,
 }
 
-impl LinearEquation<i32> {
-    pub const fn from_line(line: &Line) -> Self {
+impl LinearEquation {
+    /// Creates a new linear equation from a line.
+    pub fn from_line(line: &Line) -> Self {
+        let normal_vector = line.delta().rotate_90();
+        let origin_distance = line.start.dot_product(normal_vector);
+
         Self {
-            a: line.end.y - line.start.y,
-            b: line.start.x - line.end.x,
-            c: line.end.x * line.start.y - line.start.x * line.end.y,
+            normal_vector,
+            origin_distance,
         }
     }
-}
 
-impl LinearEquation<Real> {
-    /// Create a new linear equation based on one point and one angle
+    /// Creates a new linear equation based on one point and one angle.
     pub fn from_point_angle(point: Point, angle: Angle) -> Self {
         // FIXME: angle.tan() for 180.0 degrees isn't exactly 0 which causes problems when drawing
         //        a single quadrant. Is there a better solution to fix this?
-        let (a, b) = if angle == Angle::from_degrees(180.0) {
-            (Real::from(0.0), Real::from(-1.0))
+        let normal_vector = if angle == Angle::from_degrees(180.0) {
+            Point::new(0, NORMAL_VECTOR_SCALE)
         } else {
-            match angle.tan() {
-                None => (Real::from(1.0), Real::from(0.0)),
-                Some(a) => (-a, Real::from(-1.0)),
-            }
+            -Point::new(
+                i32::from(angle.sin() * Real::from(NORMAL_VECTOR_SCALE)),
+                i32::from(angle.cos() * Real::from(NORMAL_VECTOR_SCALE)),
+            )
         };
 
-        let c = -(a * point.x.into() + b * point.y.into());
-        LinearEquation { a, b, c }
+        let origin_distance = point.dot_product(normal_vector);
+
+        LinearEquation {
+            normal_vector,
+            origin_distance,
+        }
     }
 
-    /// Create a horizontal line equation
+    /// Creates a horizontal line equation.
     pub fn new_horizontal() -> Self {
         LinearEquation {
-            a: Real::from(0.0),
-            b: Real::from(1.0),
-            c: Real::from(0.0),
+            normal_vector: Point::new(0, -16384),
+            origin_distance: 0,
         }
+    }
+
+    /// Returns the distance between the line and a point.
+    ///
+    /// The scaling of the returned value depends on the length of the normal vector.
+    /// Positive values will be returned for points on the left side of the line and negative
+    /// values for points on the right.
+    pub fn distance(&self, point: Point) -> i32 {
+        point.dot_product(self.normal_vector) - self.origin_distance
     }
 
     /// Checks if a point is on the given side of the line.
     ///
     /// Always returns `true` if the point is on the line.
     pub fn check_side(&self, point: Point, side: LineSide) -> bool {
-        let t = self.a * point.x.into() + self.b * point.y.into() + self.c;
+        let distance = self.distance(point);
 
         match side {
-            LineSide::Right => t <= Real::from(0.0),
-            LineSide::Left => t >= Real::from(0.0),
+            LineSide::Right => distance <= 0,
+            LineSide::Left => distance >= 0,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::geometry::AngleUnit;
+
+    #[test]
+    fn from_line() {
+        assert_eq!(
+            LinearEquation::from_line(&Line::new(Point::zero(), Point::new(1, 0))),
+            LinearEquation {
+                normal_vector: Point::new(0, -1),
+                origin_distance: 0, // line goes through the origin
+            }
+        );
+
+        assert_eq!(
+            LinearEquation::from_line(&Line::new(Point::zero(), Point::new(0, 1))),
+            LinearEquation {
+                normal_vector: Point::new(1, 0),
+                origin_distance: 0, // line goes through the origin
+            }
+        );
+
+        assert_eq!(
+            LinearEquation::from_line(&Line::new(Point::new(2, 3), Point::new(-2, 3))),
+            LinearEquation {
+                normal_vector: Point::new(0, 4),
+                // origin_distance = min. distance between line and origin * length of unit vector
+                //                 = 3 * 4
+                origin_distance: 12,
+            }
+        );
+    }
+
+    #[test]
+    fn from_point_angle() {
+        assert_eq!(
+            LinearEquation::from_point_angle(Point::zero(), 0.0.deg()),
+            LinearEquation {
+                normal_vector: Point::new(0, -NORMAL_VECTOR_SCALE),
+                origin_distance: 0, // line goes through the origin
+            }
+        );
+
+        assert_eq!(
+            LinearEquation::from_point_angle(Point::zero(), 90.0.deg()),
+            LinearEquation {
+                normal_vector: Point::new(-NORMAL_VECTOR_SCALE, 0),
+                origin_distance: 0, // line goes through the origin
+            }
+        );
+
+        let point = Point::new(3, 4);
+        assert_eq!(
+            LinearEquation::from_point_angle(point, 180.0.deg()),
+            LinearEquation {
+                normal_vector: Point::new(0, NORMAL_VECTOR_SCALE),
+                // (0, 4) is the closest point to the origin that lies on the line
+                origin_distance: 4 * NORMAL_VECTOR_SCALE,
+            }
+        );
+    }
+
+    #[test]
+    fn distance() {
+        let line = LinearEquation::from_point_angle(Point::zero(), 90.0.deg());
+        assert_eq!(line.distance(Point::new(-1, 0)), NORMAL_VECTOR_SCALE);
+        assert_eq!(line.distance(Point::new(1, 0)), -NORMAL_VECTOR_SCALE);
+    }
+
+    #[test]
+    fn check_side_horizontal() {
+        let line = LinearEquation::from_point_angle(Point::zero(), 0.0.deg());
+        assert!(line.check_side(Point::new(0, 0), LineSide::Left));
+        assert!(line.check_side(Point::new(1, 0), LineSide::Right));
+        assert!(!line.check_side(Point::new(-2, 1), LineSide::Left));
+        assert!(line.check_side(Point::new(3, 1), LineSide::Right));
+        assert!(line.check_side(Point::new(-4, -1), LineSide::Left));
+        assert!(!line.check_side(Point::new(5, -1), LineSide::Right));
+
+        let line = LinearEquation::from_point_angle(Point::zero(), 180.0.deg());
+        assert!(line.check_side(Point::new(0, 0), LineSide::Left));
+        assert!(line.check_side(Point::new(1, 0), LineSide::Right));
+        assert!(line.check_side(Point::new(-2, 1), LineSide::Left));
+        assert!(!line.check_side(Point::new(3, 1), LineSide::Right));
+        assert!(!line.check_side(Point::new(-4, -1), LineSide::Left));
+        assert!(line.check_side(Point::new(5, -1), LineSide::Right));
+    }
+
+    #[test]
+    fn check_side_vertical() {
+        let line = LinearEquation::from_point_angle(Point::zero(), 90.0.deg());
+        assert!(line.check_side(Point::new(0, 0), LineSide::Left));
+        assert!(line.check_side(Point::new(0, -1), LineSide::Right));
+        assert!(line.check_side(Point::new(-1, 2), LineSide::Left));
+        assert!(!line.check_side(Point::new(-1, -3), LineSide::Right));
+        assert!(!line.check_side(Point::new(1, 4), LineSide::Left));
+        assert!(line.check_side(Point::new(1, -5), LineSide::Right));
+
+        let line = LinearEquation::from_point_angle(Point::zero(), 270.0.deg());
+        assert!(line.check_side(Point::new(0, 0), LineSide::Left));
+        assert!(line.check_side(Point::new(0, 1), LineSide::Right));
+        assert!(!line.check_side(Point::new(-1, -2), LineSide::Left));
+        assert!(line.check_side(Point::new(-1, 3), LineSide::Right));
+        assert!(line.check_side(Point::new(1, -4), LineSide::Left));
+        assert!(!line.check_side(Point::new(1, 5), LineSide::Right));
     }
 }

--- a/src/primitives/common/plane_sector.rs
+++ b/src/primitives/common/plane_sector.rs
@@ -1,10 +1,20 @@
 use crate::{
-    geometry::{angle_consts::*, Angle, Dimensions, Point, Real},
+    geometry::{angle_consts::*, Angle, Dimensions, Point},
     primitives::{
         common::{LineSide, LinearEquation},
         rectangle, Primitive, Rectangle,
     },
 };
+
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+enum Operation {
+    /// Return the intersection of both half planes.
+    Intersection,
+    /// Return the union of both half planes.
+    Union,
+    /// Return the entire plane.
+    EntirePlane,
+}
 
 /// Sector shaped part of a plane.
 ///
@@ -14,49 +24,45 @@ use crate::{
 /// half-planes.
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
 pub struct PlaneSector {
-    line_a: LinearEquation<Real>,
-    line_b: LinearEquation<Real>,
-    side_a: LineSide,
-    side_b: LineSide,
-    sweep: Angle,
+    /// Half plane on the left side of a line.
+    half_plane_left: LinearEquation,
+    /// Half plane on the right side of a line.
+    half_plane_right: LinearEquation,
+    /// The operation used to combine the two half planes.
+    operation: Operation,
 }
 
 impl PlaneSector {
-    pub fn new(center_2x: Point, angle_start: Angle, angle_sweep: Angle) -> Self {
-        let angle_end = angle_start + angle_sweep;
+    pub fn new(center_2x: Point, mut angle_start: Angle, angle_sweep: Angle) -> Self {
+        let mut angle_end = angle_start + angle_sweep;
 
-        let angle_start_norm = angle_start.normalize_from(-ANGLE_90DEG);
-        let angle_end_norm = angle_end.normalize_from(-ANGLE_90DEG);
-        let negative_sweep = angle_sweep < Angle::zero();
+        // Swap angles for negative sweeps to use the correct sides of the half planes.
+        if angle_sweep < Angle::zero() {
+            core::mem::swap(&mut angle_start, &mut angle_end)
+        }
 
-        let side_a = if (angle_start_norm < ANGLE_90DEG) ^ negative_sweep {
-            LineSide::Left
+        let angle_sweep_abs = angle_sweep.abs();
+        let operation = if angle_sweep_abs < ANGLE_180DEG {
+            Operation::Intersection
+        } else if angle_sweep_abs < ANGLE_360DEG {
+            Operation::Union
         } else {
-            LineSide::Right
-        };
-
-        let side_b = if (angle_end_norm >= ANGLE_90DEG) ^ negative_sweep {
-            LineSide::Left
-        } else {
-            LineSide::Right
+            Operation::EntirePlane
         };
 
         Self {
-            line_a: LinearEquation::from_point_angle(center_2x, angle_start),
-            line_b: LinearEquation::from_point_angle(center_2x, angle_end),
-            side_a,
-            side_b,
-            sweep: angle_sweep.abs(),
+            half_plane_left: LinearEquation::from_point_angle(center_2x, angle_start),
+            half_plane_right: LinearEquation::from_point_angle(center_2x, angle_end),
+            operation,
         }
     }
 
+    /// TODO: This method doesn't really return an empty plane sector. Does this matter?
     fn empty() -> Self {
         Self {
-            line_a: LinearEquation::new_horizontal(),
-            line_b: LinearEquation::new_horizontal(),
-            side_a: LineSide::Left,
-            side_b: LineSide::Left,
-            sweep: Angle::zero(),
+            half_plane_left: LinearEquation::new_horizontal(),
+            half_plane_right: LinearEquation::new_horizontal(),
+            operation: Operation::Union,
         }
     }
 
@@ -64,15 +70,13 @@ impl PlaneSector {
         // `PlaneSector` uses scaled coordinates for an increased resolution.
         let point = point * 2;
 
-        let correct_side_a = self.line_a.check_side(point, self.side_a);
-        let correct_side_b = self.line_b.check_side(point, self.side_b);
+        let correct_side_1 = self.half_plane_left.check_side(point, LineSide::Left);
+        let correct_side_2 = self.half_plane_right.check_side(point, LineSide::Right);
 
-        if self.sweep < ANGLE_180DEG {
-            correct_side_a && correct_side_b
-        } else if self.sweep < ANGLE_360DEG {
-            correct_side_a || correct_side_b
-        } else {
-            true
+        match self.operation {
+            Operation::Intersection => correct_side_1 && correct_side_2,
+            Operation::Union => correct_side_1 || correct_side_2,
+            Operation::EntirePlane => true,
         }
     }
 }

--- a/src/primitives/line/mod.rs
+++ b/src/primitives/line/mod.rs
@@ -202,7 +202,7 @@ impl Line {
         // Calculate the determinant to solve the system of linear equations using Cramer's rule.
         let denominator = line1.normal_vector.determinant(line2.normal_vector);
 
-        // The system of linear equations has no solutions if the determinant is zero. In this case, 
+        // The system of linear equations has no solutions if the determinant is zero. In this case,
         // the lines must be colinear.
         if denominator == 0 {
             return Intersection::Colinear;

--- a/src/primitives/line/mod.rs
+++ b/src/primitives/line/mod.rs
@@ -191,24 +191,6 @@ impl Line {
         self.end - self.start
     }
 
-    /// Checks if the point lies on the given side of the line.
-    ///
-    /// Returns `true` if the point lies on the correct side or on the line.
-    pub(in crate::primitives) fn check_side(&self, point: Point, side: LineSide) -> bool {
-        let Point { x: x1, y: y1 } = self.start;
-        let Point { x: x2, y: y2 } = self.end;
-
-        let Point { x, y } = point;
-
-        // https://math.stackexchange.com/a/274728/4506
-        let t = (x - x1) * (y2 - y1) - (y - y1) * (x2 - x1);
-
-        match side {
-            LineSide::Left => t >= 0,
-            LineSide::Right => t <= 0,
-        }
-    }
-
     /// Integer-only line intersection
     ///
     /// Inspired from https://stackoverflow.com/a/61485959/383609, which links to

--- a/src/primitives/line/mod.rs
+++ b/src/primitives/line/mod.rs
@@ -202,8 +202,8 @@ impl Line {
         // Calculate the determinant to solve the system of linear equations using Cramer's rule.
         let denominator = line1.normal_vector.determinant(line2.normal_vector);
 
-        // The system of linear equations has no solutions if the determinant is zero and the lines
-        // have to be colinear.
+        // The system of linear equations has no solutions if the determinant is zero. In this case, 
+        // the lines must be colinear.
         if denominator == 0 {
             return Intersection::Colinear;
         }

--- a/src/primitives/line/mod.rs
+++ b/src/primitives/line/mod.rs
@@ -217,28 +217,42 @@ impl Line {
         let line1 = LinearEquation::from_line(self);
         let line2 = LinearEquation::from_line(other);
 
-        let denom = line1.a * line2.b - line2.a * line1.b;
+        // Calculate the determinant to solve the system of linear equations using Cramer's rule.
+        let denominator = line1.normal_vector.determinant(line2.normal_vector);
 
-        // Lines are colinear or parallel
-        if denom == 0 {
+        // The system of linear equations has no solutions if the determinant is zero and the lines
+        // have to be colinear.
+        if denominator == 0 {
             return Intersection::Colinear;
         }
 
         // If we got here, line segments intersect. Compute intersection point using method similar
         // to that described here: http://paulbourke.net/geometry/pointlineplane/#i2l
 
-        // The denom/2 is to get rounding instead of truncating.
-        let offset = denom.abs() / 2;
+        // The denominator/2 is to get rounding instead of truncating.
+        let offset = denominator.abs() / 2;
 
-        let num = line1.b * line2.c - line2.b * line1.c;
-        let x = if num < 0 { num - offset } else { num + offset } / denom;
+        let origin_distances = Point::new(line1.origin_distance, line2.origin_distance);
 
-        let num = line2.a * line1.c - line1.a * line2.c;
-        let y = if num < 0 { num - offset } else { num + offset } / denom;
+        let numerator =
+            origin_distances.determinant(Point::new(line1.normal_vector.y, line2.normal_vector.y));
+        let x_numerator = if numerator < 0 {
+            numerator - offset
+        } else {
+            numerator + offset
+        };
+
+        let numerator =
+            Point::new(line1.normal_vector.x, line2.normal_vector.x).determinant(origin_distances);
+        let y_numerator = if numerator < 0 {
+            numerator - offset
+        } else {
+            numerator + offset
+        };
 
         Intersection::Point {
-            point: Point::new(x, y),
-            outer_side: if denom > 0 {
+            point: Point::new(x_numerator, y_numerator) / denominator,
+            outer_side: if denominator > 0 {
                 LineSide::Right
             } else {
                 LineSide::Left

--- a/src/primitives/triangle/mod.rs
+++ b/src/primitives/triangle/mod.rs
@@ -8,7 +8,7 @@ mod styled;
 use crate::{
     geometry::{Dimensions, Point},
     primitives::{
-        common::{LineJoin, LineSide, Scanline, StrokeOffset},
+        common::{LineJoin, LineSide, LinearEquation, Scanline, StrokeOffset},
         ContainsPoint, Line, Primitive, Rectangle,
     },
     transform::Transform,
@@ -271,7 +271,7 @@ impl Triangle {
 
             // If the inner point is to the left of the opposite side line, the triangle edges self-
             // intersect, so the triangle is collapsed.
-            opposite.check_side(inner_point, LineSide::Left)
+            LinearEquation::from_line(&opposite).check_side(inner_point, LineSide::Left)
         })
     }
 }


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR merges `LinearEquation<Real>` and `LinearEquation<i32>` into one variant that uses `i32` values. I've also changed the way the coefficients are stored inside `LinearEquation` to make the formulas that use these values more readable. But this means that the PR turned out to be longer than expected.

I had to rewrite some code for sectors, so there might be some changes for #484, but I haven't checked yet.