### PR TITLE
Detect nearly-parallel numerical inaccuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 - [#507](https://github.com/embedded-graphics/embedded-graphics/pull/507) Fixed drawing of the join between the radial lines for sectors with a sweep angle close to 360°.
 - [#525](https://github.com/embedded-graphics/embedded-graphics/pull/525) `Triangle`s and `Polyline`s with thick strokes would overdraw in some cases.
-- [#527](https://github.com/embedded-graphics/embedded-graphics/pull/527) Some `Polyline`s occasionally drew spurs between joints. This is now fixed.
+- [#527](https://github.com/embedded-graphics/embedded-graphics/pull/527) Some cases where the ends of `Polyline`s would draw unwanted "spurs" are now fixed.
 
 ## [0.7.0-alpha.2] - 2020-11-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 - [#507](https://github.com/embedded-graphics/embedded-graphics/pull/507) Fixed drawing of the join between the radial lines for sectors with a sweep angle close to 360°.
 - [#525](https://github.com/embedded-graphics/embedded-graphics/pull/525) `Triangle`s and `Polyline`s with thick strokes would overdraw in some cases.
+- [#527](https://github.com/embedded-graphics/embedded-graphics/pull/527) Some `Polyline`s occasionally drew spurs between joints. This is now fixed.
 
 ## [0.7.0-alpha.2] - 2020-11-29
 

--- a/src/primitives/common/line_join.rs
+++ b/src/primitives/common/line_join.rs
@@ -4,7 +4,7 @@ use crate::{
     geometry::{Point, PointExt},
     primitives::{
         common::{LineSide, LinearEquation, StrokeOffset},
-        line::Intersection,
+        line::{intersection_params::IntersectionParams, Intersection},
         Line,
     },
 };
@@ -305,19 +305,29 @@ fn intersections(
     second_edge_left: &Line,
     second_edge_right: &Line,
 ) -> Option<(Point, LineSide, Point)> {
+    let params = IntersectionParams::from_lines(second_edge_left, first_edge_left);
+
     let (l_intersection, outer_side) = if let Intersection::Point {
         point, outer_side, ..
-    } = second_edge_left.intersection(&first_edge_left)
+    } = params.intersection()
     {
-        (point, outer_side)
+        if !params.nearly_colinear_has_error() {
+            (point, outer_side)
+        } else {
+            (first_edge_left.end, outer_side)
+        }
     } else {
         return None;
     };
 
-    let r_intersection = if let Intersection::Point { point, .. } =
-        second_edge_right.intersection(&first_edge_right)
-    {
-        point
+    let params = IntersectionParams::from_lines(second_edge_right, first_edge_right);
+
+    let r_intersection = if let Intersection::Point { point, .. } = params.intersection() {
+        if !params.nearly_colinear_has_error() {
+            point
+        } else {
+            first_edge_right.end
+        }
     } else {
         return None;
     };

--- a/src/primitives/common/line_join.rs
+++ b/src/primitives/common/line_join.rs
@@ -4,7 +4,7 @@ use crate::{
     geometry::{Point, PointExt},
     primitives::{
         common::{LineSide, LinearEquation, StrokeOffset},
-        line::{intersection_params::IntersectionParams, Intersection},
+        line::intersection_params::{Intersection, IntersectionParams},
         Line,
     },
 };

--- a/src/primitives/line/intersection_params.rs
+++ b/src/primitives/line/intersection_params.rs
@@ -1,0 +1,95 @@
+//! Line intersection parameters.
+
+use crate::{
+    geometry::{Point, PointExt},
+    primitives::{
+        common::{LineSide, LinearEquation},
+        line::Intersection,
+        Line,
+    },
+};
+
+/// Line intersection parameters.
+#[derive(Debug, Copy, Clone)]
+pub struct IntersectionParams<'a> {
+    line1: &'a Line,
+    line2: &'a Line,
+    le1: LinearEquation,
+    le2: LinearEquation,
+
+    /// Determinant, used to solve linear equations using Cramer's rule.
+    pub denominator: i32,
+}
+
+impl<'a> IntersectionParams<'a> {
+    pub fn from_lines(line1: &'a Line, line2: &'a Line) -> Self {
+        let le1 = LinearEquation::from_line(line1);
+        let le2 = LinearEquation::from_line(line2);
+        let denominator = le1.normal_vector.determinant(le2.normal_vector);
+
+        Self {
+            line1,
+            line2,
+            le1,
+            le2,
+            denominator,
+        }
+    }
+
+    /// Check whether two almost-colinear lines are intersecting in the wrong place due to numerical
+    /// innacuracies.
+    pub fn nearly_colinear_has_error(&self) -> bool {
+        self.denominator.pow(2) < self.line1.delta().dot_product(self.line2.delta())
+    }
+
+    /// Compute the intersection point.
+    pub fn intersection(&self) -> Intersection {
+        let Self {
+            denominator,
+            le1: line1,
+            le2: line2,
+            ..
+        } = *self;
+
+        // The system of linear equations has no solutions if the determinant is zero. In this case,
+        // the lines must be colinear.
+        if denominator == 0 {
+            return Intersection::Colinear;
+        }
+
+        let outer_side = if denominator > 0 {
+            LineSide::Right
+        } else {
+            LineSide::Left
+        };
+
+        // If we got here, line segments intersect. Compute intersection point using method similar
+        // to that described here: http://paulbourke.net/geometry/pointlineplane/#i2l
+
+        // The denominator/2 is to get rounding instead of truncating.
+        let offset = denominator.abs() / 2;
+
+        let origin_distances = Point::new(line1.origin_distance, line2.origin_distance);
+
+        let numerator =
+            origin_distances.determinant(Point::new(line1.normal_vector.y, line2.normal_vector.y));
+        let x_numerator = if numerator < 0 {
+            numerator - offset
+        } else {
+            numerator + offset
+        };
+
+        let numerator =
+            Point::new(line1.normal_vector.x, line2.normal_vector.x).determinant(origin_distances);
+        let y_numerator = if numerator < 0 {
+            numerator - offset
+        } else {
+            numerator + offset
+        };
+
+        Intersection::Point {
+            point: Point::new(x_numerator, y_numerator) / denominator,
+            outer_side,
+        }
+    }
+}

--- a/src/primitives/line/intersection_params.rs
+++ b/src/primitives/line/intersection_params.rs
@@ -4,21 +4,50 @@ use crate::{
     geometry::{Point, PointExt},
     primitives::{
         common::{LineSide, LinearEquation},
-        line::Intersection,
         Line,
     },
 };
 
+/// Intersection test result.
+#[derive(Copy, Clone, Debug)]
+pub enum Intersection {
+    /// Intersection at point
+    Point {
+        /// Intersection point.
+        point: Point,
+
+        /// The "outer" side of the intersection, i.e. the side that has the joint's reflex angle.
+        ///
+        /// For example:
+        ///
+        /// ```text
+        /// # Left outer side:
+        ///
+        ///  ⎯
+        /// ╱
+        ///
+        /// # Right outer side:
+        ///  │
+        /// ╱
+        /// ```
+        ///
+        /// This is used to find the outside edge of a corner.
+        outer_side: LineSide,
+    },
+
+    /// No intersection: lines are colinear or parallel.
+    Colinear,
+}
 /// Line intersection parameters.
 #[derive(Debug, Copy, Clone)]
-pub(in crate::primitives) struct IntersectionParams<'a> {
+pub struct IntersectionParams<'a> {
     line1: &'a Line,
     line2: &'a Line,
     le1: LinearEquation,
     le2: LinearEquation,
 
     /// Determinant, used to solve linear equations using Cramer's rule.
-    pub denominator: i32,
+    denominator: i32,
 }
 
 impl<'a> IntersectionParams<'a> {

--- a/src/primitives/line/intersection_params.rs
+++ b/src/primitives/line/intersection_params.rs
@@ -11,7 +11,7 @@ use crate::{
 
 /// Line intersection parameters.
 #[derive(Debug, Copy, Clone)]
-pub struct IntersectionParams<'a> {
+pub(in crate::primitives) struct IntersectionParams<'a> {
     line1: &'a Line,
     line2: &'a Line,
     le1: LinearEquation,

--- a/src/primitives/line/mod.rs
+++ b/src/primitives/line/mod.rs
@@ -9,11 +9,8 @@ mod thick_points;
 use crate::{
     geometry::{Dimensions, Point},
     primitives::{
-        common::{LineSide, StrokeOffset},
-        line::{
-            intersection_params::IntersectionParams,
-            thick_points::{ParallelLineType, ParallelsIterator},
-        },
+        common::StrokeOffset,
+        line::thick_points::{ParallelLineType, ParallelsIterator},
         PointsIter, Primitive, Rectangle,
     },
     transform::Transform,
@@ -70,37 +67,6 @@ impl Dimensions for Line {
     fn bounding_box(&self) -> Rectangle {
         Rectangle::with_corners(self.start, self.end)
     }
-}
-
-/// Intersection test result.
-#[derive(Copy, Clone, Debug)]
-pub(in crate::primitives) enum Intersection {
-    /// Intersection at point
-    Point {
-        /// Intersection point.
-        point: Point,
-
-        /// The "outer" side of the intersection, i.e. the side that has the joint's reflex angle.
-        ///
-        /// For example:
-        ///
-        /// ```text
-        /// # Left outer side:
-        ///
-        ///  ⎯
-        /// ╱
-        ///
-        /// # Right outer side:
-        ///  │
-        /// ╱
-        /// ```
-        ///
-        /// This is used to find the outside edge of a corner.
-        outer_side: LineSide,
-    },
-
-    /// No intersection: lines are colinear or parallel.
-    Colinear,
 }
 
 impl Line {
@@ -194,15 +160,6 @@ impl Line {
     /// Compute the delta (`end - start`) of the line.
     pub fn delta(&self) -> Point {
         self.end - self.start
-    }
-
-    /// Integer-only line intersection
-    ///
-    /// Inspired from https://stackoverflow.com/a/61485959/383609, which links to
-    /// https://webdocs.cs.ualberta.ca/~graphics/books/GraphicsGems/gemsii/xlines.c
-    #[allow(unused)]
-    pub(in crate::primitives) fn intersection(&self, other: &Line) -> Intersection {
-        IntersectionParams::from_lines(self, other).intersection()
     }
 }
 

--- a/src/primitives/line/mod.rs
+++ b/src/primitives/line/mod.rs
@@ -74,7 +74,7 @@ impl Dimensions for Line {
 
 /// Intersection test result.
 #[derive(Copy, Clone, Debug)]
-pub enum Intersection {
+pub(in crate::primitives) enum Intersection {
     /// Intersection at point
     Point {
         /// Intersection point.

--- a/src/primitives/line/mod.rs
+++ b/src/primitives/line/mod.rs
@@ -209,6 +209,21 @@ impl Line {
             return Intersection::Colinear;
         }
 
+        let outer_side = if denominator > 0 {
+            LineSide::Right
+        } else {
+            LineSide::Left
+        };
+
+        // Special case: If the two lines are almost parallel, return the average point between
+        // them.
+        if denominator.pow(2) < self.delta().dot_product(other.delta()) {
+            return Intersection::Point {
+                point: (self.end + other.start) / 2,
+                outer_side,
+            };
+        }
+
         // If we got here, line segments intersect. Compute intersection point using method similar
         // to that described here: http://paulbourke.net/geometry/pointlineplane/#i2l
 
@@ -235,11 +250,7 @@ impl Line {
 
         Intersection::Point {
             point: Point::new(x_numerator, y_numerator) / denominator,
-            outer_side: if denominator > 0 {
-                LineSide::Right
-            } else {
-                LineSide::Left
-            },
+            outer_side,
         }
     }
 }

--- a/src/primitives/polyline/styled.rs
+++ b/src/primitives/polyline/styled.rs
@@ -603,4 +603,24 @@ mod tests {
             .draw(&mut display)
             .unwrap();
     }
+
+    #[test]
+    fn issue_471_spurs() {
+        let points = [Point::new(10, 70), Point::new(20, 50), Point::new(31, 30)];
+
+        let line = Polyline::new(&points)
+            .translate(Point::new(0, -15))
+            .into_styled(PrimitiveStyle::with_stroke(Rgb565::RED, 18));
+
+        let bb = line.bounding_box();
+
+        // Check bounding box is correct
+        assert_eq!(bb, Rectangle::new(Point::new(1, 11), Size::new(39, 49)));
+
+        let mut display = MockDisplay::new();
+        line.draw(&mut display).unwrap();
+
+        // Check no pixels are drawn outside bounding box
+        assert_eq!(display.affected_area(), bb);
+    }
 }

--- a/src/primitives/polyline/styled.rs
+++ b/src/primitives/polyline/styled.rs
@@ -623,4 +623,27 @@ mod tests {
         // Check no pixels are drawn outside bounding box
         assert_eq!(display.affected_area(), bb);
     }
+
+    #[test]
+    // FIXME: Un-ignore when more polyline spur fixes are made. This test checks for a smaller
+    // spur created from a different set of points than `issue_471_spurs`.
+    #[ignore]
+    fn issue_471_spurs_2() {
+        let points = [Point::new(13, 65), Point::new(20, 50), Point::new(31, 30)];
+
+        let line = Polyline::new(&points)
+            .translate(Point::new(0, -15))
+            .into_styled(PrimitiveStyle::with_stroke(Rgb565::RED, 18));
+
+        let bb = line.bounding_box();
+
+        // Check bounding box is correct
+        assert_eq!(bb, Rectangle::new(Point::new(4, 26), Size::new(36, 44)));
+
+        let mut display = MockDisplay::new();
+        line.draw(&mut display).unwrap();
+
+        // Check no pixels are drawn outside bounding box
+        assert_eq!(display.affected_area(), bb);
+    }
 }


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Not too happy with this solution, but it fixes the original problem so
at least there's that.

I don't understand the maths behind it at _all_, this just seemed to
work for the cases in #471. Hopefully no other bugs are introduced by
this change.

I'm very open to a better solution, or at least an explanation of why my
fix works.

Closes #471.