### PR TITLE
Publish UndefinedFont

### DIFF
--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -6,7 +6,7 @@ mod styled;
 mod text_style;
 
 pub use mono_text_style::{
-    HorizontalAlignment, MonoTextStyle, MonoTextStyleBuilder, VerticalAlignment,
+    HorizontalAlignment, MonoTextStyle, MonoTextStyleBuilder, UndefinedFont, VerticalAlignment,
 };
 pub use primitive_style::{PrimitiveStyle, PrimitiveStyleBuilder, StrokeAlignment};
 pub use styled::{Styled, StyledPrimitiveAreas};

--- a/src/style/mono_text_style.rs
+++ b/src/style/mono_text_style.rs
@@ -240,12 +240,21 @@ where
 ///     .build();
 /// ```
 ///
+/// # Setting the font
+///
+/// The default font set in `MonoTextStyleBuilder` is [`UndefinedFont`]. You will need to set a
+/// valid [`MonoFont`] by calling the [`font()`] builder method, otherwise you will not be able
+/// to create a style object using the builder.
+///
 /// [`Font`]: ../fonts/trait.Font.html
 /// [`Font6x8`]: ../fonts/struct.Font6x8.html
 /// [`Font8x16`]: ../fonts/struct.Font8x16.html
 /// [other fonts]: ../fonts/index.html
 /// [`Text`]: ../fonts/struct.Text.html
 /// [`MonoTextStyle`]: ./struct.MonoTextStyle.html
+/// [`UndefinedFont`]: ./struct.UndefinedFont.html
+/// [`MonoFont`]: ../fonts/trait.MonoFont.html
+/// [`font()`]: #method.font
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct MonoTextStyleBuilder<C, F> {
     style: MonoTextStyle<C, F>,
@@ -268,6 +277,12 @@ impl<C> MonoTextStyleBuilder<C, UndefinedFont> {
 
 impl<C, F> MonoTextStyleBuilder<C, F> {
     /// Sets the font.
+    ///
+    /// Setting the font is required to build a `MonoTextStyle`. On construction, the
+    /// builder's font is set to [`UndefinedFont`] and the [`build()`] method is not
+    /// implemented for `UndefinedFont`.
+    ///
+    /// [`build()`]: #method.build
     pub fn font<Font>(self, font: Font) -> MonoTextStyleBuilder<C, Font> {
         let style = MonoTextStyle {
             font,


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This change makes it possible to create wrapper objects that contain `MonoTextStyleBuilder`s without the need to specify the font in the constructor. This allows users to create APIs consistent with the one provided by e-g.
