### PR TITLE
Use released version of bdf-parser

### DIFF
--- a/tools/bdf-to-mono/Cargo.toml
+++ b/tools/bdf-to-mono/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.38"
-bdf-parser = { git = "https://github.com/embedded-graphics/embedded-bdf", rev = "ab27a8bcedcfbeb8125bea5d76b5038ba40d1f14" }
+bdf-parser = { version = "0.1.0" }

--- a/tools/convert-fonts/Cargo.toml
+++ b/tools/convert-fonts/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 anyhow = "1.0.38"
 bdf-to-mono = { path = "../bdf-to-mono" }
 image = { version = "0.23.12", default-features = false, features = ["png"] }
-bdf-parser = { git = "https://github.com/embedded-graphics/embedded-bdf", rev = "ab27a8bcedcfbeb8125bea5d76b5038ba40d1f14" }
+bdf-parser = { version = "0.1.0" }
 base64 = "0.13.0"

--- a/tools/convert-fonts/src/main.rs
+++ b/tools/convert-fonts/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use bdf_parser::BdfFont;
 use bdf_to_mono::{bdf_to_bitmap, Bitmap, Encoding};
 use image::{png::PngEncoder, ColorType, GrayImage, Luma};
-use std::{ffi::OsStr, fs, path::Path, str::FromStr};
+use std::{ffi::OsStr, fs, path::Path};
 
 fn main() -> Result<()> {
     let fonts_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../fonts");
@@ -28,8 +28,8 @@ fn main() -> Result<()> {
             .replace("B", "Bold")
             .replace("O", "Italic");
 
-        let bdf = fs::read_to_string(&file.path())?;
-        let font = BdfFont::from_str(&bdf).map_err(|_| anyhow!("couldn't parse BDF file"))?;
+        let bdf = fs::read(&file.path())?;
+        let font = BdfFont::parse(&bdf).map_err(|_| anyhow!("couldn't parse BDF file"))?;
 
         let ascii_out = Output::new(&font_name, &font, Encoding::Ascii)?;
         let latin1_out = Output::new(&font_name, &font, Encoding::Latin1)?;

--- a/tools/generate-drawing-examples/Cargo.toml
+++ b/tools/generate-drawing-examples/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 # TODO: change to path dependency after next simulator release
 # embedded-graphics = { path = "../../" }
-embedded-graphics = { version = "=0.7.0-alpha.2" }
+embedded-graphics = { version = "=0.7.0-alpha.3" }
 tinytga = "0.4.0-alpha.1"
 
 # TODO: replace by non git dependency after next simulator release


### PR DESCRIPTION
This PR changes the `bdf-parser` dependencies in the tools directory to a non git dependencies.