### PR TITLE
Text alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 ### Added
 
 - [#508](https://github.com/embedded-graphics/embedded-graphics/pull/508) Added `MockDisplay::assert_eq_with_message` and `MockDisplay::assert_pattern_with_message`.
+- [#XXX](https://github.com/embedded-graphics/embedded-graphics/pull/XXX) Added `vertical_alignment` and `horizontal_alignment` to `MonoTextStyle`.
+- [#XXX](https://github.com/embedded-graphics/embedded-graphics/pull/XXX) Added `From` impl to convert an existing `MonoTextStyle` into a `MonoTextStyleBuilder`.
 
 ### Removed
 
 - **(breaking)** [#508](https://github.com/embedded-graphics/embedded-graphics/pull/508) `MockDisplay` no longer implements `PartialEq`, use `MockDisplay::assert_eq` instead.
 - **(breaking)** [#509](https://github.com/embedded-graphics/embedded-graphics/pull/509) Styled text can no longer be converted into a pixel iterator, because `IntoPixels` is no longer implemented for `Styled<Text<'_>, S>`.
+- **(breaking)** [#XXX](https://github.com/embedded-graphics/embedded-graphics/pull/XXX) `MonoTextStyleBuilder::new` no longer takes a font as an argument, use `MonoTextStyleBuilder::new().font(SomeFont)` instead.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,14 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 ### Added
 
 - [#508](https://github.com/embedded-graphics/embedded-graphics/pull/508) Added `MockDisplay::assert_eq_with_message` and `MockDisplay::assert_pattern_with_message`.
-- [#XXX](https://github.com/embedded-graphics/embedded-graphics/pull/XXX) Added `vertical_alignment` and `horizontal_alignment` to `MonoTextStyle`.
-- [#XXX](https://github.com/embedded-graphics/embedded-graphics/pull/XXX) Added `From` impl to convert an existing `MonoTextStyle` into a `MonoTextStyleBuilder`.
+- [#510](https://github.com/embedded-graphics/embedded-graphics/pull/510) Added `vertical_alignment` and `horizontal_alignment` to `MonoTextStyle`.
+- [#510](https://github.com/embedded-graphics/embedded-graphics/pull/510) Added `From` impl to convert an existing `MonoTextStyle` into a `MonoTextStyleBuilder`.
 
 ### Removed
 
 - **(breaking)** [#508](https://github.com/embedded-graphics/embedded-graphics/pull/508) `MockDisplay` no longer implements `PartialEq`, use `MockDisplay::assert_eq` instead.
 - **(breaking)** [#509](https://github.com/embedded-graphics/embedded-graphics/pull/509) Styled text can no longer be converted into a pixel iterator, because `IntoPixels` is no longer implemented for `Styled<Text<'_>, S>`.
-- **(breaking)** [#XXX](https://github.com/embedded-graphics/embedded-graphics/pull/XXX) `MonoTextStyleBuilder::new` no longer takes a font as an argument, use `MonoTextStyleBuilder::new().font(SomeFont)` instead.
+- **(breaking)** [#510](https://github.com/embedded-graphics/embedded-graphics/pull/510) `MonoTextStyleBuilder::new` no longer takes a font as an argument, use `MonoTextStyleBuilder::new().font(SomeFont)` instead.
 
 ### Fixed
 

--- a/MIGRATING-0.6-0.7.md
+++ b/MIGRATING-0.6-0.7.md
@@ -97,6 +97,16 @@ The `DrawTargetExt` trait is introduced to allow a translated, cropped or clippe
 
 Please search for `DrawTargetExt` on <https://docs.rs/embedded-graphics> for usage examples.
 
+### Text rendering
+
+TODO: Improve this section before release.
+
+- `TextStyle` -> `MonoTextStyle`
+- Added support for external renderers
+- `MonoTextStyleBuilder::new(Font)` -> `MonoTextStyle::new().font(Font)`
+- Added horizontal and vertical alignment to `MonoTextStyle`
+- New default vertical alignment is baseline
+
 ## For display driver authors
 
 Driver authors should use `DrawTarget` exported by the [`embedded-graphics-core`](https://crates.io/crates/embedded-graphics-core) crate to integrate with embedded-graphics.

--- a/benches/fonts.rs
+++ b/benches/fonts.rs
@@ -18,7 +18,8 @@ fn font_6x8(c: &mut Criterion) {
     let mut group = c.benchmark_group("font 6x8");
 
     let style = MonoTextStyle::new(Font6x8, Gray8::WHITE);
-    let style_with_bg = MonoTextStyleBuilder::new(Font6x8)
+    let style_with_bg = MonoTextStyleBuilder::new()
+        .font(Font6x8)
         .text_color(Gray8::WHITE)
         .background_color(Gray8::BLACK)
         .build();
@@ -58,7 +59,8 @@ fn font_12x16(c: &mut Criterion) {
     let mut group = c.benchmark_group("font 12x16");
 
     let style = MonoTextStyle::new(Font12x16, Gray8::WHITE);
-    let style_with_bg = MonoTextStyleBuilder::new(Font12x16)
+    let style_with_bg = MonoTextStyleBuilder::new()
+        .font(Font12x16)
         .text_color(Gray8::WHITE)
         .background_color(Gray8::BLACK)
         .build();

--- a/core/src/draw_target/mod.rs
+++ b/core/src/draw_target/mod.rs
@@ -556,13 +556,13 @@ pub trait DrawTargetExt: DrawTarget + Sized {
     ///
     /// // Only the first 4 characters will be drawn, because the others are outside
     /// // the clipping area
-    /// Text::new("Clipped", Point::new(0, 15))
+    /// Text::new("Clipped", Point::new(0, 13))
     ///     .into_styled(MonoTextStyle::new(Font12x16, BinaryColor::On))
     ///     .draw(&mut clipped_display)?;
     /// #
     /// # let mut expected = MockDisplay::new();
     /// #
-    /// # Text::new("Clip", Point::new(0, 15))
+    /// # Text::new("Clip", Point::new(0, 13))
     /// #     .into_styled(MonoTextStyle::new(Font12x16, BinaryColor::On))
     /// #     .draw(&mut expected)?;
     /// #

--- a/core/src/draw_target/mod.rs
+++ b/core/src/draw_target/mod.rs
@@ -455,16 +455,16 @@ pub trait DrawTargetExt: DrawTarget + Sized {
     /// };
     ///
     /// let mut display = MockDisplay::new();
-    /// let mut translated_display = display.translated(Point::new(10, 5));
+    /// let mut translated_display = display.translated(Point::new(5, 10));
     ///
-    /// // Draws text at position (10, 5) in the display coordinate system
+    /// // Draws text at position (5, 10) in the display coordinate system
     /// Text::new("Text", Point::zero())
     ///     .into_styled(MonoTextStyle::new(Font6x8, BinaryColor::On))
     ///     .draw(&mut translated_display)?;
     /// #
     /// # let mut expected = MockDisplay::new();
     /// #
-    /// # Text::new("Text", Point::new(10, 5))
+    /// # Text::new("Text", Point::new(5, 10))
     /// #     .into_styled(MonoTextStyle::new(Font6x8, BinaryColor::On))
     /// #     .draw(&mut expected)?;
     /// #
@@ -556,13 +556,13 @@ pub trait DrawTargetExt: DrawTarget + Sized {
     ///
     /// // Only the first 4 characters will be drawn, because the others are outside
     /// // the clipping area
-    /// Text::new("Clipped", Point::zero())
+    /// Text::new("Clipped", Point::new(0, 15))
     ///     .into_styled(MonoTextStyle::new(Font12x16, BinaryColor::On))
     ///     .draw(&mut clipped_display)?;
     /// #
     /// # let mut expected = MockDisplay::new();
     /// #
-    /// # Text::new("Clip", Point::zero())
+    /// # Text::new("Clip", Point::new(0, 15))
     /// #     .into_styled(MonoTextStyle::new(Font12x16, BinaryColor::On))
     /// #     .draw(&mut expected)?;
     /// #

--- a/core/src/drawable.rs
+++ b/core/src/drawable.rs
@@ -38,7 +38,7 @@ use crate::{draw_target::DrawTarget, geometry::Point, pixelcolor::PixelColor};
 ///             .into_styled(PrimitiveStyle::with_fill(self.bg_color))
 ///             .draw(display)?;
 ///
-///         Text::new(self.text, Point::new(6, 6))
+///         Text::new(self.text, Point::new(6, 13))
 ///             .into_styled(MonoTextStyle::new(Font6x8, self.fg_color))
 ///             .draw(display)
 ///     }

--- a/src/fonts/font12x16.rs
+++ b/src/fonts/font12x16.rs
@@ -16,6 +16,7 @@ impl MonoFont for Font12x16 {
     const FONT_IMAGE_WIDTH: u32 = 480;
 
     const CHARACTER_SIZE: Size = Size::new(12, 16);
+    const BASELINE: Option<i32> = Some(13);
 
     fn char_offset(c: char) -> u32 {
         let fallback = '?' as u32 - ' ' as u32;
@@ -36,7 +37,7 @@ impl MonoFont for Font12x16 {
 mod tests {
     use super::*;
     use crate::{
-        fonts::{tests::assert_text_from_pattern, MonoFont, Text},
+        fonts::{tests::*, MonoFont, Text},
         geometry::{Dimensions, Point, Size},
         pixelcolor::BinaryColor,
         style::MonoTextStyle,
@@ -186,5 +187,10 @@ mod tests {
 
         assert_text_from_pattern("\x7F\u{A0}", Font12x16, two_question_marks);
         assert_text_from_pattern("Ā💣", Font12x16, two_question_marks);
+    }
+
+    #[test]
+    fn baseline() {
+        test_baseline(Font12x16);
     }
 }

--- a/src/fonts/font24x32.rs
+++ b/src/fonts/font24x32.rs
@@ -21,6 +21,7 @@ impl MonoFont for Font24x32 {
     const FONT_IMAGE_WIDTH: u32 = 960;
 
     const CHARACTER_SIZE: Size = Size::new(24, 32);
+    const BASELINE: Option<i32> = Some(27);
 
     fn char_offset(c: char) -> u32 {
         let fallback = '?' as u32 - ' ' as u32;
@@ -41,7 +42,7 @@ impl MonoFont for Font24x32 {
 mod tests {
     use super::*;
     use crate::{
-        fonts::{tests::assert_text_from_pattern, MonoFont, Text},
+        fonts::{tests::*, MonoFont, Text},
         geometry::{Dimensions, Point, Size},
         pixelcolor::BinaryColor,
         style::MonoTextStyle,
@@ -239,5 +240,10 @@ mod tests {
 
         assert_text_from_pattern("\x7F\u{A0}", Font24x32, two_question_marks);
         assert_text_from_pattern("Ā💣", Font24x32, two_question_marks);
+    }
+
+    #[test]
+    fn baseline() {
+        test_baseline(Font24x32);
     }
 }

--- a/src/fonts/font6x12.rs
+++ b/src/fonts/font6x12.rs
@@ -15,6 +15,7 @@ impl MonoFont for Font6x12 {
     const FONT_IMAGE_WIDTH: u32 = 96;
 
     const CHARACTER_SIZE: Size = Size::new(6, 12);
+    const BASELINE: Option<i32> = Some(9);
 
     fn char_offset(c: char) -> u32 {
         let fallback = '?' as u32 - ' ' as u32;
@@ -32,7 +33,7 @@ impl MonoFont for Font6x12 {
 mod tests {
     use super::*;
     use crate::{
-        fonts::{tests::assert_text_from_pattern, MonoFont, Text},
+        fonts::{tests::*, MonoFont, Text},
         geometry::{Dimensions, Point, Size},
         pixelcolor::BinaryColor,
         style::MonoTextStyle,
@@ -141,5 +142,10 @@ mod tests {
         assert_text_from_pattern("\x7F\u{A0}", Font6x12, two_question_marks);
         assert_text_from_pattern("¡ÿ", Font6x12, two_question_marks);
         assert_text_from_pattern("Ā💣", Font6x12, two_question_marks);
+    }
+
+    #[test]
+    fn baseline() {
+        test_baseline(Font6x12);
     }
 }

--- a/src/fonts/font6x8.rs
+++ b/src/fonts/font6x8.rs
@@ -48,8 +48,8 @@ mod tests {
     #[test]
     fn text_dimensions() {
         let style = MonoTextStyle::new(Font6x8, BinaryColor::On);
-        let hello = Text::new(HELLO_WORLD, Point::zero()).into_styled(style);
-        let empty = Text::new("", Point::zero()).into_styled(style);
+        let hello = Text::new(HELLO_WORLD, Point::new(0, 7)).into_styled(style);
+        let empty = Text::new("", Point::new(0, 7)).into_styled(style);
 
         assert_eq!(
             hello.bounding_box().size,

--- a/src/fonts/font6x8.rs
+++ b/src/fonts/font6x8.rs
@@ -15,6 +15,7 @@ impl MonoFont for Font6x8 {
     const FONT_IMAGE_WIDTH: u32 = 240;
 
     const CHARACTER_SIZE: Size = Size::new(6, 8);
+    const BASELINE: Option<i32> = Some(6);
 
     fn char_offset(c: char) -> u32 {
         let fallback = '?' as u32 - ' ' as u32;
@@ -35,7 +36,7 @@ impl MonoFont for Font6x8 {
 mod tests {
     use super::*;
     use crate::{
-        fonts::{tests::assert_text_from_pattern, MonoFont, Text},
+        fonts::{tests::*, MonoFont, Text},
         geometry::{Dimensions, Point, Size},
         pixelcolor::BinaryColor,
         style::MonoTextStyle,
@@ -145,5 +146,10 @@ mod tests {
 
         assert_text_from_pattern("\x7F\u{A0}", Font6x8, two_question_marks);
         assert_text_from_pattern("Ā💣", Font6x8, two_question_marks);
+    }
+
+    #[test]
+    fn baseline() {
+        test_baseline(Font6x8);
     }
 }

--- a/src/fonts/font8x16.rs
+++ b/src/fonts/font8x16.rs
@@ -15,6 +15,7 @@ impl MonoFont for Font8x16 {
     const FONT_IMAGE_WIDTH: u32 = 240;
 
     const CHARACTER_SIZE: Size = Size::new(8, 16);
+    const BASELINE: Option<i32> = Some(11);
 
     fn char_offset(c: char) -> u32 {
         let fallback = '?' as u32 - ' ' as u32;
@@ -35,7 +36,7 @@ impl MonoFont for Font8x16 {
 mod tests {
     use super::*;
     use crate::{
-        fonts::{tests::assert_text_from_pattern, MonoFont, Text},
+        fonts::{tests::*, MonoFont, Text},
         geometry::{Dimensions, Point, Size},
         pixelcolor::BinaryColor,
         style::MonoTextStyle,
@@ -185,5 +186,10 @@ mod tests {
 
         assert_text_from_pattern("\x7F\u{A0}", Font8x16, two_question_marks);
         assert_text_from_pattern("Ā💣", Font8x16, two_question_marks);
+    }
+
+    #[test]
+    fn baseline() {
+        test_baseline(Font8x16);
     }
 }

--- a/src/fonts/mod.rs
+++ b/src/fonts/mod.rs
@@ -29,7 +29,8 @@
 //! # display.set_allow_out_of_bounds_drawing(true);
 //!
 //! // Create a new text style
-//! let style = MonoTextStyleBuilder::new(Font6x8)
+//! let style = MonoTextStyleBuilder::new()
+//!     .font(Font6x8)
 //!     .text_color(Rgb565::YELLOW)
 //!     .background_color(Rgb565::BLUE)
 //!     .build();
@@ -98,7 +99,8 @@
 //!
 //! Text::new(&buf, Point::zero())
 //!     .into_styled(
-//!         MonoTextStyleBuilder::new(Font6x8)
+//!         MonoTextStyleBuilder::new()
+//!             .font(Font6x8)
 //!             .text_color(Rgb565::YELLOW)
 //!             .background_color(Rgb565::BLUE)
 //!             .build(),

--- a/src/fonts/mod.rs
+++ b/src/fonts/mod.rs
@@ -169,6 +169,11 @@ pub trait MonoFont: Copy {
     /// on a single line of text.
     const CHARACTER_SPACING: u32 = 0;
 
+    /// The baseline.
+    ///
+    /// TODO: add description how this value is used and what the default value is
+    const BASELINE: Option<i32> = None;
+
     /// Returns the position of a character in the font.
     fn char_offset(_: char) -> u32;
 }

--- a/src/fonts/mod.rs
+++ b/src/fonts/mod.rs
@@ -194,7 +194,7 @@ mod tests {
         F: MonoFont,
     {
         let mut display = MockDisplay::new();
-        Text::new(text, Point::zero())
+        Text::new(text, Point::new(0, F::CHARACTER_SIZE.height as i32 - 1))
             .into_styled(MonoTextStyle::new(font, BinaryColor::On))
             .draw(&mut display)
             .unwrap();

--- a/src/fonts/mod.rs
+++ b/src/fonts/mod.rs
@@ -182,7 +182,10 @@ pub trait MonoFont: Copy {
 mod tests {
     use super::*;
     use crate::{
-        geometry::Point, mock_display::MockDisplay, pixelcolor::BinaryColor, style::MonoTextStyle,
+        geometry::Point,
+        mock_display::MockDisplay,
+        pixelcolor::BinaryColor,
+        style::{MonoTextStyleBuilder, VerticalAlignment},
         Drawable,
     };
 
@@ -193,12 +196,43 @@ mod tests {
     where
         F: MonoFont,
     {
+        let style = MonoTextStyleBuilder::new()
+            .font(font)
+            .text_color(BinaryColor::On)
+            .vertical_alignment(VerticalAlignment::Top)
+            .build();
+
         let mut display = MockDisplay::new();
-        Text::new(text, Point::new(0, F::CHARACTER_SIZE.height as i32 - 1))
-            .into_styled(MonoTextStyle::new(font, BinaryColor::On))
+        Text::new(text, Point::zero())
+            .into_styled(style)
             .draw(&mut display)
             .unwrap();
 
         display.assert_pattern(pattern);
+    }
+
+    /// Test if the baseline constant is set correctly.
+    ///
+    /// This test assumes that the character `A` is on the baseline.
+    pub(super) fn test_baseline<F>(font: F)
+    where
+        F: MonoFont,
+    {
+        let style = MonoTextStyleBuilder::new()
+            .font(font)
+            .text_color(BinaryColor::On)
+            .vertical_alignment(VerticalAlignment::Top)
+            .build();
+
+        // Draw 'A' character to determine it's baseline
+        let mut display = MockDisplay::new();
+        Text::new("A", Point::zero())
+            .into_styled(style)
+            .draw(&mut display)
+            .unwrap();
+
+        let baseline = display.affected_area().bottom_right().unwrap().y;
+
+        assert_eq!(F::BASELINE, Some(baseline));
     }
 }

--- a/src/fonts/text.rs
+++ b/src/fonts/text.rs
@@ -417,7 +417,7 @@ mod tests {
             .build();
 
         let mut display = MockDisplay::new();
-        Text::new("A\nBC", Point::new(0, 7))
+        Text::new("A\nBC", Point::new(0, 6))
             .into_styled(style)
             .draw(&mut display)
             .unwrap();
@@ -451,7 +451,7 @@ mod tests {
             .build();
 
         let mut display = MockDisplay::new();
-        Text::new("A\nBC", Point::new(5, 7))
+        Text::new("A\nBC", Point::new(5, 6))
             .into_styled(style)
             .draw(&mut display)
             .unwrap();
@@ -485,7 +485,7 @@ mod tests {
             .build();
 
         let mut display = MockDisplay::new();
-        Text::new("A\nBC", Point::new(11, 7))
+        Text::new("A\nBC", Point::new(11, 6))
             .into_styled(style)
             .draw(&mut display)
             .unwrap();

--- a/src/fonts/text.rs
+++ b/src/fonts/text.rs
@@ -322,22 +322,20 @@ mod tests {
     #[test]
     fn inverted_text() {
         let mut display_inverse = MockDisplay::new();
-        let style_inverse = MonoTextStyle {
-            font: Font6x8,
-            text_color: Some(BinaryColor::Off),
-            background_color: Some(BinaryColor::On),
-        };
+        let style_inverse = MonoTextStyleBuilder::new(Font6x8)
+            .text_color(BinaryColor::Off)
+            .background_color(BinaryColor::On)
+            .build();
         Text::new("Mm", Point::zero())
             .into_styled(style_inverse)
             .draw(&mut display_inverse)
             .unwrap();
 
         let mut display_normal = MockDisplay::new();
-        let style_normal = MonoTextStyle {
-            font: Font6x8,
-            text_color: Some(BinaryColor::On),
-            background_color: Some(BinaryColor::Off),
-        };
+        let style_normal = MonoTextStyleBuilder::new(Font6x8)
+            .text_color(BinaryColor::On)
+            .background_color(BinaryColor::Off)
+            .build();
         Text::new("Mm", Point::zero())
             .into_styled(style_normal)
             .draw(&mut display_normal)
@@ -359,11 +357,9 @@ mod tests {
 
     #[test]
     fn transparent_text_color_does_not_overwrite_background() {
-        let style = MonoTextStyle {
-            font: Font6x8,
-            text_color: None,
-            background_color: Some(BinaryColor::On),
-        };
+        let style = MonoTextStyleBuilder::new(Font6x8)
+            .background_color(BinaryColor::On)
+            .build();
 
         let mut display = MockDisplay::new();
         display.set_allow_overdraw(true);
@@ -393,11 +389,7 @@ mod tests {
 
     #[test]
     fn transparent_text_has_zero_size_but_retains_position() {
-        let style: MonoTextStyle<BinaryColor, _> = MonoTextStyle {
-            font: Font6x8,
-            text_color: None,
-            background_color: None,
-        };
+        let style = MonoTextStyleBuilder::<BinaryColor, _>::new(Font6x8).build();
 
         let styled = Text::new(" A", Point::new(7, 11)).into_styled(style);
 

--- a/src/fonts/text.rs
+++ b/src/fonts/text.rs
@@ -129,7 +129,7 @@ mod tests {
         pixelcolor::BinaryColor,
         prelude::*,
         style::MonoTextStyle,
-        style::{HorizontalAlignment, MonoTextStyleBuilder, PrimitiveStyle, VerticalAlignment},
+        style::{MonoTextStyleBuilder, PrimitiveStyle, VerticalAlignment},
     };
 
     const HELLO_WORLD: &'static str = "Hello World!";
@@ -208,7 +208,11 @@ mod tests {
 
     #[test]
     fn character_spacing_dimensions() {
-        let style = MonoTextStyle::new(SpacedFont, BinaryColor::On);
+        let style = MonoTextStyleBuilder::new()
+            .font(SpacedFont)
+            .text_color(BinaryColor::On)
+            .vertical_alignment(VerticalAlignment::Top)
+            .build();
 
         assert_eq!(
             Text::new("#", Point::zero())
@@ -293,7 +297,11 @@ mod tests {
 
     #[test]
     fn multiline_dimensions() {
-        let style = MonoTextStyle::new(Font6x8, BinaryColor::On);
+        let style = MonoTextStyleBuilder::new()
+            .font(Font6x8)
+            .text_color(BinaryColor::On)
+            .vertical_alignment(VerticalAlignment::Top)
+            .build();
         let text = Text::new("AB\nC", Point::zero()).into_styled(style);
 
         assert_eq!(
@@ -406,107 +414,5 @@ mod tests {
             Rectangle::new(Point::new(7, 11), Size::zero()),
             "Transparent text is expected to have a zero sized bounding box with the top left corner at the text position",
         );
-    }
-
-    #[test]
-    fn horizontal_alignment_left() {
-        let style = MonoTextStyleBuilder::new()
-            .font(Font6x8)
-            .text_color(BinaryColor::On)
-            .horizontal_alignment(HorizontalAlignment::Left)
-            .build();
-
-        let mut display = MockDisplay::new();
-        Text::new("A\nBC", Point::new(0, 6))
-            .into_styled(style)
-            .draw(&mut display)
-            .unwrap();
-
-        display.assert_pattern(&[
-            " ###        ",
-            "#   #       ",
-            "#   #       ",
-            "#####       ",
-            "#   #       ",
-            "#   #       ",
-            "#   #       ",
-            "            ",
-            "####   ###  ",
-            "#   # #   # ",
-            "#   # #     ",
-            "####  #     ",
-            "#   # #     ",
-            "#   # #   # ",
-            "####   ###  ",
-            "            ",
-        ]);
-    }
-
-    #[test]
-    fn horizontal_alignment_center() {
-        let style = MonoTextStyleBuilder::new()
-            .font(Font6x8)
-            .text_color(BinaryColor::On)
-            .horizontal_alignment(HorizontalAlignment::Center)
-            .build();
-
-        let mut display = MockDisplay::new();
-        Text::new("A\nBC", Point::new(5, 6))
-            .into_styled(style)
-            .draw(&mut display)
-            .unwrap();
-
-        display.assert_pattern(&[
-            "    ###     ",
-            "   #   #    ",
-            "   #   #    ",
-            "   #####    ",
-            "   #   #    ",
-            "   #   #    ",
-            "   #   #    ",
-            "            ",
-            "####   ###  ",
-            "#   # #   # ",
-            "#   # #     ",
-            "####  #     ",
-            "#   # #     ",
-            "#   # #   # ",
-            "####   ###  ",
-            "            ",
-        ]);
-    }
-
-    #[test]
-    fn horizontal_alignment_right() {
-        let style = MonoTextStyleBuilder::new()
-            .font(Font6x8)
-            .text_color(BinaryColor::On)
-            .horizontal_alignment(HorizontalAlignment::Right)
-            .build();
-
-        let mut display = MockDisplay::new();
-        Text::new("A\nBC", Point::new(11, 6))
-            .into_styled(style)
-            .draw(&mut display)
-            .unwrap();
-
-        display.assert_pattern(&[
-            "       ###  ",
-            "      #   # ",
-            "      #   # ",
-            "      ##### ",
-            "      #   # ",
-            "      #   # ",
-            "      #   # ",
-            "            ",
-            "####   ###  ",
-            "#   # #   # ",
-            "#   # #     ",
-            "####  #     ",
-            "#   # #     ",
-            "#   # #   # ",
-            "####   ###  ",
-            "            ",
-        ]);
     }
 }

--- a/src/fonts/text.rs
+++ b/src/fonts/text.rs
@@ -184,7 +184,8 @@ mod tests {
         let mut display = MockDisplay::new();
         Text::new("##", Point::zero())
             .into_styled(
-                MonoTextStyleBuilder::new(SpacedFont)
+                MonoTextStyleBuilder::new()
+                    .font(SpacedFont)
                     .text_color(BinaryColor::On)
                     .background_color(BinaryColor::Off)
                     .build(),
@@ -322,7 +323,8 @@ mod tests {
     #[test]
     fn inverted_text() {
         let mut display_inverse = MockDisplay::new();
-        let style_inverse = MonoTextStyleBuilder::new(Font6x8)
+        let style_inverse = MonoTextStyleBuilder::new()
+            .font(Font6x8)
             .text_color(BinaryColor::Off)
             .background_color(BinaryColor::On)
             .build();
@@ -332,7 +334,8 @@ mod tests {
             .unwrap();
 
         let mut display_normal = MockDisplay::new();
-        let style_normal = MonoTextStyleBuilder::new(Font6x8)
+        let style_normal = MonoTextStyleBuilder::new()
+            .font(Font6x8)
             .text_color(BinaryColor::On)
             .background_color(BinaryColor::Off)
             .build();
@@ -357,7 +360,8 @@ mod tests {
 
     #[test]
     fn transparent_text_color_does_not_overwrite_background() {
-        let style = MonoTextStyleBuilder::new(Font6x8)
+        let style = MonoTextStyleBuilder::new()
+            .font(Font6x8)
             .background_color(BinaryColor::On)
             .build();
 
@@ -389,7 +393,9 @@ mod tests {
 
     #[test]
     fn transparent_text_has_zero_size_but_retains_position() {
-        let style = MonoTextStyleBuilder::<BinaryColor, _>::new(Font6x8).build();
+        let style = MonoTextStyleBuilder::<BinaryColor, _>::new()
+            .font(Font6x8)
+            .build();
 
         let styled = Text::new(" A", Point::new(7, 11)).into_styled(style);
 

--- a/src/fonts/text.rs
+++ b/src/fonts/text.rs
@@ -129,7 +129,7 @@ mod tests {
         pixelcolor::BinaryColor,
         prelude::*,
         style::MonoTextStyle,
-        style::{HorizontalAlignment, MonoTextStyleBuilder, PrimitiveStyle},
+        style::{HorizontalAlignment, MonoTextStyleBuilder, PrimitiveStyle, VerticalAlignment},
     };
 
     const HELLO_WORLD: &'static str = "Hello World!";
@@ -188,6 +188,7 @@ mod tests {
                     .font(SpacedFont)
                     .text_color(BinaryColor::On)
                     .background_color(BinaryColor::Off)
+                    .vertical_alignment(VerticalAlignment::Top)
                     .build(),
             )
             .draw(&mut display)
@@ -328,7 +329,7 @@ mod tests {
             .text_color(BinaryColor::Off)
             .background_color(BinaryColor::On)
             .build();
-        Text::new("Mm", Point::zero())
+        Text::new("Mm", Point::new(0, 7))
             .into_styled(style_inverse)
             .draw(&mut display_inverse)
             .unwrap();
@@ -339,7 +340,7 @@ mod tests {
             .text_color(BinaryColor::On)
             .background_color(BinaryColor::Off)
             .build();
-        Text::new("Mm", Point::zero())
+        Text::new("Mm", Point::new(0, 7))
             .into_styled(style_normal)
             .draw(&mut display_normal)
             .unwrap();
@@ -363,6 +364,7 @@ mod tests {
         let style = MonoTextStyleBuilder::new()
             .font(Font6x8)
             .background_color(BinaryColor::On)
+            .vertical_alignment(VerticalAlignment::Top)
             .build();
 
         let mut display = MockDisplay::new();
@@ -415,7 +417,7 @@ mod tests {
             .build();
 
         let mut display = MockDisplay::new();
-        Text::new("A\nBC", Point::zero())
+        Text::new("A\nBC", Point::new(0, 7))
             .into_styled(style)
             .draw(&mut display)
             .unwrap();
@@ -449,7 +451,7 @@ mod tests {
             .build();
 
         let mut display = MockDisplay::new();
-        Text::new("A\nBC", Point::new(5, 0))
+        Text::new("A\nBC", Point::new(5, 7))
             .into_styled(style)
             .draw(&mut display)
             .unwrap();
@@ -483,7 +485,7 @@ mod tests {
             .build();
 
         let mut display = MockDisplay::new();
-        Text::new("A\nBC", Point::new(12, 0))
+        Text::new("A\nBC", Point::new(11, 7))
             .into_styled(style)
             .draw(&mut display)
             .unwrap();

--- a/src/fonts/text.rs
+++ b/src/fonts/text.rs
@@ -129,7 +129,7 @@ mod tests {
         pixelcolor::BinaryColor,
         prelude::*,
         style::MonoTextStyle,
-        style::{MonoTextStyleBuilder, PrimitiveStyle},
+        style::{HorizontalAlignment, MonoTextStyleBuilder, PrimitiveStyle},
     };
 
     const HELLO_WORLD: &'static str = "Hello World!";
@@ -404,5 +404,107 @@ mod tests {
             Rectangle::new(Point::new(7, 11), Size::zero()),
             "Transparent text is expected to have a zero sized bounding box with the top left corner at the text position",
         );
+    }
+
+    #[test]
+    fn horizontal_alignment_left() {
+        let style = MonoTextStyleBuilder::new()
+            .font(Font6x8)
+            .text_color(BinaryColor::On)
+            .horizontal_alignment(HorizontalAlignment::Left)
+            .build();
+
+        let mut display = MockDisplay::new();
+        Text::new("A\nBC", Point::zero())
+            .into_styled(style)
+            .draw(&mut display)
+            .unwrap();
+
+        display.assert_pattern(&[
+            " ###        ",
+            "#   #       ",
+            "#   #       ",
+            "#####       ",
+            "#   #       ",
+            "#   #       ",
+            "#   #       ",
+            "            ",
+            "####   ###  ",
+            "#   # #   # ",
+            "#   # #     ",
+            "####  #     ",
+            "#   # #     ",
+            "#   # #   # ",
+            "####   ###  ",
+            "            ",
+        ]);
+    }
+
+    #[test]
+    fn horizontal_alignment_center() {
+        let style = MonoTextStyleBuilder::new()
+            .font(Font6x8)
+            .text_color(BinaryColor::On)
+            .horizontal_alignment(HorizontalAlignment::Center)
+            .build();
+
+        let mut display = MockDisplay::new();
+        Text::new("A\nBC", Point::new(5, 0))
+            .into_styled(style)
+            .draw(&mut display)
+            .unwrap();
+
+        display.assert_pattern(&[
+            "    ###     ",
+            "   #   #    ",
+            "   #   #    ",
+            "   #####    ",
+            "   #   #    ",
+            "   #   #    ",
+            "   #   #    ",
+            "            ",
+            "####   ###  ",
+            "#   # #   # ",
+            "#   # #     ",
+            "####  #     ",
+            "#   # #     ",
+            "#   # #   # ",
+            "####   ###  ",
+            "            ",
+        ]);
+    }
+
+    #[test]
+    fn horizontal_alignment_right() {
+        let style = MonoTextStyleBuilder::new()
+            .font(Font6x8)
+            .text_color(BinaryColor::On)
+            .horizontal_alignment(HorizontalAlignment::Right)
+            .build();
+
+        let mut display = MockDisplay::new();
+        Text::new("A\nBC", Point::new(12, 0))
+            .into_styled(style)
+            .draw(&mut display)
+            .unwrap();
+
+        display.assert_pattern(&[
+            "       ###  ",
+            "      #   # ",
+            "      #   # ",
+            "      ##### ",
+            "      #   # ",
+            "      #   # ",
+            "      #   # ",
+            "            ",
+            "####   ###  ",
+            "#   # #   # ",
+            "#   # #     ",
+            "####  #     ",
+            "#   # #     ",
+            "#   # #   # ",
+            "####   ###  ",
+            "            ",
+        ]);
     }
 }

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -5,7 +5,9 @@ mod primitive_style;
 mod styled;
 mod text_style;
 
-pub use mono_text_style::{MonoTextStyle, MonoTextStyleBuilder};
+pub use mono_text_style::{
+    HorizontalAlignment, MonoTextStyle, MonoTextStyleBuilder, VerticalAlignment,
+};
 pub use primitive_style::{PrimitiveStyle, PrimitiveStyleBuilder, StrokeAlignment};
 pub use styled::{Styled, StyledPrimitiveAreas};
 pub use text_style::TextStyle;

--- a/src/style/mono_text_style.rs
+++ b/src/style/mono_text_style.rs
@@ -21,7 +21,7 @@ use crate::{
 /// [`non_exhaustive`]: https://blog.rust-lang.org/2019/12/19/Rust-1.40.0.html#[non_exhaustive]-structs,-enums,-and-variants
 /// [`MonoTextStyleBuilder`]: ./struct.MonoTextStyleBuilder.html
 /// [`new`]: #method.new
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[non_exhaustive]
 pub struct MonoTextStyle<C, F>
 where
@@ -34,6 +34,12 @@ where
     /// Background color.
     pub background_color: Option<C>,
 
+    /// Horizontal alignment.
+    pub horizontal_alignment: HorizontalAlignment,
+
+    /// Vertical alignment.
+    pub vertical_alignment: VerticalAlignment,
+
     /// Font.
     pub font: F,
 }
@@ -45,11 +51,9 @@ where
 {
     /// Creates a text style with transparent background.
     pub fn new(font: F, text_color: C) -> Self {
-        Self {
-            font,
-            text_color: Some(text_color),
-            background_color: None,
-        }
+        MonoTextStyleBuilder::new(font)
+            .text_color(text_color)
+            .build()
     }
 }
 
@@ -197,7 +201,7 @@ where
 /// [other fonts]: ../fonts/index.html
 /// [`Text`]: ../fonts/struct.Text.html
 /// [`MonoTextStyle`]: ./struct.MonoTextStyle.html
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct MonoTextStyleBuilder<C, F>
 where
     C: PixelColor,
@@ -218,6 +222,8 @@ where
                 font,
                 background_color: None,
                 text_color: None,
+                horizontal_alignment: HorizontalAlignment::Left,
+                vertical_alignment: VerticalAlignment::Baseline,
             },
         }
     }
@@ -236,10 +242,48 @@ where
         self
     }
 
+    /// Sets the horizontal alignment.
+    pub fn horizontal_alignment(mut self, horizontal_alignment: HorizontalAlignment) -> Self {
+        self.style.horizontal_alignment = horizontal_alignment;
+
+        self
+    }
+
+    /// Sets the vertical alignment.
+    pub fn vertical_alignment(mut self, vertical_alignment: VerticalAlignment) -> Self {
+        self.style.vertical_alignment = vertical_alignment;
+
+        self
+    }
+
     /// Builds the text style.
     pub fn build(self) -> MonoTextStyle<C, F> {
         self.style
     }
+}
+
+/// Vertical text alignment.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub enum VerticalAlignment {
+    /// Top.
+    Top,
+    /// Bottom.
+    Bottom,
+    /// Center.
+    Center,
+    /// Baseline.
+    Baseline,
+}
+
+/// Horizontal text alignment.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub enum HorizontalAlignment {
+    /// Left.
+    Left,
+    /// Center.
+    Center,
+    /// Right.
+    Right,
 }
 
 #[cfg(test)]
@@ -254,7 +298,9 @@ mod tests {
             MonoTextStyle {
                 font: Font12x16,
                 text_color: None,
-                background_color: None
+                background_color: None,
+                horizontal_alignment: HorizontalAlignment::Left,
+                vertical_alignment: VerticalAlignment::Baseline,
             }
         );
     }
@@ -284,5 +330,16 @@ mod tests {
                 style
             }
         );
+    }
+
+    #[test]
+    fn builder_alignments() {
+        let style = MonoTextStyleBuilder::<BinaryColor, _>::new(Font12x16)
+            .horizontal_alignment(HorizontalAlignment::Right)
+            .vertical_alignment(VerticalAlignment::Top)
+            .build();
+
+        assert_eq!(style.horizontal_alignment, HorizontalAlignment::Right);
+        assert_eq!(style.vertical_alignment, VerticalAlignment::Top);
     }
 }

--- a/src/style/mono_text_style.rs
+++ b/src/style/mono_text_style.rs
@@ -80,10 +80,27 @@ where
         match self.horizontal_alignment {
             HorizontalAlignment::Left => {}
             HorizontalAlignment::Right => {
-                position -= Size::new(self.line_width(text), 0);
+                position -= Size::new(self.line_width(text).saturating_sub(1), 0);
             }
             HorizontalAlignment::Center => {
                 position -= Size::new(self.line_width(text).saturating_sub(1) / 2, 0);
+            }
+        }
+
+        match self.vertical_alignment {
+            VerticalAlignment::Top => {}
+            VerticalAlignment::Bottom => {
+                position -= F::CHARACTER_SIZE.y_axis().saturating_sub(Size::new(0, 1));
+            }
+            VerticalAlignment::Center => {
+                position -= F::CHARACTER_SIZE.y_axis().saturating_sub(Size::new(0, 1)) / 2;
+            }
+            VerticalAlignment::Baseline => {
+                if let Some(baseline) = F::BASELINE {
+                    unimplemented!()
+                } else {
+                    position -= F::CHARACTER_SIZE.y_axis().saturating_sub(Size::new(0, 1));
+                }
             }
         }
 

--- a/src/style/mono_text_style.rs
+++ b/src/style/mono_text_style.rs
@@ -52,6 +52,11 @@ where
             .text_color(text_color)
             .build()
     }
+
+    fn line_width(&self, text: &str) -> u32 {
+        (text.len() as u32 * (F::CHARACTER_SIZE.width + F::CHARACTER_SPACING))
+            .saturating_sub(F::CHARACTER_SPACING)
+    }
 }
 
 impl<C, F> TextStyle for MonoTextStyle<C, F>
@@ -71,6 +76,16 @@ where
         D: DrawTarget<Color = Self::Color>,
     {
         let mut first = true;
+
+        match self.horizontal_alignment {
+            HorizontalAlignment::Left => {}
+            HorizontalAlignment::Right => {
+                position -= Size::new(self.line_width(text), 0);
+            }
+            HorizontalAlignment::Center => {
+                position -= Size::new(self.line_width(text).saturating_sub(1) / 2, 0);
+            }
+        }
 
         for c in text.chars() {
             if first {
@@ -136,10 +151,7 @@ where
             return (Rectangle::new(position, Size::zero()), position_delta);
         }
 
-        let width = (text.len() as u32 * (F::CHARACTER_SPACING + F::CHARACTER_SIZE.width))
-            .saturating_sub(F::CHARACTER_SPACING);
-
-        let size = Size::new(width, F::CHARACTER_SIZE.height);
+        let size = Size::new(self.line_width(text), F::CHARACTER_SIZE.height);
 
         (Rectangle::new(position, size), position_delta)
     }

--- a/src/style/mono_text_style.rs
+++ b/src/style/mono_text_style.rs
@@ -96,11 +96,10 @@ where
                 position -= F::CHARACTER_SIZE.y_axis().saturating_sub(Size::new(0, 1)) / 2;
             }
             VerticalAlignment::Baseline => {
-                if let Some(baseline) = F::BASELINE {
-                    unimplemented!()
-                } else {
-                    position -= F::CHARACTER_SIZE.y_axis().saturating_sub(Size::new(0, 1));
-                }
+                let baseline = F::BASELINE
+                    .unwrap_or_else(|| F::CHARACTER_SIZE.height.saturating_sub(1) as i32);
+
+                position.y -= baseline;
             }
         }
 


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR adds vertical and horizontal text alignment settings to `MonoTextStyle`. The default vertical alignment is now `Baseline` instead of `Top` and all builtin fonts now set the baseline.

I've also changed the implementation of `MonoTextStyleBuilder` to be more similar to the `PrimitiveStyleBuilder`. All settings can now be changed using setters and it's no longer required to pass the font to the `new` constructor.
