### PR TITLE
CharacterStyle: Add Clone supertrait

### DIFF
--- a/core/src/text/character_style.rs
+++ b/core/src/text/character_style.rs
@@ -12,7 +12,7 @@ use crate::pixelcolor::PixelColor;
 /// Text renderers don't need to support all settings in this trait. All calls to unsupported
 /// setters should be ignored by the implementation. The trait provided empty default
 /// implementations for all setters.
-pub trait CharacterStyle {
+pub trait CharacterStyle: Clone {
     /// The color type.
     type Color: PixelColor;
 


### PR DESCRIPTION
This change would ensure that all text renderers can be used with embedded-text.

e-t requires `CharacterStyle: Clone` because ANSI escape sequence support can change various style options during rendering, where otherwise the style is only accessable through a shared (immutable) reference. While current renderers are all `Clone`, it's possible to create new ones that aren't, which would in turn be incompatible with embedded-text.