### PR TITLE
Replace anonymous magic constants with named equivalents in tests

### DIFF
--- a/core/src/pixelcolor/conversion.rs
+++ b/core/src/pixelcolor/conversion.rs
@@ -88,7 +88,7 @@ mod tests {
 
     #[test]
     fn convert_rgb565_to_rgb888_and_back() {
-        for r in 0..=63 {
+        for r in 0..=Rgb565::MAX_R {
             let c = Rgb565::new(r, 0, 0);
             let c2 = Rgb888::from(c);
             let c3 = Rgb565::from(c2);
@@ -96,7 +96,7 @@ mod tests {
             assert_eq!(c, c3);
         }
 
-        for g in 0..=63 {
+        for g in 0..=Rgb565::MAX_G {
             let c = Rgb565::new(0, g, 0);
             let c2 = Rgb888::from(c);
             let c3 = Rgb565::from(c2);
@@ -104,7 +104,7 @@ mod tests {
             assert_eq!(c, c3);
         }
 
-        for b in 0..=63 {
+        for b in 0..=Rgb565::MAX_B {
             let c = Rgb565::new(0, 0, b);
             let c2 = Rgb888::from(c);
             let c3 = Rgb565::from(c2);


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Since we have `MAX_R`/`MAX_G`/`MAX_B` defined on `RgbColor` we might as well use them, rather than equivalent anonymous magic constants. We already do this in all other tests in the same file.