### PR TITLE
Add CharacterStyle trait

### DIFF
--- a/core/src/text/character_style.rs
+++ b/core/src/text/character_style.rs
@@ -1,0 +1,44 @@
+use crate::pixelcolor::PixelColor;
+
+/// Character style.
+///
+/// This trait is used to modify character styles programmatically, for example, to implement
+/// rendering of text with multiple colors. Applications shouldn't use this trait and instead use
+/// the character style types that are provided by the text renderer, like [`MonoTextStyle`] and
+/// [`MonoTextStyleBuilder`] for the integrated font support.
+///
+///  # Implementation notes
+///
+/// Text renderers don't need to support all settings in this trait. All calls to unsupported
+/// setters should be ignored by the implementation. The trait provided empty default
+/// implementations for all setters.
+///
+/// [`MonoTextStyle`]: ../mono_font/struct.MonoTextStyle.html
+/// [`MonoTextStyleBuilder`]: ../mono_font/struct.MonoTextStyleBuilder.html
+pub trait CharacterStyle {
+    /// The color type.
+    type Color: PixelColor;
+
+    /// Sets the text color.
+    fn set_text_color(&mut self, _text_color: Option<Self::Color>) {}
+
+    /// Sets the background color.
+    fn set_background_color(&mut self, _background_color: Option<Self::Color>) {}
+
+    /// Sets the underline color.
+    fn set_underline_color(&mut self, _underline_color: DecorationColor<Self::Color>) {}
+
+    /// Sets the strikethrough color.
+    fn set_strikethrough_color(&mut self, _strikethrough_color: DecorationColor<Self::Color>) {}
+}
+
+/// Text decoration color.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub enum DecorationColor<C> {
+    /// No text decoration.
+    None,
+    /// Text decoration with the same color as the text.
+    TextColor,
+    /// Text decoration with a custom color.
+    Custom(C),
+}

--- a/core/src/text/character_style.rs
+++ b/core/src/text/character_style.rs
@@ -4,17 +4,14 @@ use crate::pixelcolor::PixelColor;
 ///
 /// This trait is used to modify character styles programmatically, for example, to implement
 /// rendering of text with multiple colors. Applications shouldn't use this trait and instead use
-/// the character style types that are provided by the text renderer, like [`MonoTextStyle`] and
-/// [`MonoTextStyleBuilder`] for the integrated font support.
+/// the character style types that are provided by the text renderer, like `MonoTextStyle` and
+/// `MonoTextStyleBuilder` for the integrated font support.
 ///
 ///  # Implementation notes
 ///
 /// Text renderers don't need to support all settings in this trait. All calls to unsupported
 /// setters should be ignored by the implementation. The trait provided empty default
 /// implementations for all setters.
-///
-/// [`MonoTextStyle`]: ../mono_font/struct.MonoTextStyle.html
-/// [`MonoTextStyleBuilder`]: ../mono_font/struct.MonoTextStyleBuilder.html
 pub trait CharacterStyle {
     /// The color type.
     type Color: PixelColor;

--- a/core/src/text/mod.rs
+++ b/core/src/text/mod.rs
@@ -4,6 +4,10 @@ use crate::{
     draw_target::DrawTarget, geometry::Point, pixelcolor::PixelColor, primitives::Rectangle,
 };
 
+mod character_style;
+
+pub use character_style::{CharacterStyle, DecorationColor};
+
 /// Text renderer.
 ///
 /// The `TextRenderer` trait is used to integrate text renderers into embedded-graphics. Users should

--- a/src/mono_font/mono_text_style.rs
+++ b/src/mono_font/mono_text_style.rs
@@ -4,7 +4,7 @@ use crate::{
     mono_font::{MonoCharPixels, MonoFont},
     pixelcolor::{BinaryColor, PixelColor},
     primitives::Rectangle,
-    text::{TextMetrics, TextRenderer, VerticalAlignment},
+    text::{CharacterStyle, DecorationColor, TextMetrics, TextRenderer, VerticalAlignment},
     Pixel, SaturatingCast,
 };
 
@@ -243,6 +243,30 @@ where
     }
 }
 
+impl<C, F> CharacterStyle for MonoTextStyle<C, F>
+where
+    C: PixelColor,
+    F: MonoFont,
+{
+    type Color = C;
+
+    fn set_text_color(&mut self, text_color: Option<Self::Color>) {
+        self.text_color = text_color;
+    }
+
+    fn set_background_color(&mut self, background_color: Option<Self::Color>) {
+        self.background_color = background_color;
+    }
+
+    fn set_underline_color(&mut self, underline_color: DecorationColor<Self::Color>) {
+        self.underline_color = underline_color;
+    }
+
+    fn set_strikethrough_color(&mut self, strikethrough_color: DecorationColor<Self::Color>) {
+        self.strikethrough_color = strikethrough_color;
+    }
+}
+
 /// Text style builder for monospaced fonts.
 ///
 /// Use this builder to create [`MonoTextStyle`]s for [`Text`].
@@ -427,14 +451,6 @@ where
 /// Marker type to improve compiler errors if no font was set in builder.
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct UndefinedFont;
-
-/// Text decoration color.
-#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
-pub enum DecorationColor<C> {
-    None,
-    TextColor,
-    Custom(C),
-}
 
 #[cfg(test)]
 mod tests {
@@ -830,5 +846,28 @@ mod tests {
             .unwrap();
 
         display.assert_eq(&expected);
+    }
+
+    #[test]
+    fn character_style() {
+        let mut style = MonoTextStyle::new(Font6x8, BinaryColor::On);
+        CharacterStyle::set_text_color(&mut style, None);
+        CharacterStyle::set_background_color(&mut style, Some(BinaryColor::On));
+        CharacterStyle::set_underline_color(&mut style, DecorationColor::TextColor);
+        CharacterStyle::set_strikethrough_color(
+            &mut style,
+            DecorationColor::Custom(BinaryColor::On),
+        );
+
+        assert_eq!(
+            style,
+            MonoTextStyle {
+                text_color: None,
+                background_color: Some(BinaryColor::On),
+                underline_color: DecorationColor::TextColor,
+                strikethrough_color: DecorationColor::Custom(BinaryColor::On),
+                font: Font6x8,
+            }
+        );
     }
 }

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -4,7 +4,8 @@ mod text;
 mod text_style;
 
 pub use embedded_graphics_core::text::{
-    HorizontalAlignment, TextMetrics, TextRenderer, VerticalAlignment,
+    CharacterStyle, DecorationColor, HorizontalAlignment, TextMetrics, TextRenderer,
+    VerticalAlignment,
 };
 pub use text::Text;
 pub use text_style::{TextStyle, TextStyleBuilder};

--- a/src/text/text_style.rs
+++ b/src/text/text_style.rs
@@ -1,3 +1,5 @@
+use embedded_graphics_core::text::CharacterStyle;
+
 use crate::text::{HorizontalAlignment, TextRenderer, VerticalAlignment};
 
 /// Text style.
@@ -63,7 +65,7 @@ impl<S> TextStyleBuilder<S> {
 
 impl<S> TextStyleBuilder<S>
 where
-    S: TextRenderer,
+    S: CharacterStyle + TextRenderer,
 {
     /// Builds the text style.
     pub fn build(self) -> TextStyle<S> {


### PR DESCRIPTION
This PR adds the `CharacterStyle` trait that was discussed in https://github.com/embedded-graphics/embedded-text/pull/90#discussion_r555892950. @bugadani should be able to use it to make SGRs in e-t work independent of the renderer.
