### PR TITLE
Fix dependent version on core release

### DIFF
--- a/justfile
+++ b/justfile
@@ -128,8 +128,8 @@ push-ci-image:
 # -------
 # Release embedded-graphics-core
 release-core *args:
-    cargo release --workspace --exclude embedded-graphics {{args}}
+    cargo release --workspace --exclude embedded-graphics --dependent-version fix {{args}}
 
 # Release embedded-graphics
 release-e-g *args:
-    cargo release --package embedded-graphics {{args}}
+    cargo release --package embedded-graphics --dependent-version fix {{args}}


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Fixes `just release-core [ver]` command - it was previously not reading `[ver]` and would try to release the current version. I believe this is caused by it not being able to update the version in `e-g`, which `--dependent-version fix` allows it to do.

`cargo-release` is great... when it works :(
