### PR TITLE
Rename text alignment settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- **(breaking)** [#561](https://github.com/embedded-graphics/embedded-graphics/pull/561) Renamed `HorizontalAlignment` and `VerticalAlignment` to `Alignment` and `Baseline`.
+- **(breaking)** [#561](https://github.com/embedded-graphics/embedded-graphics/pull/561) Replaced `TextRenderer::vertical_offset` by `baseline` arguments for the other `TextRenderer` methods.
+
 ## [0.7.0-alpha.3] - 2021-02-03
 
 ### Added

--- a/core/src/text/mod.rs
+++ b/core/src/text/mod.rs
@@ -18,10 +18,6 @@ pub trait TextRenderer {
 
     /// Draws a string.
     ///
-    /// The interpretation of the y coordinate of `position` is dependent on the implementation and
-    /// can, for example, be the top edge of the bounding box or a point on the baseline. The
-    /// caller must ensure that the coordinate is first converted with the `vertical_offset` method.
-    ///
     /// The method returns the start position of the next character to allow chaining of multiple
     /// draw calls.
     ///
@@ -34,6 +30,7 @@ pub trait TextRenderer {
         &self,
         text: &str,
         position: Point,
+        baseline: Baseline,
         target: &mut D,
     ) -> Result<Point, D::Error>
     where
@@ -41,16 +38,13 @@ pub trait TextRenderer {
 
     /// Draws whitespace of the given width.
     ///
-    /// The interpretation of the y coordinate of `position` is dependent on the implementation and
-    /// can, for example, be the top edge of the bounding box or a point on the baseline. The
-    /// caller must ensure that the coordinate is first converted with the `vertical_offset` method.
-    ///
     /// The method returns the start position of the next character to allow chaining of multiple
     /// draw calls.
     fn draw_whitespace<D>(
         &self,
         width: u32,
         position: Point,
+        baseline: Baseline,
         target: &mut D,
     ) -> Result<Point, D::Error>
     where
@@ -58,23 +52,19 @@ pub trait TextRenderer {
 
     /// Returns the text metrics for a string.
     ///
-    /// The interpretation of the y coordinate of `position` is dependent on the implementation and
-    /// can, for example, be the top edge of the bounding box or a point on the baseline. The
-    /// caller must ensure that the coordinate is first converted with the `vertical_offset` method.
-    ///
-    /// The returned bounding box is zero sized, if the text is completely transparent.
-    ///
     /// # Implementation notes
+    ///
+    /// The returned bounding box must be independent of the text color. This is different to the
+    /// `Dimensions` trait, which should return a zero sized bounding box for completely transparent
+    /// drawables. But this behavior would make it impossible to correctly layout text which
+    /// contains a mixture of transparent and non transparent words.
     ///
     /// This method must not interpret any control characters and only render a single line of text.
     /// Any control character in the `text` should be handled the same way as any other character
     /// that isn't included in the font.
-    fn measure_string(&self, text: &str, position: Point) -> TextMetrics;
+    fn measure_string(&self, text: &str, position: Point, baseline: Baseline) -> TextMetrics;
 
-    /// Offsets the point to apply the vertical alignment.
-    fn vertical_offset(&self, position: Point, vertical_alignment: VerticalAlignment) -> Point;
-
-    /// Returns the line height.
+    /// Returns the default line height.
     ///
     /// The line height is defined as the vertical distance between the baseline of two adjacent
     /// lines in pixels.
@@ -95,22 +85,22 @@ pub struct TextMetrics {
     pub next_position: Point,
 }
 
-/// Vertical text alignment.
+/// Text baseline.
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
-pub enum VerticalAlignment {
+pub enum Baseline {
     /// Top.
     Top,
     /// Bottom.
     Bottom,
-    /// Center.
-    Center,
-    /// Baseline.
-    Baseline,
+    /// Middle.
+    Middle,
+    /// Alphabetic baseline.
+    Alphabetic,
 }
 
 /// Horizontal text alignment.
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
-pub enum HorizontalAlignment {
+pub enum Alignment {
     /// Left.
     Left,
     /// Center.

--- a/src/mono_font/mod.rs
+++ b/src/mono_font/mod.rs
@@ -187,7 +187,7 @@ pub(crate) mod tests {
         mock_display::MockDisplay,
         mono_font::MonoTextStyleBuilder,
         pixelcolor::BinaryColor,
-        text::{Text, TextStyleBuilder, VerticalAlignment},
+        text::{Baseline, Text, TextStyleBuilder},
         Drawable,
     };
 
@@ -205,7 +205,7 @@ pub(crate) mod tests {
 
         let text_style = TextStyleBuilder::new()
             .character_style(character_style)
-            .vertical_alignment(VerticalAlignment::Top)
+            .baseline(Baseline::Top)
             .build();
 
         let mut display = MockDisplay::new();
@@ -231,7 +231,7 @@ pub(crate) mod tests {
 
         let text_style = TextStyleBuilder::new()
             .character_style(character_style)
-            .vertical_alignment(VerticalAlignment::Top)
+            .baseline(Baseline::Top)
             .build();
 
         // Draw 'A' character to determine it's baseline

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -4,8 +4,7 @@ mod text;
 mod text_style;
 
 pub use embedded_graphics_core::text::{
-    CharacterStyle, DecorationColor, HorizontalAlignment, TextMetrics, TextRenderer,
-    VerticalAlignment,
+    Alignment, Baseline, CharacterStyle, DecorationColor, TextMetrics, TextRenderer,
 };
 pub use text::Text;
 pub use text_style::{TextStyle, TextStyleBuilder};

--- a/src/text/text_style.rs
+++ b/src/text/text_style.rs
@@ -1,6 +1,6 @@
 use embedded_graphics_core::text::CharacterStyle;
 
-use crate::text::{HorizontalAlignment, TextRenderer, VerticalAlignment};
+use crate::text::{Alignment, Baseline, TextRenderer};
 
 /// Text style.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -8,11 +8,11 @@ pub struct TextStyle<S> {
     /// Character style.
     pub character_style: S,
 
-    /// Horizontal alignment.
-    pub horizontal_alignment: HorizontalAlignment,
+    /// Horizontal text alignment.
+    pub alignment: Alignment,
 
-    /// Vertical alignment.
-    pub vertical_alignment: VerticalAlignment,
+    /// Text baseline.
+    pub baseline: Baseline,
 }
 
 impl<S> TextStyle<S> {}
@@ -29,24 +29,24 @@ impl TextStyleBuilder<UndefinedCharacterStyle> {
         Self {
             style: TextStyle {
                 character_style: UndefinedCharacterStyle,
-                horizontal_alignment: HorizontalAlignment::Left,
-                vertical_alignment: VerticalAlignment::Baseline,
+                alignment: Alignment::Left,
+                baseline: Baseline::Alphabetic,
             },
         }
     }
 }
 
 impl<S> TextStyleBuilder<S> {
-    /// Sets the horizontal alignment.
-    pub fn horizontal_alignment(mut self, horizontal_alignment: HorizontalAlignment) -> Self {
-        self.style.horizontal_alignment = horizontal_alignment;
+    /// Sets the horizontal text alignment.
+    pub fn alignment(mut self, alignment: Alignment) -> Self {
+        self.style.alignment = alignment;
 
         self
     }
 
-    /// Sets the vertical alignment.
-    pub fn vertical_alignment(mut self, vertical_alignment: VerticalAlignment) -> Self {
-        self.style.vertical_alignment = vertical_alignment;
+    /// Sets the text baseline.
+    pub fn baseline(mut self, baseline: Baseline) -> Self {
+        self.style.baseline = baseline;
 
         self
     }
@@ -56,8 +56,8 @@ impl<S> TextStyleBuilder<S> {
         TextStyleBuilder {
             style: TextStyle {
                 character_style,
-                horizontal_alignment: self.style.horizontal_alignment,
-                vertical_alignment: self.style.vertical_alignment,
+                alignment: self.style.alignment,
+                baseline: self.style.baseline,
             },
         }
     }
@@ -95,11 +95,11 @@ mod tests {
 
         let text_style = TextStyleBuilder::new()
             .character_style(character_style)
-            .horizontal_alignment(HorizontalAlignment::Right)
-            .vertical_alignment(VerticalAlignment::Top)
+            .alignment(Alignment::Right)
+            .baseline(Baseline::Top)
             .build();
 
-        assert_eq!(text_style.horizontal_alignment, HorizontalAlignment::Right);
-        assert_eq!(text_style.vertical_alignment, VerticalAlignment::Top);
+        assert_eq!(text_style.alignment, Alignment::Right);
+        assert_eq!(text_style.baseline, Baseline::Top);
     }
 }


### PR DESCRIPTION
This PR changes the names of the `HorizontalAlignment` and `VerticalAlignment` enums to `Alignment` and `Baseline`. The reason for this change is that `VerticalAlignment` might be misleading, because the vertical alignment does only apply to the first line of multiline text:
![Bildschirmfoto von 2021-03-04 18-19-46](https://user-images.githubusercontent.com/226123/110003001-41b3ff80-7d16-11eb-9db6-2126b40b0351.png)
The text on the left is the actual result for `Baseline::Middle` and the right is an example of what users might expect for `VerticalAlignment::Center`. This also matches the names used in the HTML5 canvas API: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/textBaseline, https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/textAlign

The PR also included some tweaks to the `TextRenderer` trait. I've removed the `vertical_offset` method, which was intended as a performance optimization. The potential grain of saving a few additions and subtractions  per text object isn't worth having an more error prone API.