### PR TITLE
Add additional sector tests and benches

### DIFF
--- a/benches/primitives.rs
+++ b/benches/primitives.rs
@@ -153,7 +153,7 @@ fn sector(c: &mut Criterion) {
         b.iter(|| sector.into_styled(style).draw(&mut framebuffer))
     });
 
-    group.bench_function("1px stroke & fill", |b| {
+    group.bench_function("1px stroke and fill", |b| {
         let style = PrimitiveStyleBuilder::new()
             .stroke_color(Gray8::WHITE)
             .stroke_width(1)
@@ -164,7 +164,7 @@ fn sector(c: &mut Criterion) {
         b.iter(|| sector.into_styled(style).draw(&mut framebuffer))
     });
 
-    group.bench_function("10px stroke & fill", |b| {
+    group.bench_function("10px stroke and fill", |b| {
         let style = PrimitiveStyleBuilder::new()
             .stroke_color(Gray8::WHITE)
             .stroke_width(10)
@@ -212,7 +212,7 @@ fn sector_360(c: &mut Criterion) {
         b.iter(|| sector.into_styled(style).draw(&mut framebuffer))
     });
 
-    group.bench_function("1px stroke & fill", |b| {
+    group.bench_function("1px stroke and fill", |b| {
         let style = PrimitiveStyleBuilder::new()
             .stroke_color(Gray8::WHITE)
             .stroke_width(1)
@@ -223,7 +223,7 @@ fn sector_360(c: &mut Criterion) {
         b.iter(|| sector.into_styled(style).draw(&mut framebuffer))
     });
 
-    group.bench_function("10px stroke & fill", |b| {
+    group.bench_function("10px stroke and fill", |b| {
         let style = PrimitiveStyleBuilder::new()
             .stroke_color(Gray8::WHITE)
             .stroke_width(10)

--- a/benches/primitives.rs
+++ b/benches/primitives.rs
@@ -153,6 +153,32 @@ fn sector(c: &mut Criterion) {
         b.iter(|| sector.into_styled(style).draw(&mut framebuffer))
     });
 
+    group.bench_function("1px stroke & fill", |b| {
+        let style = PrimitiveStyleBuilder::new()
+            .stroke_color(Gray8::WHITE)
+            .stroke_width(1)
+            .fill_color(Gray8::new(128))
+            .build();
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| sector.into_styled(style).draw(&mut framebuffer))
+    });
+
+    group.bench_function("10px stroke & fill", |b| {
+        let style = PrimitiveStyleBuilder::new()
+            .stroke_color(Gray8::WHITE)
+            .stroke_width(10)
+            .fill_color(Gray8::new(128))
+            .build();
+
+        // Reduce sector radius by half the stoke width to make the bounding box
+        // equal to the other benches.
+        let sector = sector.offset(-(style.stroke_width as i32 / 2));
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| sector.into_styled(style).draw(&mut framebuffer))
+    });
+
     group.bench_function("fill", |b| {
         let style = PrimitiveStyle::with_fill(Gray8::WHITE);
 
@@ -177,6 +203,32 @@ fn sector_360(c: &mut Criterion) {
 
     group.bench_function("10px stroke", |b| {
         let style = PrimitiveStyle::with_stroke(Gray8::WHITE, 10);
+
+        // Reduce sector radius by half the stoke width to make the bounding box
+        // equal to the other benches.
+        let sector = sector.offset(-(style.stroke_width as i32 / 2));
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| sector.into_styled(style).draw(&mut framebuffer))
+    });
+
+    group.bench_function("1px stroke & fill", |b| {
+        let style = PrimitiveStyleBuilder::new()
+            .stroke_color(Gray8::WHITE)
+            .stroke_width(1)
+            .fill_color(Gray8::new(128))
+            .build();
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| sector.into_styled(style).draw(&mut framebuffer))
+    });
+
+    group.bench_function("10px stroke & fill", |b| {
+        let style = PrimitiveStyleBuilder::new()
+            .stroke_color(Gray8::WHITE)
+            .stroke_width(10)
+            .fill_color(Gray8::new(128))
+            .build();
 
         // Reduce sector radius by half the stoke width to make the bounding box
         // equal to the other benches.

--- a/benches/primitives.rs
+++ b/benches/primitives.rs
@@ -145,6 +145,10 @@ fn sector(c: &mut Criterion) {
     group.bench_function("10px stroke", |b| {
         let style = PrimitiveStyle::with_stroke(Gray8::WHITE, 10);
 
+        // Reduce sector radius by half the stoke width to make the bounding box
+        // equal to the other benches.
+        let sector = sector.offset(-(style.stroke_width as i32 / 2));
+
         let mut framebuffer = Framebuffer::new();
         b.iter(|| sector.into_styled(style).draw(&mut framebuffer))
     });
@@ -173,6 +177,10 @@ fn sector_360(c: &mut Criterion) {
 
     group.bench_function("10px stroke", |b| {
         let style = PrimitiveStyle::with_stroke(Gray8::WHITE, 10);
+
+        // Reduce sector radius by half the stoke width to make the bounding box
+        // equal to the other benches.
+        let sector = sector.offset(-(style.stroke_width as i32 / 2));
 
         let mut framebuffer = Framebuffer::new();
         b.iter(|| sector.into_styled(style).draw(&mut framebuffer))

--- a/benches/primitives.rs
+++ b/benches/primitives.rs
@@ -131,23 +131,61 @@ fn arc(c: &mut Criterion) {
 }
 
 fn sector(c: &mut Criterion) {
-    c.bench_function("sector", |b| {
-        let object = Sector::new(Point::new(100, 100), 100, -30.0.deg(), 150.0.deg())
-            .into_styled(PrimitiveStyle::with_stroke(Gray8::new(1), 1));
+    let mut group = c.benchmark_group("sector");
+
+    let sector = Sector::with_center(Point::new_equal(32), 30, -30.0.deg(), 150.0.deg());
+
+    group.bench_function("1px stroke", |b| {
+        let style = PrimitiveStyle::with_stroke(Gray8::WHITE, 1);
 
         let mut framebuffer = Framebuffer::new();
-        b.iter(|| object.draw(&mut framebuffer))
+        b.iter(|| sector.into_styled(style).draw(&mut framebuffer))
     });
+
+    group.bench_function("10px stroke", |b| {
+        let style = PrimitiveStyle::with_stroke(Gray8::WHITE, 10);
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| sector.into_styled(style).draw(&mut framebuffer))
+    });
+
+    group.bench_function("fill", |b| {
+        let style = PrimitiveStyle::with_fill(Gray8::WHITE);
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| sector.into_styled(style).draw(&mut framebuffer))
+    });
+
+    group.finish();
 }
 
-fn filled_sector(c: &mut Criterion) {
-    c.bench_function("filled_sector", |b| {
-        let object = Sector::new(Point::new(100, 100), 100, -30.0.deg(), 150.0.deg())
-            .into_styled(PrimitiveStyle::with_fill(Gray8::new(1)));
+fn sector_360(c: &mut Criterion) {
+    let mut group = c.benchmark_group("360° sector");
+
+    let sector = Sector::with_center(Point::new_equal(32), 30, 0.0.deg(), 360.0.deg());
+
+    group.bench_function("1px stroke", |b| {
+        let style = PrimitiveStyle::with_stroke(Gray8::WHITE, 1);
 
         let mut framebuffer = Framebuffer::new();
-        b.iter(|| object.draw(&mut framebuffer))
+        b.iter(|| sector.into_styled(style).draw(&mut framebuffer))
     });
+
+    group.bench_function("10px stroke", |b| {
+        let style = PrimitiveStyle::with_stroke(Gray8::WHITE, 10);
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| sector.into_styled(style).draw(&mut framebuffer))
+    });
+
+    group.bench_function("fill", |b| {
+        let style = PrimitiveStyle::with_fill(Gray8::WHITE);
+
+        let mut framebuffer = Framebuffer::new();
+        b.iter(|| sector.into_styled(style).draw(&mut framebuffer))
+    });
+
+    group.finish();
 }
 
 fn polyline(c: &mut Criterion) {
@@ -247,6 +285,6 @@ criterion_group!(
     rounded_rectangle_corners,
     arc,
     sector,
-    filled_sector
+    sector_360,
 );
 criterion_main!(primitives);


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR adds tests for all issues reported in #484. I've also included the two tests from #497.

![grafik](https://user-images.githubusercontent.com/226123/100002640-28212480-2dc5-11eb-835e-67c358f1cb0c.png)

All failing tests are ignored can be reenabled in the PRs that fix one or more of these issues. I've updated #484 to track the progress.

In addition to the tests I've also added more benches for sectors. The additional 10px stroke tests shows the huge impact of the line drawing:

![grafik](https://user-images.githubusercontent.com/226123/100003018-bbf2f080-2dc5-11eb-8f5d-98e121bb74b0.png)





