### PR TITLE
Improve sector drawing

### DIFF
--- a/src/geometry/angle.rs
+++ b/src/geometry/angle.rs
@@ -10,7 +10,6 @@ use micromath::F32Ext;
 pub(crate) mod angle_consts {
     use super::{real, Angle};
 
-    #[allow(dead_code)]
     pub(crate) const ANGLE_90DEG: Angle = Angle(real::FRAC_PI_2);
     pub(crate) const ANGLE_180DEG: Angle = Angle(real::PI);
     pub(crate) const ANGLE_360DEG: Angle = Angle(real::TAU);

--- a/src/primitives/arc/styled.rs
+++ b/src/primitives/arc/styled.rs
@@ -140,14 +140,10 @@ mod tests {
             .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
             .draw(&mut display)?;
 
-        #[rustfmt::skip]
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
-                "  ###  ",
-                " #   # ",
-            ])
-        );
+        display.assert_pattern(&[
+            "  ###  ", //
+            " #   # ", //
+        ]);
 
         Ok(())
     }
@@ -231,8 +227,8 @@ mod tests {
             .draw(&mut display_outside)
             .unwrap();
 
-        assert_eq!(display_center, display_inside);
-        assert_eq!(display_center, display_outside);
+        display_inside.assert_eq(&display_center);
+        display_outside.assert_eq(&display_center);
     }
 
     #[test]

--- a/src/primitives/circle/distance_iterator.rs
+++ b/src/primitives/circle/distance_iterator.rs
@@ -1,25 +1,35 @@
-use crate::geometry::Point;
+use crate::{
+    geometry::Point,
+    primitives::{
+        rectangle::{self, Rectangle},
+        Primitive,
+    },
+};
 
 /// Iterator that returns the squared distance to the center for all points in the bounding box.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub struct DistanceIterator<I> {
+pub struct DistanceIterator {
     center_2x: Point,
-    points: I,
+    points: rectangle::Points,
 }
 
-impl<I> DistanceIterator<I>
-where
-    I: Iterator<Item = Point>,
-{
-    pub(super) fn new(center_2x: Point, points: I) -> Self {
-        Self { center_2x, points }
+impl DistanceIterator {
+    pub fn new(center_2x: Point, bounding_box: &Rectangle) -> Self {
+        Self {
+            center_2x,
+            points: bounding_box.points(),
+        }
+    }
+
+    pub fn empty() -> Self {
+        Self {
+            center_2x: Point::zero(),
+            points: rectangle::Points::empty(),
+        }
     }
 }
 
-impl<I> Iterator for DistanceIterator<I>
-where
-    I: Iterator<Item = Point>,
-{
+impl Iterator for DistanceIterator {
     type Item = (Point, u32);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -40,7 +50,7 @@ mod tests {
     fn distance_iter() {
         let circle = Circle::new(Point::zero(), 3);
 
-        let mut iter = DistanceIterator::new(circle.center_2x(), circle.bounding_box().points());
+        let mut iter = DistanceIterator::new(circle.center_2x(), &circle.bounding_box());
         assert_eq!(iter.next(), Some((Point::new(0, 0), 8)));
         assert_eq!(iter.next(), Some((Point::new(1, 0), 4)));
         assert_eq!(iter.next(), Some((Point::new(2, 0), 8)));
@@ -55,7 +65,7 @@ mod tests {
 
     #[test]
     fn distance_iter_empty() {
-        let mut iter = DistanceIterator::new(Point::zero(), Rectangle::zero().points());
+        let mut iter = DistanceIterator::empty();
         assert_eq!(iter.next(), None);
     }
 }

--- a/src/primitives/circle/mod.rs
+++ b/src/primitives/circle/mod.rs
@@ -97,12 +97,9 @@ impl Circle {
         diameter_to_threshold(self.diameter)
     }
 
-    /// Returns the squared distance for every point returned by the iterator.
-    pub(in crate::primitives) fn distances<I>(&self, points: I) -> DistanceIterator<I>
-    where
-        I: Iterator<Item = Point>,
-    {
-        DistanceIterator::new(self.center_2x(), points)
+    /// Returns the squared distance for every point in the bounding box.
+    pub(in crate::primitives) fn distances(&self) -> DistanceIterator {
+        DistanceIterator::new(self.center_2x(), &self.bounding_box())
     }
 }
 

--- a/src/primitives/circle/points.rs
+++ b/src/primitives/circle/points.rs
@@ -1,21 +1,19 @@
 use crate::{
-    geometry::{Dimensions, Point},
+    geometry::Point,
     primitives::circle::{distance_iterator::DistanceIterator, Circle},
-    primitives::rectangle,
-    primitives::Primitive,
 };
 
 /// Iterator over all points inside the circle.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Points {
-    iter: DistanceIterator<rectangle::Points>,
+    iter: DistanceIterator,
     threshold: u32,
 }
 
 impl Points {
     pub(in crate::primitives) fn new(circle: &Circle) -> Self {
         Self {
-            iter: circle.distances(circle.bounding_box().points()),
+            iter: circle.distances(),
             threshold: circle.threshold(),
         }
     }

--- a/src/primitives/circle/styled.rs
+++ b/src/primitives/circle/styled.rs
@@ -4,10 +4,9 @@ use crate::{
     geometry::{Dimensions, Size},
     iterator::IntoPixels,
     pixelcolor::PixelColor,
-    primitives::rectangle::{self, Rectangle},
-    primitives::Primitive,
     primitives::{
         circle::{distance_iterator::DistanceIterator, Circle},
+        rectangle::Rectangle,
         OffsetOutline,
     },
     style::{PrimitiveStyle, Styled, StyledPrimitiveAreas},
@@ -20,7 +19,7 @@ pub struct StyledPixels<C>
 where
     C: PixelColor,
 {
-    iter: DistanceIterator<rectangle::Points>,
+    iter: DistanceIterator,
 
     outer_threshold: u32,
     outer_color: Option<C>,
@@ -37,14 +36,14 @@ where
         let stroke_area = styled.stroke_area();
         let fill_area = styled.fill_area();
 
-        let points = if !styled.style.is_transparent() {
-            stroke_area.bounding_box().points()
+        let iter = if !styled.style.is_transparent() {
+            stroke_area.distances()
         } else {
-            Rectangle::zero().points()
+            DistanceIterator::empty()
         };
 
         Self {
-            iter: stroke_area.distances(points),
+            iter,
             outer_threshold: stroke_area.threshold(),
             outer_color: styled.style.stroke_color,
             inner_threshold: fill_area.threshold(),

--- a/src/primitives/common/linear_equation.rs
+++ b/src/primitives/common/linear_equation.rs
@@ -86,6 +86,59 @@ impl LinearEquation {
     }
 }
 
+/// Linear equation though the origin.
+///
+/// TODO: docs
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+pub struct OriginLinearEquation {
+    pub normal_vector: Point,
+}
+
+impl OriginLinearEquation {
+    pub fn with_angle(angle: Angle) -> Self {
+        // FIXME: angle.tan() for 180.0 degrees isn't exactly 0 which causes problems when drawing
+        //        a single quadrant. Is there a better solution to fix this?
+        let normal_vector = if angle == Angle::from_degrees(180.0) {
+            Point::new(0, NORMAL_VECTOR_SCALE)
+        } else {
+            -Point::new(
+                i32::from(angle.sin() * Real::from(NORMAL_VECTOR_SCALE)),
+                i32::from(angle.cos() * Real::from(NORMAL_VECTOR_SCALE)),
+            )
+        };
+
+        Self { normal_vector }
+    }
+
+    /// Creates a new horizontal linear equation.
+    pub fn new_horizontal() -> Self {
+        Self {
+            normal_vector: Point::new(0, -NORMAL_VECTOR_SCALE),
+        }
+    }
+
+    /// Returns the distance between the line and a point.
+    ///
+    /// The scaling of the returned value depends on the length of the normal vector.
+    /// Positive values will be returned for points on the left side of the line and negative
+    /// values for points on the right.
+    pub fn distance(&self, point: Point) -> i32 {
+        point.dot_product(self.normal_vector)
+    }
+
+    /// Checks if a point is on the given side of the line.
+    ///
+    /// Always returns `true` if the point is on the line.
+    pub fn check_side(&self, point: Point, side: LineSide) -> bool {
+        let distance = self.distance(point);
+
+        match side {
+            LineSide::Right => distance <= 0,
+            LineSide::Left => distance >= 0,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/primitives/common/linear_equation.rs
+++ b/src/primitives/common/linear_equation.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 /// Scaling factor for unit length normal vectors.
-const NORMAL_VECTOR_SCALE: i32 = 1 << 10;
+pub const NORMAL_VECTOR_SCALE: i32 = 1 << 10;
 
 /// Linear equation.
 ///
@@ -35,35 +35,6 @@ impl LinearEquation {
         }
     }
 
-    /// Creates a new linear equation based on one point and one angle.
-    pub fn from_point_angle(point: Point, angle: Angle) -> Self {
-        // FIXME: angle.tan() for 180.0 degrees isn't exactly 0 which causes problems when drawing
-        //        a single quadrant. Is there a better solution to fix this?
-        let normal_vector = if angle == Angle::from_degrees(180.0) {
-            Point::new(0, NORMAL_VECTOR_SCALE)
-        } else {
-            -Point::new(
-                i32::from(angle.sin() * Real::from(NORMAL_VECTOR_SCALE)),
-                i32::from(angle.cos() * Real::from(NORMAL_VECTOR_SCALE)),
-            )
-        };
-
-        let origin_distance = point.dot_product(normal_vector);
-
-        LinearEquation {
-            normal_vector,
-            origin_distance,
-        }
-    }
-
-    /// Creates a horizontal line equation.
-    pub fn new_horizontal() -> Self {
-        LinearEquation {
-            normal_vector: Point::new(0, -NORMAL_VECTOR_SCALE),
-            origin_distance: 0,
-        }
-    }
-
     /// Returns the distance between the line and a point.
     ///
     /// The scaling of the returned value depends on the length of the normal vector.
@@ -86,15 +57,14 @@ impl LinearEquation {
     }
 }
 
-/// Linear equation though the origin.
-///
-/// TODO: docs
+/// Linear equation with zero distance to the origin.
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
 pub struct OriginLinearEquation {
     pub normal_vector: Point,
 }
 
 impl OriginLinearEquation {
+    /// Creates a new linear equation with the given angle.
     pub fn with_angle(angle: Angle) -> Self {
         // FIXME: angle.tan() for 180.0 degrees isn't exactly 0 which causes problems when drawing
         //        a single quadrant. Is there a better solution to fix this?
@@ -174,44 +144,32 @@ mod tests {
     }
 
     #[test]
-    fn from_point_angle() {
+    fn with_angle() {
         assert_eq!(
-            LinearEquation::from_point_angle(Point::zero(), 0.0.deg()),
-            LinearEquation {
+            OriginLinearEquation::with_angle(0.0.deg()),
+            OriginLinearEquation {
                 normal_vector: Point::new(0, -NORMAL_VECTOR_SCALE),
-                origin_distance: 0, // line goes through the origin
             }
         );
 
         assert_eq!(
-            LinearEquation::from_point_angle(Point::zero(), 90.0.deg()),
-            LinearEquation {
+            OriginLinearEquation::with_angle(90.0.deg()),
+            OriginLinearEquation {
                 normal_vector: Point::new(-NORMAL_VECTOR_SCALE, 0),
-                origin_distance: 0, // line goes through the origin
-            }
-        );
-
-        let point = Point::new(3, 4);
-        assert_eq!(
-            LinearEquation::from_point_angle(point, 180.0.deg()),
-            LinearEquation {
-                normal_vector: Point::new(0, NORMAL_VECTOR_SCALE),
-                // (0, 4) is the closest point to the origin that lies on the line
-                origin_distance: 4 * NORMAL_VECTOR_SCALE,
             }
         );
     }
 
     #[test]
     fn distance() {
-        let line = LinearEquation::from_point_angle(Point::zero(), 90.0.deg());
+        let line = OriginLinearEquation::with_angle(90.0.deg());
         assert_eq!(line.distance(Point::new(-1, 0)), NORMAL_VECTOR_SCALE);
         assert_eq!(line.distance(Point::new(1, 0)), -NORMAL_VECTOR_SCALE);
     }
 
     #[test]
     fn check_side_horizontal() {
-        let line = LinearEquation::from_point_angle(Point::zero(), 0.0.deg());
+        let line = OriginLinearEquation::with_angle(0.0.deg());
         assert!(line.check_side(Point::new(0, 0), LineSide::Left));
         assert!(line.check_side(Point::new(1, 0), LineSide::Right));
         assert!(!line.check_side(Point::new(-2, 1), LineSide::Left));
@@ -219,7 +177,7 @@ mod tests {
         assert!(line.check_side(Point::new(-4, -1), LineSide::Left));
         assert!(!line.check_side(Point::new(5, -1), LineSide::Right));
 
-        let line = LinearEquation::from_point_angle(Point::zero(), 180.0.deg());
+        let line = OriginLinearEquation::with_angle(180.0.deg());
         assert!(line.check_side(Point::new(0, 0), LineSide::Left));
         assert!(line.check_side(Point::new(1, 0), LineSide::Right));
         assert!(line.check_side(Point::new(-2, 1), LineSide::Left));
@@ -230,7 +188,7 @@ mod tests {
 
     #[test]
     fn check_side_vertical() {
-        let line = LinearEquation::from_point_angle(Point::zero(), 90.0.deg());
+        let line = OriginLinearEquation::with_angle(90.0.deg());
         assert!(line.check_side(Point::new(0, 0), LineSide::Left));
         assert!(line.check_side(Point::new(0, -1), LineSide::Right));
         assert!(line.check_side(Point::new(-1, 2), LineSide::Left));
@@ -238,7 +196,7 @@ mod tests {
         assert!(!line.check_side(Point::new(1, 4), LineSide::Left));
         assert!(line.check_side(Point::new(1, -5), LineSide::Right));
 
-        let line = LinearEquation::from_point_angle(Point::zero(), 270.0.deg());
+        let line = OriginLinearEquation::with_angle(270.0.deg());
         assert!(line.check_side(Point::new(0, 0), LineSide::Left));
         assert!(line.check_side(Point::new(0, 1), LineSide::Right));
         assert!(!line.check_side(Point::new(-1, -2), LineSide::Left));

--- a/src/primitives/common/mod.rs
+++ b/src/primitives/common/mod.rs
@@ -8,8 +8,8 @@ mod thick_segment_iter;
 
 pub use closed_thick_segment_iter::ClosedThickSegmentIter;
 pub use line_join::{JoinKind, LineJoin};
-pub use linear_equation::{LinearEquation, OriginLinearEquation};
-pub use plane_sector::{PlaneSector, PlaneSectorIterator};
+pub use linear_equation::{LinearEquation, OriginLinearEquation, NORMAL_VECTOR_SCALE};
+pub use plane_sector::PlaneSector;
 pub use scanline::Scanline;
 pub use thick_segment::ThickSegment;
 pub use thick_segment_iter::ThickSegmentIter;
@@ -59,4 +59,14 @@ impl LineSide {
             Self::Right => Self::Left,
         }
     }
+}
+
+/// Point type.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub enum PointType {
+    /// Represents part of the stroke.
+    Stroke,
+
+    /// Represents the interior of the shape.
+    Fill,
 }

--- a/src/primitives/common/mod.rs
+++ b/src/primitives/common/mod.rs
@@ -8,7 +8,7 @@ mod thick_segment_iter;
 
 pub use closed_thick_segment_iter::ClosedThickSegmentIter;
 pub use line_join::{JoinKind, LineJoin};
-pub use linear_equation::LinearEquation;
+pub use linear_equation::{LinearEquation, OriginLinearEquation};
 pub use plane_sector::{PlaneSector, PlaneSectorIterator};
 pub use scanline::Scanline;
 pub use thick_segment::ThickSegment;

--- a/src/primitives/line/mod.rs
+++ b/src/primitives/line/mod.rs
@@ -17,7 +17,6 @@ use crate::{
 };
 pub use points::Points;
 pub use styled::StyledPixels;
-pub(in crate::primitives) use thick_points::ThickPoints;
 
 /// Line primitive
 ///

--- a/src/primitives/sector/mod.rs
+++ b/src/primitives/sector/mod.rs
@@ -4,10 +4,8 @@ mod points;
 mod styled;
 
 use crate::{
-    geometry::{Angle, Dimensions, Point, Real, Size, Trigonometry},
-    primitives::{
-        common::PlaneSector, line::Line, Circle, ContainsPoint, OffsetOutline, Primitive, Rectangle,
-    },
+    geometry::{Angle, Dimensions, Point, Size},
+    primitives::{common::PlaneSector, Circle, ContainsPoint, OffsetOutline, Primitive, Rectangle},
     transform::Transform,
 };
 pub use points::Points;
@@ -132,24 +130,6 @@ impl Sector {
         let radius = self.diameter.saturating_sub(1);
 
         self.top_left * 2 + Size::new(radius, radius)
-    }
-
-    /// Return the end angle of the sector
-    fn angle_end(&self) -> Angle {
-        self.angle_start + self.angle_sweep
-    }
-
-    /// Return a `Line` between the sector center and a point on the circumference following a given angle
-    fn line_from_angle(&self, angle: Angle) -> Line {
-        let center = self.center();
-        let radius = Real::from(self.diameter.saturating_sub(1)) / 2.into();
-
-        let point = Point::new(
-            center.x + i32::from(angle.cos() * radius),
-            center.y - i32::from(angle.sin() * radius),
-        );
-
-        Line::new(center, point)
     }
 }
 

--- a/src/primitives/sector/styled.rs
+++ b/src/primitives/sector/styled.rs
@@ -229,7 +229,6 @@ mod tests {
     #[test]
     fn tiny_sector() {
         let mut display = MockDisplay::new();
-        display.set_allow_overdraw(true);
 
         Sector::new(Point::zero(), 9, 30.0.deg(), 120.0.deg())
             .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
@@ -287,7 +286,6 @@ mod tests {
             .build();
 
         let mut display = MockDisplay::new();
-        display.set_allow_out_of_bounds_drawing(true);
 
         Sector::with_center(Point::new(3, 10), diameter, 0.0.deg(), 90.0.deg())
             .into_styled(style)

--- a/src/primitives/sector/styled.rs
+++ b/src/primitives/sector/styled.rs
@@ -179,73 +179,63 @@ mod tests {
     };
 
     #[test]
-    fn stroke_width_doesnt_affect_fill() -> Result<(), core::convert::Infallible> {
+    fn stroke_width_doesnt_affect_fill() {
         let mut expected = MockDisplay::new();
         let mut style = PrimitiveStyle::with_fill(BinaryColor::On);
         Sector::new(Point::new(5, 5), 4, 30.0.deg(), 120.0.deg())
             .into_styled(style)
-            .draw(&mut expected)?;
+            .draw(&mut expected)
+            .unwrap();
 
         let mut with_stroke_width = MockDisplay::new();
         style.stroke_width = 1;
         Sector::new(Point::new(5, 5), 4, 30.0.deg(), 120.0.deg())
             .into_styled(style)
-            .draw(&mut with_stroke_width)?;
+            .draw(&mut with_stroke_width)
+            .unwrap();
 
-        assert_eq!(expected, with_stroke_width);
-
-        Ok(())
+        with_stroke_width.assert_eq(&expected);
     }
 
     // Check the rendering of a simple sector
     #[test]
-    fn tiny_sector() -> Result<(), core::convert::Infallible> {
+    fn tiny_sector() {
         let mut display = MockDisplay::new();
         display.set_allow_overdraw(true);
 
         Sector::new(Point::zero(), 9, 30.0.deg(), 120.0.deg())
             .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
-            .draw(&mut display)?;
+            .draw(&mut display)
+            .unwrap();
 
-        #[rustfmt::skip]
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
-                "  #####  ",
-                " ##   ## ",
-                " #     # ",
-                "  ## ##  ",
-                "    #    ",
-            ])
-        );
-
-        Ok(())
+        display.assert_pattern(&[
+            "  #####  ", //
+            " ##   ## ", //
+            " #     # ", //
+            "  ## ##  ", //
+            "    #    ", //
+        ]);
     }
 
     // Check the rendering of a filled sector with negative sweep
     #[test]
-    fn tiny_sector_filled() -> Result<(), core::convert::Infallible> {
+    fn tiny_sector_filled() {
         let mut display = MockDisplay::new();
 
         Sector::new(Point::zero(), 7, -30.0.deg(), -300.0.deg())
             .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
-            .draw(&mut display)?;
+            .draw(&mut display)
+            .unwrap();
 
-        #[rustfmt::skip]
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
-                "  ###  ",
-                " ##### ",
-                "#####  ",
-                "####   ",
-                "#####  ",
-                " ##### ",
-                "  ###  ",
-            ])
-        );
-
-        Ok(())
+        display.assert_pattern(&[
+            "  ###  ", //
+            " ##### ", //
+            "#####  ", //
+            "####   ", //
+            "#####  ", //
+            " ##### ", //
+            "  ###  ", //
+        ]);
     }
 
     #[test]
@@ -293,8 +283,8 @@ mod tests {
             .draw(&mut display_outside)
             .unwrap();
 
-        assert_eq!(display_center, display_inside);
-        assert_eq!(display_center, display_outside);
+        display_inside.assert_eq(&display_center);
+        display_outside.assert_eq(&display_center);
     }
 
     #[test]
@@ -331,7 +321,6 @@ mod tests {
 
     /// The radial lines should be connected using a line join.
     #[test]
-    #[ignore]
     fn issue_484_line_join_90_deg() {
         let mut display = MockDisplay::<Rgb888>::new();
         // TODO: sectors shouldn't overdraw
@@ -367,7 +356,6 @@ mod tests {
     /// The stroke for the radial lines shouldn't overlap the outer edge of the stroke on the
     /// circular part of the sector.
     #[test]
-    #[ignore]
     fn issue_484_stroke_should_not_overlap_outer_edge() {
         let mut display = MockDisplay::<Rgb888>::new();
         // TODO: sectors shouldn't overdraw
@@ -416,7 +404,6 @@ mod tests {
 
     /// Both radial lines should be perfectly aligned for 180° sweep angle.
     #[test]
-    #[ignore]
     fn issue_484_stroke_center_semicircle() {
         let mut display = MockDisplay::new();
         // TODO: sectors shouldn't overdraw
@@ -449,7 +436,6 @@ mod tests {
 
     /// Both radial lines should be perfectly aligned for 180° sweep angle.
     #[test]
-    #[ignore]
     fn issue_484_stroke_center_semicircle_vertical() {
         let mut display = MockDisplay::new();
         // TODO: sectors shouldn't overdraw
@@ -490,7 +476,6 @@ mod tests {
 
     /// The fill shouldn't overlap the stroke and there should be no gaps between stroke and fill.
     #[test]
-    #[ignore]
     fn issue_484_gaps_and_overlap() {
         let mut display = MockDisplay::new();
         // TODO: sectors shouldn't overdraw
@@ -514,7 +499,6 @@ mod tests {
 
     /// No radial lines should be drawn if the sweep angle is 360°.
     #[test]
-    #[ignore]
     fn issue_484_no_radial_lines_for_360_degree_sweep_angle() {
         let style = PrimitiveStyleBuilder::new()
             .fill_color(Rgb888::GREEN)
@@ -541,7 +525,6 @@ mod tests {
 
     /// No radial lines should be drawn for sweep angles larger than 360°.
     #[test]
-    #[ignore]
     fn issue_484_no_radial_lines_for_sweep_angles_larger_than_360_degree() {
         let style = PrimitiveStyleBuilder::new()
             .fill_color(Rgb888::GREEN)

--- a/src/primitives/sector/styled.rs
+++ b/src/primitives/sector/styled.rs
@@ -1,23 +1,18 @@
 use crate::{
     draw_target::DrawTarget,
     drawable::{Drawable, Pixel},
-    geometry::{Dimensions, Size},
+    geometry::angle_consts::ANGLE_90DEG,
+    geometry::{Angle, Dimensions, Size},
     iterator::IntoPixels,
     pixelcolor::PixelColor,
     primitives::{
-        circle::DistanceIterator, common::PlaneSectorIterator, line::ThickPoints, OffsetOutline,
-        Rectangle, Sector, Styled,
+        circle::DistanceIterator,
+        common::{OriginLinearEquation, PlaneSector, PointType, NORMAL_VECTOR_SCALE},
+        OffsetOutline, Rectangle, Sector, Styled,
     },
     style::{PrimitiveStyle, StyledPrimitiveAreas},
     SaturatingCast,
 };
-
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-enum IterState {
-    Arc,
-    Lines,
-    Done,
-}
 
 /// Pixel iterator for each pixel in the sector border
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
@@ -25,18 +20,21 @@ pub struct StyledPixels<C>
 where
     C: PixelColor,
 {
-    iter: DistanceIterator<PlaneSectorIterator>,
+    iter: DistanceIterator,
+
+    plane_sector: PlaneSector,
 
     outer_threshold: u32,
-    outer_color: Option<C>,
-
     inner_threshold: u32,
+
+    stroke_threshold_inside: i32,
+    stroke_threshold_outside: i32,
+
+    bevel: Option<OriginLinearEquation>,
+    bevel_threshold: i32,
+
+    outer_color: Option<C>,
     inner_color: Option<C>,
-
-    line_a_iter: ThickPoints,
-    line_b_iter: ThickPoints,
-
-    state: IterState,
 }
 
 impl<C> StyledPixels<C>
@@ -44,37 +42,63 @@ where
     C: PixelColor,
 {
     fn new(styled: &Styled<Sector, PrimitiveStyle<C>>) -> Self {
+        let Styled { primitive, style } = styled;
+
         let stroke_area = styled.stroke_area();
         let fill_area = styled.fill_area();
 
-        let line_a = stroke_area.line_from_angle(styled.primitive.angle_start);
-        let line_b = stroke_area.line_from_angle(styled.primitive.angle_end());
-
-        let line_a_iter = ThickPoints::new(&line_a, styled.style.stroke_width.saturating_cast());
-        let line_b_iter = ThickPoints::new(&line_b, styled.style.stroke_width.saturating_cast());
-
-        let points = if !styled.style.is_transparent() {
-            PlaneSectorIterator::new(
-                &stroke_area,
-                stroke_area.center_2x(),
-                stroke_area.angle_start,
-                stroke_area.angle_sweep,
-            )
-        } else {
-            PlaneSectorIterator::empty()
-        };
-
         let stroke_area_circle = stroke_area.to_circle();
 
+        let iter = if !style.is_transparent() {
+            stroke_area_circle.distances()
+        } else {
+            DistanceIterator::empty()
+        };
+
+        let outer_threshold = stroke_area_circle.threshold();
+        let inner_threshold = fill_area.to_circle().threshold();
+
+        let plane_sector = PlaneSector::new(
+            stroke_area.center_2x(),
+            stroke_area.angle_start,
+            stroke_area.angle_sweep,
+        );
+
+        let stroke_threshold_inside =
+            style.inside_stroke_width().saturating_cast() * NORMAL_VECTOR_SCALE * 2
+                - NORMAL_VECTOR_SCALE;
+        let stroke_threshold_outside =
+            style.outside_stroke_width().saturating_cast() * NORMAL_VECTOR_SCALE * 2
+                + NORMAL_VECTOR_SCALE;
+
+        // TODO: Polylines and sectors should use the same miter limit.
+        let (bevel, bevel_threshold) = if primitive.angle_sweep.abs() < Angle::from_degrees(55.0) {
+            let half_sweep = Angle::from_radians(primitive.angle_sweep.to_radians() / 2.0);
+
+            let threshold =
+                style.outside_stroke_width().saturating_cast() * NORMAL_VECTOR_SCALE * 4;
+
+            (
+                Some(OriginLinearEquation::with_angle(
+                    primitive.angle_start + half_sweep + ANGLE_90DEG,
+                )),
+                threshold,
+            )
+        } else {
+            (None, 0)
+        };
+
         Self {
-            iter: stroke_area_circle.distances(points),
-            outer_threshold: stroke_area_circle.threshold(),
+            iter,
+            plane_sector,
+            outer_threshold,
+            inner_threshold,
+            stroke_threshold_inside,
+            stroke_threshold_outside,
+            bevel,
+            bevel_threshold,
             outer_color: styled.style.stroke_color,
-            inner_threshold: fill_area.to_circle().threshold(),
             inner_color: styled.style.fill_color,
-            line_a_iter,
-            line_b_iter,
-            state: IterState::Arc,
         }
     }
 }
@@ -86,38 +110,42 @@ where
     type Item = Pixel<C>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            match self.state {
-                IterState::Arc => {
-                    if let Some((point, distance)) = self.iter.next() {
-                        let color = if distance < self.inner_threshold {
-                            self.inner_color
-                        } else if distance < self.outer_threshold {
-                            self.outer_color
-                        } else {
-                            None
-                        };
+        let outer_threshold = self.outer_threshold;
 
-                        if let Some(color) = color {
-                            return Some(Pixel(point, color));
+        loop {
+            let (point, distance) = self
+                .iter
+                .find(|(_, distance)| *distance < outer_threshold)?;
+
+            // TODO: only scale point once
+            let point_2x = point * 2 - self.plane_sector.origin;
+
+            let color = match self.plane_sector.point_type(
+                point,
+                self.stroke_threshold_inside,
+                self.stroke_threshold_outside,
+            ) {
+                Some(PointType::Stroke) => {
+                    if let Some(bevel) = &self.bevel {
+                        if bevel.distance(point_2x) >= self.bevel_threshold {
+                            continue;
                         }
+                    }
+
+                    self.outer_color
+                }
+                Some(PointType::Fill) => {
+                    if distance < self.inner_threshold {
+                        self.inner_color
                     } else {
-                        self.state = IterState::Lines;
+                        self.outer_color
                     }
                 }
-                IterState::Lines => {
-                    if let Some(color) = self.outer_color {
-                        if let Some(point) =
-                            self.line_a_iter.next().or_else(|| self.line_b_iter.next())
-                        {
-                            break Some(Pixel(point, color));
-                        }
-                    }
-                    self.state = IterState::Done;
-                }
-                IterState::Done => {
-                    break None;
-                }
+                None => continue,
+            };
+
+            if let Some(color) = color {
+                return Some(Pixel(point, color));
             }
         }
     }
@@ -211,7 +239,7 @@ mod tests {
         display.assert_pattern(&[
             "  #####  ", //
             " ##   ## ", //
-            " #     # ", //
+            "##     ##", //
             "  ## ##  ", //
             "    #    ", //
         ]);
@@ -230,9 +258,9 @@ mod tests {
         display.assert_pattern(&[
             "  ###  ", //
             " ##### ", //
+            "###### ", //
             "#####  ", //
-            "####   ", //
-            "#####  ", //
+            "###### ", //
             " ##### ", //
             "  ###  ", //
         ]);
@@ -247,44 +275,93 @@ mod tests {
         assert!(sector.into_pixels().count() > 0);
     }
 
-    #[test]
-    fn stroke_alignment() {
-        const CENTER: Point = Point::new(15, 15);
-        const SIZE: u32 = 10;
+    fn test_stroke_alignment(
+        stroke_alignment: StrokeAlignment,
+        diameter: u32,
+        expected_pattern: &[&str],
+    ) {
+        let style = PrimitiveStyleBuilder::new()
+            .stroke_color(BinaryColor::On)
+            .stroke_width(3)
+            .stroke_alignment(stroke_alignment)
+            .build();
 
-        let style = PrimitiveStyle::with_stroke(BinaryColor::On, 3);
+        let mut display = MockDisplay::new();
+        display.set_allow_out_of_bounds_drawing(true);
 
-        let mut display_center = MockDisplay::new();
-        display_center.set_allow_overdraw(true);
-        Sector::with_center(CENTER, SIZE, 0.0.deg(), 90.0.deg())
+        Sector::with_center(Point::new(3, 10), diameter, 0.0.deg(), 90.0.deg())
             .into_styled(style)
-            .draw(&mut display_center)
+            .draw(&mut display)
             .unwrap();
 
-        let mut display_inside = MockDisplay::new();
-        display_inside.set_allow_overdraw(true);
-        Sector::with_center(CENTER, SIZE + 2, 0.0.deg(), 90.0.deg())
-            .into_styled(
-                PrimitiveStyleBuilder::from(&style)
-                    .stroke_alignment(StrokeAlignment::Inside)
-                    .build(),
-            )
-            .draw(&mut display_inside)
-            .unwrap();
+        display.assert_pattern(expected_pattern);
+    }
 
-        let mut display_outside = MockDisplay::new();
-        display_outside.set_allow_overdraw(true);
-        Sector::with_center(CENTER, SIZE - 4, 0.0.deg(), 90.0.deg())
-            .into_styled(
-                PrimitiveStyleBuilder::from(&style)
-                    .stroke_alignment(StrokeAlignment::Outside)
-                    .build(),
-            )
-            .draw(&mut display_outside)
-            .unwrap();
+    #[test]
+    fn stroke_alignment_inside() {
+        test_stroke_alignment(
+            StrokeAlignment::Inside,
+            19 + 2,
+            &[
+                "   ####       ",
+                "   ######     ",
+                "   #######    ",
+                "   ########   ",
+                "   ###  ####  ",
+                "   ###   #### ",
+                "   ###    ### ",
+                "   ###    ####",
+                "   ###########",
+                "   ###########",
+                "   ###########",
+            ],
+        );
+    }
 
-        display_inside.assert_eq(&display_center);
-        display_outside.assert_eq(&display_center);
+    #[test]
+    fn stroke_alignment_center() {
+        test_stroke_alignment(
+            StrokeAlignment::Center,
+            19,
+            &[
+                "  #####       ",
+                "  #######     ",
+                "  ########    ",
+                "  ### #####   ",
+                "  ###   ####  ",
+                "  ###    #### ",
+                "  ###     ### ",
+                "  ###     ####",
+                "  ###      ###",
+                "  ############",
+                "  ############",
+                "  ############",
+            ],
+        );
+    }
+
+    #[test]
+    fn stroke_alignment_outside() {
+        test_stroke_alignment(
+            StrokeAlignment::Outside,
+            19 - 4,
+            &[
+                "#######       ",
+                "#########     ",
+                "##########    ",
+                "###   #####   ",
+                "###     ####  ",
+                "###      #### ",
+                "###       ### ",
+                "###       ####",
+                "###        ###",
+                "###        ###",
+                "###        ###",
+                "##############",
+                "##############",
+                "##############",
+            ],
+        );
     }
 
     #[test]
@@ -323,8 +400,6 @@ mod tests {
     #[test]
     fn issue_484_line_join_90_deg() {
         let mut display = MockDisplay::<Rgb888>::new();
-        // TODO: sectors shouldn't overdraw
-        display.set_allow_overdraw(true);
 
         Sector::new(Point::new(-6, 1), 15, 0.0.deg(), 90.0.deg())
             .into_styled(
@@ -351,15 +426,61 @@ mod tests {
         ]);
     }
 
-    // TODO: add tests for other angles with mitre and bevel joins
+    /// The radial lines should be connected using a line join.
+    #[test]
+    fn issue_484_line_join_20_deg() {
+        let mut display = MockDisplay::<Rgb888>::new();
+
+        Sector::new(Point::new(-4, -3), 15, 0.0.deg(), 20.0.deg())
+            .into_styled(
+                PrimitiveStyleBuilder::new()
+                    .stroke_color(Rgb888::RED)
+                    .stroke_width(3)
+                    .fill_color(Rgb888::GREEN)
+                    .build(),
+            )
+            .draw(&mut display)
+            .unwrap();
+
+        display.assert_pattern(&[
+            "          R ",
+            "       RRRR ",
+            "     RRRRRRR",
+            "  RRRRRRRRRR",
+            " RRRRRRRRRRR",
+            "  RRRRRRRRRR",
+        ]);
+    }
+
+    /// The radial lines should be connected using a line join.
+    // TODO: This test currently fails because a miter join is drawn instead of a bevel join
+    #[test]
+    #[ignore]
+    fn issue_484_line_join_340_deg() {
+        let mut display = MockDisplay::<Rgb888>::new();
+
+        Sector::new(Point::new_equal(2), 15, 0.0.deg(), 340.0.deg())
+            .into_styled(
+                PrimitiveStyleBuilder::new()
+                    .stroke_color(Rgb888::RED)
+                    .stroke_width(3)
+                    .fill_color(Rgb888::GREEN)
+                    .build(),
+            )
+            .draw(&mut display)
+            .unwrap();
+
+        display.assert_pattern(&[
+            // TODO: update pattern
+        ]);
+    }
 
     /// The stroke for the radial lines shouldn't overlap the outer edge of the stroke on the
     /// circular part of the sector.
     #[test]
+    #[ignore]
     fn issue_484_stroke_should_not_overlap_outer_edge() {
         let mut display = MockDisplay::<Rgb888>::new();
-        // TODO: sectors shouldn't overdraw
-        display.set_allow_overdraw(true);
 
         Sector::with_center(Point::new(10, 15), 11, 0.0.deg(), 90.0.deg())
             .into_styled(
@@ -406,8 +527,6 @@ mod tests {
     #[test]
     fn issue_484_stroke_center_semicircle() {
         let mut display = MockDisplay::new();
-        // TODO: sectors shouldn't overdraw
-        display.set_allow_overdraw(true);
 
         Sector::new(Point::new_equal(1), 15, 0.0.deg(), 180.0.deg())
             .into_styled(
@@ -429,6 +548,7 @@ mod tests {
             " ..###########.. ",
             " ..###########.. ",
             "..#############..",
+            "..#############..",
             ".................",
             ".................",
         ]);
@@ -438,8 +558,6 @@ mod tests {
     #[test]
     fn issue_484_stroke_center_semicircle_vertical() {
         let mut display = MockDisplay::new();
-        // TODO: sectors shouldn't overdraw
-        display.set_allow_overdraw(true);
 
         Sector::new(Point::new_equal(1), 15, 90.0.deg(), 180.0.deg())
             .into_styled(
@@ -454,23 +572,23 @@ mod tests {
             .unwrap();
 
         display.assert_pattern(&[
-            "      ...",
-            "    .....",
-            "  ....#..",
-            "  ..###..",
-            " ..####..",
-            " ..####..",
-            "..#####..",
-            "..#####..",
-            "..#####..",
-            "..#####..",
-            "..#####..",
-            " ..####..",
-            " ..####..",
-            "  ..###..",
-            "  ....#..",
-            "    .....",
-            "      ...",
+            "      ....",
+            "    ......",
+            "  ....##..",
+            "  ..####..",
+            " ..#####..",
+            " ..#####..",
+            "..######..",
+            "..######..",
+            "..######..",
+            "..######..",
+            "..######..",
+            " ..#####..",
+            " ..#####..",
+            "  ..####..",
+            "  ....##..",
+            "    ......",
+            "      ....",
         ]);
     }
 
@@ -478,8 +596,6 @@ mod tests {
     #[test]
     fn issue_484_gaps_and_overlap() {
         let mut display = MockDisplay::new();
-        // TODO: sectors shouldn't overdraw
-        display.set_allow_overdraw(true);
 
         Sector::with_center(Point::new(2, 20), 40, -14.0.deg(), 90.0.deg())
             .into_styled(
@@ -493,7 +609,33 @@ mod tests {
             .unwrap();
 
         display.assert_pattern(&[
-            // TODO: Update expected pattern
+            "       R                ",
+            "      RRRRR             ",
+            "      RRRRRRR           ",
+            "      RRGGRRRRR         ",
+            "      RRGGGGRRRR        ",
+            "     RRGGGGGGGRRR       ",
+            "     RRGGGGGGGGRRR      ",
+            "     RRGGGGGGGGGRRR     ",
+            "     RRGGGGGGGGGGRRR    ",
+            "    RRGGGGGGGGGGGGRRR   ",
+            "    RRGGGGGGGGGGGGGRR   ",
+            "    RRGGGGGGGGGGGGGRRR  ",
+            "    RRGGGGGGGGGGGGGGRR  ",
+            "   RRGGGGGGGGGGGGGGGRRR ",
+            "   RRGGGGGGGGGGGGGGGGRR ",
+            "   RRGGGGGGGGGGGGGGGGRR ",
+            "   RRGGGGGGGGGGGGGGGGRRR",
+            "  RRGGGGGGGGGGGGGGGGGGRR",
+            "  RRGGGGGGGGGGGGGGGGGGRR",
+            "  RRGGGGGGGGGGGGGGGGGGRR",
+            "  RRGGGGGGGGGGGGGGGGGGRR",
+            " RRRRRRGGGGGGGGGGGGGGGRR",
+            "   RRRRRRRRGGGGGGGGGGGRR",
+            "       RRRRRRRRGGGGGGGRR",
+            "           RRRRRRRRGGGRR",
+            "               RRRRRRRRR",
+            "                   RRRR ",
         ]);
     }
 
@@ -512,8 +654,6 @@ mod tests {
         circle.into_styled(style).draw(&mut expected).unwrap();
 
         let mut display = MockDisplay::new();
-        // TODO: sectors shouldn't overdraw
-        display.set_allow_overdraw(true);
 
         Sector::new(Point::new_equal(1), 11, 0.0.deg(), 360.0.deg())
             .into_styled(style)
@@ -538,8 +678,6 @@ mod tests {
         circle.into_styled(style).draw(&mut expected).unwrap();
 
         let mut display = MockDisplay::new();
-        // TODO: sectors shouldn't overdraw
-        display.set_allow_overdraw(true);
 
         Sector::from_circle(circle, 90.0.deg(), -472.0.deg())
             .into_styled(style)

--- a/src/primitives/triangle/scanline_intersections.rs
+++ b/src/primitives/triangle/scanline_intersections.rs
@@ -3,21 +3,10 @@
 use crate::{
     geometry::Point,
     primitives::{
-        common::ThickSegment,
-        common::{LineJoin, Scanline, StrokeOffset},
+        common::{LineJoin, PointType, Scanline, StrokeOffset, ThickSegment},
         Triangle,
     },
 };
-
-/// Type of scanline.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub enum PointType {
-    /// Represents part of the stroke.
-    Stroke,
-
-    /// Represents the interior of the shape.
-    Fill,
-}
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 struct LineConfig {

--- a/src/primitives/triangle/scanline_iterator.rs
+++ b/src/primitives/triangle/scanline_iterator.rs
@@ -1,8 +1,8 @@
 //! Scanline iterator.
 
 use crate::primitives::{
-    common::{Scanline, StrokeOffset},
-    triangle::scanline_intersections::{PointType, ScanlineIntersections},
+    common::{PointType, Scanline, StrokeOffset},
+    triangle::scanline_intersections::ScanlineIntersections,
     Rectangle, Triangle,
 };
 use core::ops::Range;

--- a/src/primitives/triangle/styled.rs
+++ b/src/primitives/triangle/styled.rs
@@ -5,10 +5,8 @@ use crate::{
     iterator::IntoPixels,
     pixelcolor::PixelColor,
     primitives::{
-        common::{ClosedThickSegmentIter, Scanline, StrokeOffset},
-        triangle::{
-            scanline_intersections::PointType, scanline_iterator::ScanlineIterator, Triangle,
-        },
+        common::{ClosedThickSegmentIter, PointType, Scanline, StrokeOffset},
+        triangle::{scanline_iterator::ScanlineIterator, Triangle},
         Rectangle,
     },
     style::{PrimitiveStyle, StrokeAlignment, Styled},


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR fixes most of the issues in #484. Instead of using the existing thick line drawing code the sectors are entirely drawn by using linear equations.

Some notes:
* The drawing performance for 1px stroke sectors is slower, but faster for larger stroke widths.
* There is no more overdraw or gaps between fill and stroke.
  This would have been hard to achieve if the lines were drawn using the thick line drawing code.
* Miter and bevel line joins are drawn (with some limitations).

Problems that need to be fixed in later PRs:
* Line joins for sweep angles close to 360° are always drawn as a miter, but should be beveled.
* In `issue_484_stroke_should_not_overlap_outer_edge` both sides of the radial line stoke are clipped to the circle.
  The left side of the vertical line and the bottom side of the horizontal line should be rectangular. This will also make the bounding box calculation harder, because these corners can be outside the circle bounding box for some angles.
* The behavior of line joins in `Sector` and `Polyline` should be equal. The miter limit is probably different and sectors use this method of switching between miter and bevel: http://tavmjong.free.fr/SVG/MITER_LIMIT/index.html.
