### PR TITLE
Always take stroke_width into account for bounding boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,18 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- **(breaking)** [#552](https://github.com/embedded-graphics/embedded-graphics/pull/552) Added the `Output` associated type to `Drawable` to allow returning non-`()` values from drawing operations.
+- [#563](https://github.com/embedded-graphics/embedded-graphics/pull/563) Added `is_none`, `is_text_color` and `is_custom` methods to `DecorationColor`.
+- [#563](https://github.com/embedded-graphics/embedded-graphics/pull/563) Added `is_transparent` methods to `PrimitiveStyle` and `MonoTextStyle`.
+
 ### Changed
 
 - **(breaking)** [#561](https://github.com/embedded-graphics/embedded-graphics/pull/561) Renamed `HorizontalAlignment` and `VerticalAlignment` to `Alignment` and `Baseline`.
 - **(breaking)** [#561](https://github.com/embedded-graphics/embedded-graphics/pull/561) Replaced `TextRenderer::vertical_offset` by `baseline` arguments for the other `TextRenderer` methods.
+- **(breaking)** [#563](https://github.com/embedded-graphics/embedded-graphics/pull/563) The bounding boxes returned by `Dimensions` implementations for styled primitives no longer depend on the fill and stroke color.
+- **(breaking)** [#563](https://github.com/embedded-graphics/embedded-graphics/pull/563) Drawing a primitive with a transparent stroke (`stroke_color == None && stroke_width > 0`) will now reduce the filled area.
 
 ## [0.7.0-alpha.3] - 2021-02-03
 

--- a/MIGRATING-0.6-0.7.md
+++ b/MIGRATING-0.6-0.7.md
@@ -237,6 +237,11 @@ For example, a styled rectangle is now built like this:
 
 ## Primitives
 
+### Styling
+
+TODO: Drawing primitives with transparent strokes will now affect the fill area.
+TODO: The behavior of the `Dimensions` impls has changed
+
 ### Circle
 
 A circle is now defined by it's top-left corner and diameter.

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Added
 
 - **(breaking)** [#552](https://github.com/embedded-graphics/embedded-graphics/pull/552) Added the `Output` associated type to `Drawable` to allow returning non-`()` values from drawing operations.
+- [#563](https://github.com/embedded-graphics/embedded-graphics/pull/563) Added `is_none`, `is_text_color` and `is_custom` methods to `DecorationColor`.
 
 ## [0.2.0] - 2021-02-03
 

--- a/core/src/text/character_style.rs
+++ b/core/src/text/character_style.rs
@@ -39,3 +39,56 @@ pub enum DecorationColor<C> {
     /// Text decoration with a custom color.
     Custom(C),
 }
+
+impl<C> DecorationColor<C> {
+    /// Returns `true` if the decoration_color is `None`.
+    pub fn is_none(&self) -> bool {
+        // MSRV: replace with matches! for rust >= 1.42.0
+        match self {
+            Self::None => true,
+            _ => false,
+        }
+    }
+
+    /// Returns `true` if the decoration_color is `TextColor`.
+    pub fn is_text_color(&self) -> bool {
+        // MSRV: replace with matches! for rust >= 1.42.0
+        match self {
+            Self::TextColor => true,
+            _ => false,
+        }
+    }
+
+    /// Returns `true` if the decoration_color is `Custom`.
+    pub fn is_custom(&self) -> bool {
+        // MSRV: replace with matches! for rust >= 1.42.0
+        match self {
+            Self::Custom(_) => true,
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pixelcolor::BinaryColor;
+
+    #[test]
+    fn decoration_color_is_methods() {
+        let none = DecorationColor::<BinaryColor>::None;
+        assert!(none.is_none());
+        assert!(!none.is_text_color());
+        assert!(!none.is_custom());
+
+        let text_color = DecorationColor::<BinaryColor>::TextColor;
+        assert!(!text_color.is_none());
+        assert!(text_color.is_text_color());
+        assert!(!text_color.is_custom());
+
+        let custom = DecorationColor::Custom(BinaryColor::On);
+        assert!(!custom.is_none());
+        assert!(!custom.is_text_color());
+        assert!(custom.is_custom());
+    }
+}

--- a/src/mono_font/mono_text_style.rs
+++ b/src/mono_font/mono_text_style.rs
@@ -53,6 +53,18 @@ where
             .build()
     }
 
+    /// Returns `true` if the style is transparent.
+    ///
+    /// Drawing a `Text` with a transparent `MonoTextStyle` will not draw any pixels.
+    ///
+    /// [`Text`]: ../text/struct.Text.html
+    pub fn is_transparent(&self) -> bool {
+        self.text_color.is_none()
+            && self.background_color.is_none()
+            && self.underline_color.is_none()
+            && self.strikethrough_color.is_none()
+    }
+
     /// Resolves a decoration color.
     fn resolve_decoration_color(&self, color: DecorationColor<C>) -> Option<C> {
         match color {

--- a/src/primitives/circle/styled.rs
+++ b/src/primitives/circle/styled.rs
@@ -1,6 +1,6 @@
 use crate::{
     draw_target::DrawTarget,
-    geometry::{Dimensions, Size},
+    geometry::Dimensions,
     iterator::IntoPixels,
     pixelcolor::PixelColor,
     primitives::{
@@ -107,13 +107,9 @@ where
     C: PixelColor,
 {
     fn bounding_box(&self) -> Rectangle {
-        if !self.style.is_transparent() {
-            let offset = self.style.outside_stroke_width().saturating_cast();
+        let offset = self.style.outside_stroke_width().saturating_cast();
 
-            self.primitive.bounding_box().offset(offset)
-        } else {
-            Rectangle::new(self.primitive.center(), Size::zero())
-        }
+        self.primitive.bounding_box().offset(offset)
     }
 }
 
@@ -139,25 +135,6 @@ mod tests {
             .map(|Pixel(p, _)| p);
 
         assert!(circle.points().eq(styled_points));
-    }
-
-    #[test]
-    fn stroke_width_doesnt_affect_fill() {
-        let mut expected = MockDisplay::new();
-        let mut style = PrimitiveStyle::with_fill(BinaryColor::On);
-        Circle::new(Point::new(5, 5), 4)
-            .into_styled(style)
-            .draw(&mut expected)
-            .unwrap();
-
-        let mut with_stroke_width = MockDisplay::new();
-        style.stroke_width = 1;
-        Circle::new(Point::new(5, 5), 4)
-            .into_styled(style)
-            .draw(&mut with_stroke_width)
-            .unwrap();
-
-        with_stroke_width.assert_eq(&expected);
     }
 
     // Check that tiny circles render as a "+" shape with a hole in the center
@@ -320,13 +297,15 @@ mod tests {
     }
 
     #[test]
-    fn transparent_bounding_box() {
-        let circle =
+    fn bounding_box_is_independent_of_colors() {
+        let transparent_circle =
             Circle::new(Point::new(5, 5), 11).into_styled::<BinaryColor>(PrimitiveStyle::new());
+        let filled_circle = Circle::new(Point::new(5, 5), 11)
+            .into_styled(PrimitiveStyle::with_fill(BinaryColor::On));
 
         assert_eq!(
-            circle.bounding_box(),
-            Rectangle::new(circle.primitive.center(), Size::zero())
+            transparent_circle.bounding_box(),
+            filled_circle.bounding_box(),
         );
     }
 }

--- a/src/primitives/ellipse/styled.rs
+++ b/src/primitives/ellipse/styled.rs
@@ -111,13 +111,9 @@ where
     C: PixelColor,
 {
     fn bounding_box(&self) -> Rectangle {
-        if !self.style.is_transparent() {
-            let offset = self.style.outside_stroke_width().saturating_cast();
+        let offset = self.style.outside_stroke_width().saturating_cast();
 
-            self.primitive.bounding_box().offset(offset)
-        } else {
-            Rectangle::new(self.primitive.center(), Size::zero())
-        }
+        self.primitive.bounding_box().offset(offset)
     }
 }
 
@@ -343,13 +339,15 @@ mod tests {
     }
 
     #[test]
-    fn transparent_bounding_box() {
-        let ellipse = Ellipse::new(Point::new(5, 5), Size::new(11, 14))
+    fn bounding_box_is_independent_of_colors() {
+        let transparent_ellipse = Ellipse::new(Point::new(5, 5), Size::new(11, 14))
             .into_styled::<BinaryColor>(PrimitiveStyle::new());
+        let filled_ellipse = Ellipse::new(Point::new(5, 5), Size::new(11, 14))
+            .into_styled(PrimitiveStyle::with_fill(BinaryColor::On));
 
         assert_eq!(
-            ellipse.bounding_box(),
-            Rectangle::new(ellipse.primitive.center(), Size::zero())
+            transparent_ellipse.bounding_box(),
+            filled_ellipse.bounding_box(),
         );
     }
 }

--- a/src/primitives/line/styled.rs
+++ b/src/primitives/line/styled.rs
@@ -1,6 +1,6 @@
 use crate::{
     draw_target::DrawTarget,
-    geometry::{Dimensions, Size},
+    geometry::Dimensions,
     iterator::IntoPixels,
     pixelcolor::PixelColor,
     primitives::{
@@ -88,26 +88,22 @@ where
     C: PixelColor,
 {
     fn bounding_box(&self) -> Rectangle {
-        if self.style.effective_stroke_color().is_some() {
-            let (l, r) = self
-                .primitive
-                .extents(self.style.stroke_width, StrokeOffset::None);
+        let (l, r) = self
+            .primitive
+            .extents(self.style.stroke_width, StrokeOffset::None);
 
-            let min = l
-                .start
-                .component_min(l.end)
-                .component_min(r.start)
-                .component_min(r.end);
-            let max = l
-                .start
-                .component_max(l.end)
-                .component_max(r.start)
-                .component_max(r.end);
+        let min = l
+            .start
+            .component_min(l.end)
+            .component_min(r.start)
+            .component_min(r.end);
+        let max = l
+            .start
+            .component_max(l.end)
+            .component_max(r.start)
+            .component_max(r.end);
 
-            Rectangle::with_corners(min, max)
-        } else {
-            Rectangle::new(self.primitive.bounding_box().center(), Size::zero())
-        }
+        Rectangle::with_corners(min, max)
     }
 }
 
@@ -115,10 +111,10 @@ where
 mod tests {
     use super::*;
     use crate::{
-        geometry::{Point, Size},
+        geometry::Point,
         mock_display::MockDisplay,
         pixelcolor::{Rgb888, RgbColor},
-        primitives::{Primitive, Rectangle},
+        primitives::{Primitive, PrimitiveStyleBuilder},
     };
 
     #[test]
@@ -166,20 +162,13 @@ mod tests {
     }
 
     #[test]
-    fn transparent_bounding_box() {
+    fn bounding_box_is_independent_of_colors() {
         let line = Line::new(Point::new(5, 5), Point::new(11, 14));
 
-        assert_eq!(
-            line.into_styled::<Rgb888>(PrimitiveStyle::new())
-                .bounding_box(),
-            Rectangle::new(line.bounding_box().center(), Size::zero())
-        );
+        let transparent_line =
+            line.into_styled::<Rgb888>(PrimitiveStyleBuilder::new().stroke_width(10).build());
+        let stroked_line = line.into_styled(PrimitiveStyle::with_stroke(Rgb888::RED, 10));
 
-        assert_eq!(
-            line.into_styled::<Rgb888>(PrimitiveStyle::with_fill(Rgb888::RED))
-                .bounding_box(),
-            Rectangle::new(line.bounding_box().center(), Size::zero()),
-            "filled"
-        );
+        assert_eq!(transparent_line.bounding_box(), stroked_line.bounding_box(),);
     }
 }

--- a/src/primitives/polyline/styled.rs
+++ b/src/primitives/polyline/styled.rs
@@ -511,8 +511,12 @@ mod tests {
         assert_eq!(display.affected_area(), styled.bounding_box());
 
         assert_eq!(
-            pl.into_styled(PrimitiveStyle::<Rgb565>::new())
-                .bounding_box(),
+            pl.into_styled(
+                PrimitiveStyleBuilder::<Rgb565>::new()
+                    .stroke_width(5)
+                    .build()
+            )
+            .bounding_box(),
             Rectangle::new(pl.bounding_box().center(), Size::zero()),
             "transparent"
         );

--- a/src/primitives/primitive_style.rs
+++ b/src/primitives/primitive_style.rs
@@ -78,12 +78,7 @@ where
     /// Returns the stroke width on the outside of the shape.
     ///
     /// The outside stroke width is determined by `stroke_width` and `stroke_alignment`.
-    /// If `stroke_color` is `None` the outside stroke width is always `0`.
     pub(crate) fn outside_stroke_width(&self) -> u32 {
-        if self.stroke_color.is_none() {
-            return 0;
-        }
-
         match self.stroke_alignment {
             StrokeAlignment::Inside => 0,
             StrokeAlignment::Center => self.stroke_width / 2,
@@ -94,12 +89,7 @@ where
     /// Returns the stroke width on the inside of the shape.
     ///
     /// The inside stroke width is determined by `stroke_width` and `stroke_alignment`.
-    /// If `stroke_color` is `None` the inside stroke width is always `0`.
     pub(crate) fn inside_stroke_width(&self) -> u32 {
-        if self.stroke_color.is_none() {
-            return 0;
-        }
-
         match self.stroke_alignment {
             StrokeAlignment::Inside => self.stroke_width,
             StrokeAlignment::Center => self.stroke_width.saturating_add(1) / 2,
@@ -108,7 +98,7 @@ where
     }
 
     /// Returns if a primitive drawn with this style is completely transparent.
-    pub(crate) fn is_transparent(&self) -> bool {
+    pub fn is_transparent(&self) -> bool {
         (self.stroke_color.is_none() || self.stroke_width == 0) && self.fill_color.is_none()
     }
 
@@ -329,15 +319,6 @@ mod tests {
         assert_eq!(style.fill_color, None);
         assert_eq!(style.stroke_color, Some(Rgb888::GREEN));
         assert_eq!(style.stroke_width, 123);
-    }
-
-    #[test]
-    fn stroke_width_without_stroke_color() {
-        let style: PrimitiveStyle<BinaryColor> =
-            PrimitiveStyleBuilder::new().stroke_width(10).build();
-
-        assert_eq!(style.inside_stroke_width(), 0);
-        assert_eq!(style.outside_stroke_width(), 0);
     }
 
     #[test]

--- a/src/primitives/rectangle/styled.rs
+++ b/src/primitives/rectangle/styled.rs
@@ -159,13 +159,9 @@ where
     C: PixelColor,
 {
     fn bounding_box(&self) -> Rectangle {
-        if !self.style.is_transparent() {
-            let offset = self.style.outside_stroke_width().saturating_cast();
+        let offset = self.style.outside_stroke_width().saturating_cast();
 
-            self.primitive.bounding_box().offset(offset)
-        } else {
-            Rectangle::new(self.primitive.center(), Size::zero())
-        }
+        self.primitive.bounding_box().offset(offset)
     }
 }
 
@@ -420,14 +416,12 @@ mod tests {
     }
 
     #[test]
-    fn transparent_bounding_box() {
+    fn bounding_box_is_independent_of_colors() {
         let rect = Rectangle::new(Point::new(5, 5), Size::new(11, 14));
 
-        let styled = rect.into_styled::<BinaryColor>(PrimitiveStyle::new());
+        let transparent_rect = rect.into_styled::<BinaryColor>(PrimitiveStyle::new());
+        let filled_rect = rect.into_styled(PrimitiveStyle::with_fill(BinaryColor::On));
 
-        assert_eq!(
-            styled.bounding_box(),
-            Rectangle::new(rect.center(), Size::zero())
-        );
+        assert_eq!(transparent_rect.bounding_box(), filled_rect.bounding_box(),);
     }
 }

--- a/src/primitives/rounded_rectangle/styled.rs
+++ b/src/primitives/rounded_rectangle/styled.rs
@@ -1,6 +1,6 @@
 use crate::{
     draw_target::DrawTarget,
-    geometry::{Dimensions, Size},
+    geometry::Dimensions,
     iterator::IntoPixels,
     pixelcolor::PixelColor,
     primitives::{
@@ -98,13 +98,9 @@ where
     C: PixelColor,
 {
     fn bounding_box(&self) -> Rectangle {
-        if !self.style.is_transparent() {
-            let offset = self.style.outside_stroke_width().saturating_cast();
+        let offset = self.style.outside_stroke_width().saturating_cast();
 
-            self.primitive.bounding_box().offset(offset)
-        } else {
-            Rectangle::new(self.primitive.bounding_box().center(), Size::zero())
-        }
+        self.primitive.bounding_box().offset(offset)
     }
 }
 
@@ -330,7 +326,7 @@ mod tests {
     }
 
     #[test]
-    fn transparent_bounding_box() {
+    fn bounding_box_is_independent_of_colors() {
         let rect = RoundedRectangle::new(
             Rectangle::new(Point::new(5, 5), Size::new(11, 14)),
             CornerRadii {
@@ -341,11 +337,9 @@ mod tests {
             },
         );
 
-        let styled = rect.into_styled::<Rgb888>(PrimitiveStyle::new());
+        let transparent_rect = rect.into_styled::<Rgb888>(PrimitiveStyle::new());
+        let filled_rect = rect.into_styled(PrimitiveStyle::with_fill(Rgb888::RED));
 
-        assert_eq!(
-            styled.bounding_box(),
-            Rectangle::new(rect.bounding_box().center(), Size::zero())
-        );
+        assert_eq!(transparent_rect.bounding_box(), filled_rect.bounding_box(),);
     }
 }


### PR DESCRIPTION
This  PR changes the way `stroke_width` is handled if `stroke_color` is `None`. The bounding boxes that are returned by the `Dimensions` trait will ignore `stroke_color`. The `fill_area` will also be reduced regardless of `stoke_color`. See #562 for more details.

Closes #562
