### PR TITLE
Fix triangle and polyline overdraw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 ### Fixed
 
 - [#507](https://github.com/embedded-graphics/embedded-graphics/pull/507) Fixed drawing of the join between the radial lines for sectors with a sweep angle close to 360°.
+- [#525](https://github.com/embedded-graphics/embedded-graphics/pull/525) `Triangle`s and `Polyline`s with thick strokes would overdraw in some cases.
 
 ## [0.7.0-alpha.2] - 2020-11-29
 
@@ -574,8 +575,8 @@ A big release, focussed on ergonomics. There are new macros to make drawing and 
   ```
 
 <!-- next-url -->
-[unreleased]: https://github.com/embedded-graphics/embedded-graphics/compare/embedded-graphics-v0.7.0-alpha.2...HEAD
 
+[unreleased]: https://github.com/embedded-graphics/embedded-graphics/compare/embedded-graphics-v0.7.0-alpha.2...HEAD
 [0.7.0-alpha.2]: https://github.com/embedded-graphics/embedded-graphics/compare/embedded-graphics-v0.7.0-alpha.1...embedded-graphics-v0.7.0-alpha.2
 [0.7.0-alpha.1]: https://github.com/embedded-graphics/embedded-graphics/compare/embedded-graphics-v0.6.2...embedded-graphics-v0.7.0-alpha.1
 [0.6.2]: https://github.com/embedded-graphics/embedded-graphics/compare/embedded-graphics-v0.6.1...embedded-graphics-v0.6.2

--- a/src/primitives/polyline/styled.rs
+++ b/src/primitives/polyline/styled.rs
@@ -592,4 +592,15 @@ mod tests {
 
         display.assert_eq(&MockDisplay::new());
     }
+
+    #[test]
+    fn issue_489_overdraw() {
+        let mut display = MockDisplay::new();
+
+        // Panics if pixel is drawn twice.
+        Polyline::new(&[Point::new(10, 5), Point::new(5, 10), Point::new(10, 10)])
+            .into_styled(PrimitiveStyle::with_stroke(Rgb565::RED, 5))
+            .draw(&mut display)
+            .unwrap();
+    }
 }

--- a/src/primitives/triangle/mod.rs
+++ b/src/primitives/triangle/mod.rs
@@ -432,4 +432,11 @@ mod tests {
             )
         );
     }
+
+    #[test]
+    fn check_collapsed() {
+        let triangle = Triangle::new(Point::new(10, 10), Point::new(30, 20), Point::new(20, 25));
+
+        assert_eq!(triangle.is_collapsed(20, StrokeOffset::None), true);
+    }
 }

--- a/src/primitives/triangle/styled.rs
+++ b/src/primitives/triangle/styled.rs
@@ -200,7 +200,6 @@ mod tests {
     #[test]
     fn issue_308_infinite() {
         let mut display: MockDisplay<BinaryColor> = MockDisplay::new();
-        display.set_allow_overdraw(true);
         display.set_allow_out_of_bounds_drawing(true);
 
         Triangle::new(Point::new(10, 10), Point::new(20, 30), Point::new(30, -10))
@@ -212,7 +211,6 @@ mod tests {
     #[test]
     fn it_draws_filled_strokeless_tri() {
         let mut display: MockDisplay<BinaryColor> = MockDisplay::new();
-        display.set_allow_overdraw(true);
 
         Triangle::new(Point::new(2, 2), Point::new(2, 4), Point::new(4, 2))
             .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
@@ -231,7 +229,6 @@ mod tests {
     #[test]
     fn stroke_fill_colors() {
         let mut display: MockDisplay<Rgb888> = MockDisplay::new();
-        display.set_allow_overdraw(true);
 
         Triangle::new(Point::new(2, 2), Point::new(8, 2), Point::new(2, 8))
             .into_styled(
@@ -260,7 +257,6 @@ mod tests {
     #[test]
     fn off_screen() {
         let mut display: MockDisplay<BinaryColor> = MockDisplay::new();
-        display.set_allow_overdraw(true);
         display.set_allow_out_of_bounds_drawing(true);
 
         Triangle::new(Point::new(5, 5), Point::new(10, 15), Point::new(15, -5))
@@ -382,7 +378,6 @@ mod tests {
         );
 
         let mut display = MockDisplay::new();
-        display.set_allow_overdraw(true);
 
         styled.draw(&mut display).unwrap();
 

--- a/src/primitives/triangle/styled.rs
+++ b/src/primitives/triangle/styled.rs
@@ -344,8 +344,6 @@ mod tests {
 
         let mut display = MockDisplay::new();
 
-        display.set_allow_overdraw(true);
-
         styled.draw(&mut display).unwrap();
         assert_eq!(display.affected_area(), styled.bounding_box());
     }


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Overdraw was occurring because lines like this were being merged correctly:

```
S1-----------E1
    S2---E2
```

Whereas the following was not:

```
    S1---E1
S2-----------E2
```

This PR changes the line extension behaviour to extend to the min/max of _both_ lines.

There might be a more optimal way of checking the ranges, so I'm open to suggestions there. The triangle and polyline benches haven't changed compared to master though.

Closes #489 
