### PR TITLE
Export ImageDrawable from core prelude

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- [#514](https://github.com/embedded-graphics/embedded-graphics/pull/514) Add `ImageDrawable` to the `prelude`.
+
 ## [0.1.0] - 2020-11-29
 
 ### Added

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -5,6 +5,7 @@ pub use crate::{
     draw_target::{DrawTarget, DrawTargetExt},
     drawable::{Drawable, Pixel},
     geometry::{Dimensions, OriginDimensions, Point, Size},
+    image::ImageDrawable,
     iterator::{ContiguousIteratorExt, IntoPixels, PixelIteratorExt},
     pixelcolor::{
         raw::{RawData, ToBytes as _},


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Closes #513

embedded-graphics/tinybmp#3 and embedded-graphics/tinytga#3 can be updated when this is merged and a new e-g-core version is released. I'll put a `0.1.1` patch out on merge.
