### PR TITLE
Rename iterator adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - **(breaking)** [#523](https://github.com/embedded-graphics/embedded-graphics/pull/523) The vertical and horizontal alignment of `Text` objects must now be set using the new `TextStyle` struct.
 - **(breaking)** [#535](https://github.com/embedded-graphics/embedded-graphics/pull/535) Replaced the builtin fonts with new fonts, that are generated from BDF files.
 - **(breaking)** [#538](https://github.com/embedded-graphics/embedded-graphics/pull/538) The types inside the `style` module were moved to other locations and the module itself has been removed.
-- **(breaking)** [#540](https://github.com/embedded-graphics/embedded-graphics/pull/540) Renamed `iterator::pixel::Translate` to `Translated`.
+- **(breaking)** [#540](https://github.com/embedded-graphics/embedded-graphics/pull/540) Renamed the `iterator::pixel::Translate` struct to `Translated`and the `translate` method in `PixelIteratorExt` to `translated`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - **(breaking)** [#523](https://github.com/embedded-graphics/embedded-graphics/pull/523) The vertical and horizontal alignment of `Text` objects must now be set using the new `TextStyle` struct.
 - **(breaking)** [#535](https://github.com/embedded-graphics/embedded-graphics/pull/535) Replaced the builtin fonts with new fonts, that are generated from BDF files.
 - **(breaking)** [#538](https://github.com/embedded-graphics/embedded-graphics/pull/538) The types inside the `style` module were moved to other locations and the module itself has been removed.
+- **(breaking)** [#540](https://github.com/embedded-graphics/embedded-graphics/pull/540) Renamed `iterator::pixel::Translate` to `Translated`.
 
 ### Removed
 

--- a/src/draw_target/clipped.rs
+++ b/src/draw_target/clipped.rs
@@ -1,5 +1,5 @@
 use crate::{
-    draw_target::DrawTarget, geometry::Dimensions, iterator::contiguous::Crop,
+    draw_target::DrawTarget, geometry::Dimensions, iterator::contiguous::Cropped,
     primitives::Rectangle, transform::Transform, Pixel,
 };
 
@@ -60,7 +60,7 @@ where
             self.parent.fill_contiguous(area, colors)
         } else {
             let crop_area = intersection.translate(-area.top_left);
-            let cropped = Crop::new(colors.into_iter(), area.size, &crop_area);
+            let cropped = Cropped::new(colors.into_iter(), area.size, &crop_area);
             self.parent.fill_contiguous(&intersection, cropped)
         }
     }

--- a/src/draw_target/translated.rs
+++ b/src/draw_target/translated.rs
@@ -44,7 +44,7 @@ where
         I: IntoIterator<Item = Pixel<Self::Color>>,
     {
         self.parent
-            .draw_iter(pixels.into_iter().translate(self.offset))
+            .draw_iter(pixels.into_iter().translated(self.offset))
     }
 
     fn fill_contiguous<I>(&mut self, area: &Rectangle, colors: I) -> Result<(), Self::Error>

--- a/src/iterator/contiguous.rs
+++ b/src/iterator/contiguous.rs
@@ -44,7 +44,7 @@ where
 
 /// Crops a part of the underlying iterator.
 #[derive(Debug)]
-pub(crate) struct Crop<I>
+pub(crate) struct Cropped<I>
 where
     I: Iterator,
     I::Item: PixelColor,
@@ -57,7 +57,7 @@ where
     row_skip: usize,
 }
 
-impl<I> Crop<I>
+impl<I> Cropped<I>
 where
     I: Iterator,
     I::Item: PixelColor,
@@ -82,7 +82,7 @@ where
     }
 }
 
-impl<I> Iterator for Crop<I>
+impl<I> Iterator for Cropped<I>
 where
     I: Iterator,
     I::Item: PixelColor,
@@ -117,13 +117,13 @@ mod tests {
     use crate::pixelcolor::Gray8;
 
     #[test]
-    fn crop() {
+    fn cropped() {
         let parent = (0..=255).map(Gray8::new);
         let parent_size = Size::new(16, 16);
 
         let crop_area = Rectangle::new(Point::new(2, 3), Size::new(4, 3));
 
-        let mut cropped_iter = Crop::new(parent, parent_size, &crop_area);
+        let mut cropped_iter = Cropped::new(parent, parent_size, &crop_area);
 
         let expected = &[
             50, 51, 52, 53, //
@@ -138,25 +138,25 @@ mod tests {
     }
 
     #[test]
-    fn crop_empty() {
+    fn cropped_empty() {
         let parent = (0..=255).map(Gray8::new);
         let parent_size = Size::new(16, 16);
 
         let crop_area = Rectangle::zero();
 
-        let mut cropped_iter = Crop::new(parent, parent_size, &crop_area);
+        let mut cropped_iter = Cropped::new(parent, parent_size, &crop_area);
 
         assert_eq!(cropped_iter.next(), None);
     }
 
     #[test]
-    fn crop_overlapping() {
+    fn cropped_overlapping() {
         let parent = (0..=255).map(Gray8::new);
         let parent_size = Size::new(16, 16);
 
         let crop_area = Rectangle::new(Point::new(14, 10), Size::new(4, 4));
 
-        let mut cropped_iter = Crop::new(parent, parent_size, &crop_area);
+        let mut cropped_iter = Cropped::new(parent, parent_size, &crop_area);
 
         let expected = &[
             174, 175, //

--- a/src/iterator/mod.rs
+++ b/src/iterator/mod.rs
@@ -57,7 +57,7 @@ where
         D: DrawTarget<Color = C>;
 
     /// Returns a translated version of the iterator.
-    fn translate(self, offset: Point) -> pixel::Translate<Self>;
+    fn translated(self, offset: Point) -> pixel::Translated<Self>;
 }
 
 impl<I, C> PixelIteratorExt<C> for I
@@ -72,8 +72,8 @@ where
         target.draw_iter(self)
     }
 
-    fn translate(self, offset: Point) -> pixel::Translate<Self> {
-        pixel::Translate::new(self, offset)
+    fn translated(self, offset: Point) -> pixel::Translated<Self> {
+        pixel::Translated::new(self, offset)
     }
 }
 

--- a/src/iterator/pixel.rs
+++ b/src/iterator/pixel.rs
@@ -4,12 +4,12 @@ use crate::{geometry::Point, pixelcolor::PixelColor, Pixel};
 
 /// Translated pixel iterator.
 #[derive(Debug, PartialEq)]
-pub struct Translate<I> {
+pub struct Translated<I> {
     iter: I,
     offset: Point,
 }
 
-impl<I, C> Translate<I>
+impl<I, C> Translated<I>
 where
     I: Iterator<Item = Pixel<C>>,
     C: PixelColor,
@@ -19,7 +19,7 @@ where
     }
 }
 
-impl<I, C> Iterator for Translate<I>
+impl<I, C> Iterator for Translated<I>
 where
     I: Iterator<Item = Pixel<C>>,
     C: PixelColor,
@@ -54,6 +54,6 @@ mod tests {
         ];
         let expected = expected.iter().copied();
 
-        assert!(pixels.translate(Point::new(4, 5)).eq(expected));
+        assert!(pixels.translated(Point::new(4, 5)).eq(expected));
     }
 }


### PR DESCRIPTION
This PR renames the iterator adapters to match the naming convention for the draw target adapters.

Closes #529
