### PR TITLE
Fix internal bevel joins for sectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 ### Fixed
 
-- [#507](https://github.com/embedded-graphics/embedded-graphics/pull/507) Fixed drawing of the line join between the sector radial lines for sweep angles close to 360°.
+- [#507](https://github.com/embedded-graphics/embedded-graphics/pull/507) Fixed drawing of the join between the radial lines for sectors with a sweep angle close to 360°.
 
 ## [0.7.0-alpha.2] - 2020-11-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- [#507](https://github.com/embedded-graphics/embedded-graphics/pull/507) Fixed drawing of the line join between the sector radial lines for sweep angles close to 360°.
+
 ## [0.7.0-alpha.2] - 2020-11-29
 
 ### Added

--- a/src/primitives/common/linear_equation.rs
+++ b/src/primitives/common/linear_equation.rs
@@ -24,6 +24,14 @@ pub struct LinearEquation {
 }
 
 impl LinearEquation {
+    /// Creates a new linear equation with the given angle and distance to the origin.
+    pub fn with_angle_and_distance(angle: Angle, origin_distance: i32) -> Self {
+        Self {
+            normal_vector: OriginLinearEquation::with_angle(angle).normal_vector,
+            origin_distance,
+        }
+    }
+
     /// Creates a new linear equation from a line.
     pub fn from_line(line: &Line) -> Self {
         let normal_vector = line.delta().rotate_90();


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR fixes the drawing of beveled line joins for sectors with a sweep angle close to 360°.
