### PR TITLE
Use scanlines to draw rounded shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#563](https://github.com/embedded-graphics/embedded-graphics/pull/563) Added `is_none`, `is_text_color` and `is_custom` methods to `DecorationColor`.
 - [#563](https://github.com/embedded-graphics/embedded-graphics/pull/563) Added `is_transparent` methods to `PrimitiveStyle` and `MonoTextStyle`.
 - [#569](https://github.com/embedded-graphics/embedded-graphics/pull/569) Added a `line_height` field to `TextStyle`.
+- [#571](https://github.com/embedded-graphics/embedded-graphics/pull/571) Added `MockDisplay::set_pixels` to set pixels from an iterator.
 
 ### Changed
 
@@ -22,6 +23,11 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - **(breaking)** [#566](https://github.com/embedded-graphics/embedded-graphics/pull/566) The `Drawable::Output` type was changed to `Point` for styled `Text` objects. The returned point can be used to chain texts with different styles.
 - **(breaking)** [#569](https://github.com/embedded-graphics/embedded-graphics/pull/569) Moved the text rendering API into a separate `text::renderer` submodule.
 - **(breaking)** [#569](https://github.com/embedded-graphics/embedded-graphics/pull/569) The `non_exhaustive` attribute was added to the `TextStyle` struct.
+- **(breaking)** [#571](https://github.com/embedded-graphics/embedded-graphics/pull/571) Added color argument to `MockDisplay::from_points` to make it usable for all color types.
+
+### Fixed
+
+- [#571](https://github.com/embedded-graphics/embedded-graphics/pull/571) `Rectangle::points` did return a non empty iterator for rectangles with zero width.
 
 ## [0.7.0-alpha.3] - 2021-02-03
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -15,6 +15,10 @@
 
 - **(breaking)** [#569](https://github.com/embedded-graphics/embedded-graphics/pull/569) Removed text renderer API. The text renderer API will be added back when it has stabilized.
 
+### Fixed
+
+- [#571](https://github.com/embedded-graphics/embedded-graphics/pull/571) `Rectangle::points` did return a non empty iterator for rectangles with zero width.
+
 ## [0.2.0] - 2021-02-03
 
 ### Added

--- a/core/src/primitives/rectangle/mod.rs
+++ b/core/src/primitives/rectangle/mod.rs
@@ -106,7 +106,7 @@ impl Rectangle {
     }
 
     /// Returns a zero sized rectangle.
-    pub fn zero() -> Rectangle {
+    pub const fn zero() -> Rectangle {
         Rectangle::new(Point::zero(), Size::zero())
     }
 

--- a/src/mock_display/fancy_panic.rs
+++ b/src/mock_display/fancy_panic.rs
@@ -49,9 +49,9 @@ where
     }
 
     fn write_vertical_border(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
+        writeln!(
             f,
-            "+-{:-<width$}-+-{:-<width$}-+-{:-<width$}-+\n",
+            "+-{:-<width$}-+-{:-<width$}-+-{:-<width$}-+",
             "",
             "",
             "",
@@ -60,9 +60,9 @@ where
     }
 
     fn write_header(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
+        writeln!(
             f,
-            "| {:^width$} | {:^width$} | {:^width$} |\n",
+            "| {:^width$} | {:^width$} | {:^width$} |",
             "display",
             "expected",
             "diff",
@@ -85,9 +85,9 @@ where
             Ansi::Foreground(None)
         )?;
 
-        write!(
+        writeln!(
             f,
-            ", {}\u{25FC}{} wrong color\n",
+            ", {}\u{25FC}{} wrong color",
             Ansi::Foreground(Some(Rgb888::BLUE)),
             Ansi::Foreground(None)
         )

--- a/src/mock_display/mod.rs
+++ b/src/mock_display/mod.rs
@@ -291,7 +291,23 @@ where
     /// # Panics
     ///
     /// This method will panic if `point` is outside the display bounding box.
-    pub fn set_pixel(&mut self, point: Point, color: Option<C>) {
+    fn set_pixel(&mut self, point: Point, color: Option<C>) {
+        assert!(
+            point.x >= 0 && point.y >= 0 && point.x < SIZE as i32 && point.y < SIZE as i32,
+            "point must be inside display bounding box: {:?}",
+            point
+        );
+
+        let i = point.x + point.y * SIZE as i32;
+        self.pixels[i as usize] = color;
+    }
+
+    /// Changes the value of a pixel without bounds checking.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `point` is outside the display bounding box.
+    fn set_pixel_unchecked(&mut self, point: Point, color: Option<C>) {
         let i = point.x + point.y * SIZE as i32;
         self.pixels[i as usize] = color;
     }
@@ -368,7 +384,7 @@ where
             panic!("tried to draw pixel twice (x: {}, y: {})", point.x, point.y);
         }
 
-        self.set_pixel(point, Some(color));
+        self.set_pixel_unchecked(point, Some(color));
     }
 
     /// Returns a copy of with the content mirrored by swapping x and y.
@@ -403,7 +419,7 @@ where
         let mut mirrored = MockDisplay::new();
 
         for point in Rectangle::new(Point::zero(), self.size()).points() {
-            mirrored.set_pixel(point, self.get_pixel(Point::new(point.y, point.x)));
+            mirrored.set_pixel_unchecked(point, self.get_pixel(Point::new(point.y, point.x)));
         }
 
         mirrored
@@ -442,7 +458,7 @@ where
         let mut target = MockDisplay::new();
 
         for point in Rectangle::new(Point::zero(), self.size()).points() {
-            target.set_pixel(point, self.get_pixel(point).map(f))
+            target.set_pixel_unchecked(point, self.get_pixel(point).map(f))
         }
 
         target
@@ -472,7 +488,7 @@ where
                 _ => None,
             };
 
-            display.set_pixel(point, diff_color);
+            display.set_pixel_unchecked(point, diff_color);
         }
 
         display

--- a/src/mock_display/mod.rs
+++ b/src/mock_display/mod.rs
@@ -188,7 +188,7 @@ mod fancy_panic;
 use crate::{
     draw_target::DrawTarget,
     geometry::{Dimensions, OriginDimensions, Point, Size},
-    pixelcolor::{BinaryColor, PixelColor, Rgb888, RgbColor},
+    pixelcolor::{PixelColor, Rgb888, RgbColor},
     primitives::{PointsIter, Rectangle},
     Pixel,
 };
@@ -224,6 +224,47 @@ where
         Self::default()
     }
 
+    /// Create a mock display from an iterator of [`Point`]s.
+    ///
+    /// This method can be used to create a mock display from the iterator produced by the
+    /// [`PointsIter::points`] method.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if the iterator returns a point that is outside the display bounding
+    /// box.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use embedded_graphics::{prelude::*, pixelcolor::BinaryColor, primitives::Circle, mock_display::MockDisplay};
+    ///
+    /// let circle = Circle::new(Point::new(0, 0), 4);
+    ///
+    /// let mut display = MockDisplay::from_points(circle.points(), BinaryColor::On);
+    ///
+    /// display.assert_pattern(&[
+    ///     " ## ",
+    ///     "####",
+    ///     "####",
+    ///     " ## ",
+    /// ]);
+    /// ```
+    ///
+    /// [`Point`]: ../geometry/struct.Point.html
+    /// [`PointsIter::points`]: ../primitives/trait.PointsIter.html#tymethod.points
+    /// [`map`]: #method.map
+    /// [`BinaryColor`]: ../pixelcolor/enum.BinaryColor.html
+    pub fn from_points<I>(points: I, color: C) -> Self
+    where
+        I: IntoIterator<Item = Point>,
+    {
+        let mut display = Self::new();
+        display.set_pixels(points, Some(color));
+
+        display
+    }
+
     /// Sets if out of bounds drawing is allowed.
     ///
     /// If this is set to `true` the bounds checks during drawing are disabled.
@@ -246,9 +287,24 @@ where
     }
 
     /// Changes the value of a pixel without bounds checking.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `point` is outside the display bounding box.
     pub fn set_pixel(&mut self, point: Point, color: Option<C>) {
         let i = point.x + point.y * SIZE as i32;
         self.pixels[i as usize] = color;
+    }
+
+    /// Sets the points in an iterator to the given color.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if the iterator returns points outside the display bounding box.
+    pub fn set_pixels(&mut self, points: impl IntoIterator<Item = Point>, color: Option<C>) {
+        for point in points {
+            self.set_pixel(point, color);
+        }
     }
 
     /// Returns the area that was affected by drawing operations.
@@ -428,55 +484,6 @@ where
     /// `assert_pattern` methods are used instead of the `assert_eq!` macro.
     pub fn eq(&self, other: &MockDisplay<C>) -> bool {
         self.pixels.iter().eq(other.pixels.iter())
-    }
-}
-
-impl MockDisplay<BinaryColor> {
-    /// Create a mock display from an iterator of [`Point`]s.
-    ///
-    /// This method can be used to create a mock display from the iterator produced by the
-    /// [`PointsIter::points`] method.
-    ///
-    /// The color type used in the returned display is [`BinaryColor`], which can be mapped to
-    /// another color type using the [`map`] method.
-    ///
-    /// # Panics
-    ///
-    /// This method will panic if the iterator returns a point that is outside the display bounding
-    /// box.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use embedded_graphics::{prelude::*, primitives::Circle, mock_display::MockDisplay};
-    ///
-    /// let circle = Circle::new(Point::new(0, 0), 4);
-    ///
-    /// let mut display = MockDisplay::from_points(circle.points());
-    ///
-    /// display.assert_pattern(&[
-    ///     " ## ",
-    ///     "####",
-    ///     "####",
-    ///     " ## ",
-    /// ]);
-    /// ```
-    ///
-    /// [`Point`]: ../geometry/struct.Point.html
-    /// [`PointsIter::points`]: ../primitives/trait.PointsIter.html#tymethod.points
-    /// [`map`]: #method.map
-    /// [`BinaryColor`]: ../pixelcolor/enum.BinaryColor.html
-    pub fn from_points<I>(points: I) -> Self
-    where
-        I: IntoIterator<Item = Point>,
-    {
-        let mut display = MockDisplay::new();
-
-        for point in points.into_iter() {
-            display.set_pixel(point, Some(BinaryColor::On));
-        }
-
-        display
     }
 }
 
@@ -727,7 +734,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{pixelcolor::Rgb565, Drawable};
+    use crate::{
+        pixelcolor::{BinaryColor, Rgb565},
+        Drawable,
+    };
 
     #[test]
     #[should_panic(expected = "tried to draw pixel outside the display area (x: 65, y: 0)")]

--- a/src/primitives/arc/points.rs
+++ b/src/primitives/arc/points.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 /// Iterator over all points on the arc line.
-#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct Points {
     iter: DistanceIterator,
 

--- a/src/primitives/arc/styled.rs
+++ b/src/primitives/arc/styled.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 /// Pixel iterator for each pixel in the arc border
-#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct StyledPixels<C>
 where
     C: PixelColor,

--- a/src/primitives/circle/points.rs
+++ b/src/primitives/circle/points.rs
@@ -33,10 +33,15 @@ impl Iterator for Points {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{geometry::Point, mock_display::MockDisplay, primitives::PointsIter};
+    use crate::{
+        geometry::Point, mock_display::MockDisplay, pixelcolor::BinaryColor, primitives::PointsIter,
+    };
 
     fn test_circle(diameter: u32, pattern: &[&str]) {
-        let display = MockDisplay::from_points(Circle::new(Point::new(0, 0), diameter).points());
+        let display = MockDisplay::from_points(
+            Circle::new(Point::new(0, 0), diameter).points(),
+            BinaryColor::On,
+        );
 
         display.assert_pattern(pattern);
     }

--- a/src/primitives/circle/points.rs
+++ b/src/primitives/circle/points.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 /// Iterator over all points inside the circle.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct Points {
     iter: DistanceIterator,
     threshold: u32,

--- a/src/primitives/circle/points.rs
+++ b/src/primitives/circle/points.rs
@@ -42,9 +42,11 @@ pub struct Scanlines {
 
 impl Scanlines {
     pub fn new(circle: &Circle) -> Self {
+        let bounding_box = circle.bounding_box();
+
         Self {
-            rows: circle.bounding_box().rows(),
-            columns: circle.bounding_box().columns(),
+            rows: bounding_box.rows(),
+            columns: bounding_box.columns(),
             center_2x: circle.center_2x(),
             threshold: circle.threshold(),
         }

--- a/src/primitives/circle/styled.rs
+++ b/src/primitives/circle/styled.rs
@@ -1,11 +1,13 @@
 use crate::{
     draw_target::DrawTarget,
-    geometry::Dimensions,
+    geometry::{Dimensions, Point, PointExt},
     iterator::IntoPixels,
     pixelcolor::PixelColor,
     primitives::{
-        circle::Circle, common::DistanceIterator, rectangle::Rectangle, PrimitiveStyle,
-        StyledPrimitiveAreas,
+        circle::{points::Scanlines, Circle},
+        common::{Scanline, StyledScanline},
+        rectangle::Rectangle,
+        PrimitiveStyle, StyledPrimitiveAreas,
     },
     Drawable, Pixel, SaturatingCast, Styled,
 };
@@ -16,13 +18,14 @@ pub struct StyledPixels<C>
 where
     C: PixelColor,
 {
-    iter: DistanceIterator,
+    styled_scanlines: StyledScanlines,
 
-    outer_threshold: u32,
-    outer_color: Option<C>,
+    stroke_left: Scanline,
+    fill: Scanline,
+    stroke_right: Scanline,
 
-    inner_threshold: u32,
-    inner_color: Option<C>,
+    stroke_color: Option<C>,
+    fill_color: Option<C>,
 }
 
 impl<C> StyledPixels<C>
@@ -33,18 +36,13 @@ where
         let stroke_area = styled.stroke_area();
         let fill_area = styled.fill_area();
 
-        let iter = if !styled.style.is_transparent() {
-            stroke_area.distances()
-        } else {
-            DistanceIterator::empty()
-        };
-
         Self {
-            iter,
-            outer_threshold: stroke_area.threshold(),
-            outer_color: styled.style.stroke_color,
-            inner_threshold: fill_area.threshold(),
-            inner_color: styled.style.fill_color,
+            styled_scanlines: StyledScanlines::new(&stroke_area, &fill_area),
+            stroke_left: Scanline::new_empty(0),
+            fill: Scanline::new_empty(0),
+            stroke_right: Scanline::new_empty(0),
+            stroke_color: styled.style.stroke_color,
+            fill_color: styled.style.fill_color,
         }
     }
 }
@@ -56,21 +54,47 @@ where
     type Item = Pixel<C>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        for (point, _, distance) in &mut self.iter {
-            let color = if distance < self.inner_threshold {
-                self.inner_color
-            } else if distance < self.outer_threshold {
-                self.outer_color
-            } else {
-                None
-            };
+        match (self.stroke_color, self.fill_color) {
+            (Some(stroke_color), None) => loop {
+                if let Some(pixel) = self
+                    .stroke_left
+                    .next()
+                    .or_else(|| self.stroke_right.next())
+                    .map(|p| Pixel(p, stroke_color))
+                {
+                    return Some(pixel);
+                }
 
-            if let Some(color) = color {
-                return Some(Pixel(point, color));
-            }
+                let scanline = self.styled_scanlines.next()?;
+                self.stroke_left = scanline.stroke_left();
+                self.stroke_right = scanline.stroke_right();
+            },
+            (Some(stroke_color), Some(fill_color)) => loop {
+                if let Some(pixel) = self
+                    .stroke_left
+                    .next()
+                    .map(|p| Pixel(p, stroke_color))
+                    .or_else(|| self.fill.next().map(|p| Pixel(p, fill_color)))
+                    .or_else(|| self.stroke_right.next().map(|p| Pixel(p, stroke_color)))
+                {
+                    return Some(pixel);
+                }
+
+                let scanline = self.styled_scanlines.next()?;
+                self.stroke_left = scanline.stroke_left();
+                self.fill = scanline.fill();
+                self.stroke_right = scanline.stroke_right();
+            },
+            (None, Some(fill_color)) => loop {
+                if let Some(pixel) = self.fill.next().map(|p| Pixel(p, fill_color)) {
+                    return Some(pixel);
+                }
+
+                let scanline = self.styled_scanlines.next()?;
+                self.fill = scanline.fill();
+            },
+            (None, None) => None,
         }
-
-        None
     }
 }
 
@@ -94,11 +118,30 @@ where
     type Color = C;
     type Output = ();
 
-    fn draw<D>(&self, display: &mut D) -> Result<Self::Output, D::Error>
+    fn draw<D>(&self, target: &mut D) -> Result<Self::Output, D::Error>
     where
         D: DrawTarget<Color = C>,
     {
-        display.draw_iter(self.into_pixels())
+        match (self.style.effective_stroke_color(), self.style.fill_color) {
+            (Some(stroke_color), None) => {
+                for scanline in StyledScanlines::new(&self.stroke_area(), &self.fill_area()) {
+                    scanline.draw_stroke(target, stroke_color)?;
+                }
+            }
+            (Some(stroke_color), Some(fill_color)) => {
+                for scanline in StyledScanlines::new(&self.stroke_area(), &self.fill_area()) {
+                    scanline.draw_stroke_and_fill(target, stroke_color, fill_color)?;
+                }
+            }
+            (None, Some(fill_color)) => {
+                for scanline in Scanlines::new(&self.fill_area()) {
+                    scanline.draw(target, fill_color)?;
+                }
+            }
+            (None, None) => {}
+        }
+
+        Ok(())
     }
 }
 
@@ -112,20 +155,169 @@ where
         self.primitive.bounding_box().offset(offset)
     }
 }
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+struct StyledScanlines {
+    scanlines: Scanlines,
+    fill_threshold: u32,
+}
+
+impl StyledScanlines {
+    pub fn new(stroke_area: &Circle, fill_area: &Circle) -> Self {
+        Self {
+            scanlines: Scanlines::new(stroke_area),
+            fill_threshold: fill_area.threshold(),
+        }
+    }
+}
+
+impl Iterator for StyledScanlines {
+    type Item = StyledScanline;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.scanlines.next().map(|scanline| {
+            let fill_range = scanline
+                .x
+                .clone()
+                .find(|x| {
+                    let delta = Point::new(*x, scanline.y) * 2 - self.scanlines.center_2x;
+                    (delta.length_squared() as u32) < self.fill_threshold
+                })
+                .map(|x| x..scanline.x.end - (x - scanline.x.start));
+
+            StyledScanline::new(scanline.y, scanline.x, fill_range)
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
         geometry::{Dimensions, Point},
+        iterator::PixelIteratorExt,
         mock_display::MockDisplay,
         pixelcolor::BinaryColor,
-        primitives::{PointsIter, Primitive, PrimitiveStyleBuilder, StrokeAlignment},
+        primitives::{
+            OffsetOutline, PointsIter, Primitive, PrimitiveStyleBuilder, StrokeAlignment,
+        },
         Drawable,
     };
 
+    /// Draws a styled circle by only using the points iterator.
+    fn draw_circle(
+        diameter: u32,
+        stroke_color: Option<BinaryColor>,
+        stroke_width: u32,
+        fill_color: Option<BinaryColor>,
+    ) -> MockDisplay<BinaryColor> {
+        let circle = Circle::with_center(Point::new_equal(10), diameter);
+
+        let mut display = MockDisplay::new();
+        display.set_pixels(circle.points(), stroke_color);
+        display.set_pixels(
+            circle.offset(stroke_width.saturating_cast_neg()).points(),
+            fill_color,
+        );
+
+        display
+    }
+
     #[test]
-    fn filled_styled_matches_points() {
+    fn fill() {
+        for diameter in 5..=6 {
+            let expected = draw_circle(diameter, None, 0, Some(BinaryColor::On));
+
+            let circle = Circle::with_center(Point::new_equal(10), diameter)
+                .into_styled(PrimitiveStyle::with_fill(BinaryColor::On));
+
+            let mut drawable = MockDisplay::new();
+            circle.draw(&mut drawable).unwrap();
+            drawable.assert_eq_with_message(&expected, |f| write!(f, "diameter = {}", diameter));
+
+            let mut into_pixels = MockDisplay::new();
+            circle.into_pixels().draw(&mut into_pixels).unwrap();
+            into_pixels.assert_eq_with_message(&expected, |f| write!(f, "diameter = {}", diameter));
+        }
+    }
+
+    #[test]
+    fn stroke() {
+        for (diameter, stroke_width) in [(5, 2), (5, 3), (6, 2), (6, 3)].iter().copied() {
+            let expected = draw_circle(diameter, Some(BinaryColor::On), stroke_width, None);
+
+            let style = PrimitiveStyleBuilder::new()
+                .stroke_color(BinaryColor::On)
+                .stroke_width(stroke_width)
+                .stroke_alignment(StrokeAlignment::Inside)
+                .build();
+
+            let circle = Circle::with_center(Point::new_equal(10), diameter).into_styled(style);
+
+            let mut drawable = MockDisplay::new();
+            circle.draw(&mut drawable).unwrap();
+            drawable.assert_eq_with_message(&expected, |f| {
+                write!(
+                    f,
+                    "diameter = {}, stroke_width = {}",
+                    diameter, stroke_width
+                )
+            });
+
+            let mut into_pixels = MockDisplay::new();
+            circle.into_pixels().draw(&mut into_pixels).unwrap();
+            into_pixels.assert_eq_with_message(&expected, |f| {
+                write!(
+                    f,
+                    "diameter = {}, stroke_width = {}",
+                    diameter, stroke_width
+                )
+            });
+        }
+    }
+
+    #[test]
+    fn stroke_and_fill() {
+        for (diameter, stroke_width) in [(5, 2), (5, 3), (6, 2), (6, 3)].iter().copied() {
+            let expected = draw_circle(
+                diameter,
+                Some(BinaryColor::On),
+                stroke_width,
+                Some(BinaryColor::Off),
+            );
+
+            let style = PrimitiveStyleBuilder::new()
+                .fill_color(BinaryColor::Off)
+                .stroke_color(BinaryColor::On)
+                .stroke_width(stroke_width)
+                .stroke_alignment(StrokeAlignment::Inside)
+                .build();
+
+            let circle = Circle::with_center(Point::new_equal(10), diameter).into_styled(style);
+
+            let mut drawable = MockDisplay::new();
+            circle.draw(&mut drawable).unwrap();
+            drawable.assert_eq_with_message(&expected, |f| {
+                write!(
+                    f,
+                    "diameter = {}, stroke_width = {}",
+                    diameter, stroke_width
+                )
+            });
+
+            let mut into_pixels = MockDisplay::new();
+            circle.into_pixels().draw(&mut into_pixels).unwrap();
+            into_pixels.assert_eq_with_message(&expected, |f| {
+                write!(
+                    f,
+                    "diameter = {}, stroke_width = {}",
+                    diameter, stroke_width
+                )
+            });
+        }
+    }
+
+    #[test]
+    fn filled_styled_points_matches_points() {
         let circle = Circle::with_center(Point::new(10, 10), 5);
 
         let styled_points = circle

--- a/src/primitives/circle/styled.rs
+++ b/src/primitives/circle/styled.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 /// Pixel iterator for each pixel in the circle border
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct StyledPixels<C>
 where
     C: PixelColor,

--- a/src/primitives/common/distance_iterator.rs
+++ b/src/primitives/common/distance_iterator.rs
@@ -14,7 +14,7 @@ use crate::{
 /// 2. The difference between the current position and the center point of the bounding box.
 ///    Note that this value is scaled up by a factor of 2 to increase the resolution.
 /// 3. The squared length of the second value.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct DistanceIterator {
     center_2x: Point,
     points: rectangle::Points,

--- a/src/primitives/common/mod.rs
+++ b/src/primitives/common/mod.rs
@@ -4,6 +4,7 @@ mod line_join;
 mod linear_equation;
 mod plane_sector;
 mod scanline;
+mod styled_scanline;
 mod thick_segment;
 mod thick_segment_iter;
 
@@ -13,6 +14,7 @@ pub use line_join::{JoinKind, LineJoin};
 pub use linear_equation::{LinearEquation, OriginLinearEquation, NORMAL_VECTOR_SCALE};
 pub use plane_sector::PlaneSector;
 pub use scanline::Scanline;
+pub use styled_scanline::StyledScanline;
 pub use thick_segment::ThickSegment;
 pub use thick_segment_iter::ThickSegmentIter;
 

--- a/src/primitives/common/styled_scanline.rs
+++ b/src/primitives/common/styled_scanline.rs
@@ -1,0 +1,65 @@
+use core::ops::Range;
+
+use crate::{draw_target::DrawTarget, primitives::common::Scanline};
+
+/// Scanline with stroke and fill regions.
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+pub struct StyledScanline {
+    y: i32,
+    stroke_range: Range<i32>,
+    fill_range: Range<i32>,
+}
+
+impl StyledScanline {
+    /// Creates a new styled scanline.
+    pub fn new(y: i32, stroke_range: Range<i32>, fill_range: Option<Range<i32>>) -> Self {
+        let fill_range = fill_range.unwrap_or_else(|| stroke_range.end..stroke_range.end);
+
+        Self {
+            y,
+            stroke_range,
+            fill_range,
+        }
+    }
+
+    /// Returns the stroke region on the left side.
+    ///
+    /// If the scanline contains no fill region the entire scanline will be returned.
+    pub fn stroke_left(&self) -> Scanline {
+        Scanline::new(self.y, self.stroke_range.start..self.fill_range.start)
+    }
+
+    /// Returns the stroke region on the right side.
+    ///
+    /// If the scanline contains no fill region an empty scanline will be returned.
+    pub fn stroke_right(&self) -> Scanline {
+        Scanline::new(self.y, self.fill_range.end..self.stroke_range.end)
+    }
+
+    /// Returns the fill region.
+    pub fn fill(&self) -> Scanline {
+        Scanline::new(self.y, self.fill_range.clone())
+    }
+
+    /// Draws the stroke regions.
+    pub fn draw_stroke<T: DrawTarget>(
+        &self,
+        target: &mut T,
+        stroke_color: T::Color,
+    ) -> Result<(), T::Error> {
+        self.stroke_left().draw(target, stroke_color)?;
+        self.stroke_right().draw(target, stroke_color)
+    }
+
+    /// Draws the stroke and fill regions.
+    pub fn draw_stroke_and_fill<T: DrawTarget>(
+        &self,
+        target: &mut T,
+        stroke_color: T::Color,
+        fill_color: T::Color,
+    ) -> Result<(), T::Error> {
+        self.stroke_left().draw(target, stroke_color)?;
+        self.fill().draw(target, fill_color)?;
+        self.stroke_right().draw(target, stroke_color)
+    }
+}

--- a/src/primitives/common/thick_segment.rs
+++ b/src/primitives/common/thick_segment.rs
@@ -69,7 +69,7 @@ impl ThickSegment {
     }
 
     pub fn intersection(&self, scanline_y: i32) -> Scanline {
-        let mut scanline = Scanline::new(scanline_y);
+        let mut scanline = Scanline::new_empty(scanline_y);
 
         // Single 1px line
         if self.is_skeleton() {

--- a/src/primitives/ellipse/mod.rs
+++ b/src/primitives/ellipse/mod.rs
@@ -226,13 +226,14 @@ mod tests {
     fn contains() {
         let ellipse = Ellipse::new(Point::zero(), Size::new(40, 20));
 
-        let display = MockDisplay::<BinaryColor>::from_points(
+        let display = MockDisplay::from_points(
             Rectangle::new(Point::zero(), Size::new(40, 20))
                 .points()
                 .filter(|p| ellipse.contains(*p)),
+            BinaryColor::On,
         );
 
-        let expected = MockDisplay::from_points(ellipse.points());
+        let expected = MockDisplay::from_points(ellipse.points(), BinaryColor::On);
 
         display.assert_eq(&expected);
     }

--- a/src/primitives/ellipse/mod.rs
+++ b/src/primitives/ellipse/mod.rs
@@ -198,14 +198,6 @@ impl EllipseContains {
         Self { a, b, threshold }
     }
 
-    pub const fn empty() -> Self {
-        Self {
-            a: 0,
-            b: 0,
-            threshold: 0,
-        }
-    }
-
     /// Returns `true` if the point is inside the ellipse.
     pub fn contains(&self, point: Point) -> bool {
         let x = point.x.pow(2) as u32;

--- a/src/primitives/ellipse/mod.rs
+++ b/src/primitives/ellipse/mod.rs
@@ -122,9 +122,8 @@ impl PointsIter for Ellipse {
 
 impl ContainsPoint for Ellipse {
     fn contains(&self, point: Point) -> bool {
-        let (size_sq, threshold) = compute_threshold(self.size);
-
-        is_point_inside_ellipse(size_sq, point * 2 - self.center_2x(), threshold)
+        let ellipse_contains = EllipseContains::new(self.size);
+        ellipse_contains.contains(point * 2 - self.center_2x())
     }
 }
 
@@ -170,45 +169,54 @@ impl Transform for Ellipse {
     }
 }
 
-pub(in crate::primitives) fn compute_threshold(size: Size) -> (Size, u32) {
-    let Size { width, height } = size;
-
-    let a = width.pow(2);
-    let b = height.pow(2);
-
-    // Special case for circles, where width and height are equal
-    let threshold = if width == height {
-        circle::diameter_to_threshold(width)
-    } else {
-        b * a
-    };
-
-    (Size::new(a, b), threshold)
+/// Determines if a point is inside an ellipse.
+// TODO: Make this available to the user as part of #343
+#[derive(Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, Debug)]
+pub(in crate::primitives) struct EllipseContains {
+    a: u32,
+    b: u32,
+    threshold: u32,
 }
 
-/// Uses the ellipse equation b^2 * x^2 + a^2 * y^2 - a^2 * b^2 to return a value signifying whether
-/// a given point lies inside (`true`) or outside (`false`) an ellipse centered around `(0, 0)` with
-/// width and height defined by the `size` parameter.
-pub(in crate::primitives) fn is_point_inside_ellipse(
-    size: Size,
-    point: Point,
-    threshold: u32,
-) -> bool {
-    let Size {
-        width: a,
-        height: b,
-    } = size;
+impl EllipseContains {
+    /// Creates an object to determine if a point is inside an ellipse.
+    ///
+    /// The ellipse is always located in the origin.
+    pub fn new(size: Size) -> Self {
+        let Size { width, height } = size;
 
-    let Point { x, y } = point;
+        let a = width.pow(2);
+        let b = height.pow(2);
 
-    let x = x.pow(2) as u32;
-    let y = y.pow(2) as u32;
+        // Special case for circles, where width and height are equal
+        let threshold = if width == height {
+            circle::diameter_to_threshold(width)
+        } else {
+            b * a
+        };
 
-    // Special case for circles, where width and height are equal
-    if a == b {
-        x + y < threshold
-    } else {
-        b * x + a * y < threshold
+        Self { a, b, threshold }
+    }
+
+    pub const fn empty() -> Self {
+        Self {
+            a: 0,
+            b: 0,
+            threshold: 0,
+        }
+    }
+
+    /// Returns `true` if the point is inside the ellipse.
+    pub fn contains(&self, point: Point) -> bool {
+        let x = point.x.pow(2) as u32;
+        let y = point.y.pow(2) as u32;
+
+        // Special case for circles, where width and height are equal
+        if self.a == self.b {
+            x + y < self.threshold
+        } else {
+            self.b * x + self.a * y < self.threshold
+        }
     }
 }
 

--- a/src/primitives/ellipse/points.rs
+++ b/src/primitives/ellipse/points.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 /// Iterator over all points inside the ellipse
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct Points {
     iter: rectangle::Points,
     center_2x: Point,

--- a/src/primitives/ellipse/points.rs
+++ b/src/primitives/ellipse/points.rs
@@ -1,39 +1,25 @@
+use core::ops::Range;
+
 use crate::{
     geometry::{Dimensions, Point, Size},
     primitives::{
+        common::Scanline,
         ellipse::{compute_threshold, is_point_inside_ellipse, Ellipse},
-        rectangle::{self, Rectangle},
-        PointsIter,
     },
 };
 
 /// Iterator over all points inside the ellipse
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct Points {
-    iter: rectangle::Points,
-    center_2x: Point,
-    size_sq: Size,
-    threshold: u32,
+    scanlines: Scanlines,
+    current_scanline: Scanline,
 }
 
 impl Points {
     pub(in crate::primitives) fn new(ellipse: &Ellipse) -> Self {
-        let (size_sq, threshold) = compute_threshold(ellipse.size);
-
         Self {
-            iter: ellipse.bounding_box().points(),
-            center_2x: ellipse.center_2x(),
-            size_sq,
-            threshold,
-        }
-    }
-
-    pub(in crate::primitives) fn empty() -> Self {
-        Self {
-            iter: Rectangle::zero().points(),
-            center_2x: Point::zero(),
-            size_sq: Size::zero(),
-            threshold: 0,
+            scanlines: Scanlines::new(ellipse),
+            current_scanline: Scanline::new_empty(0),
         }
     }
 }
@@ -42,13 +28,55 @@ impl Iterator for Points {
     type Item = Point;
 
     fn next(&mut self) -> Option<Self::Item> {
-        for point in &mut self.iter {
-            if is_point_inside_ellipse(self.size_sq, point * 2 - self.center_2x, self.threshold) {
-                return Some(point);
-            }
-        }
+        self.current_scanline.next().or_else(|| {
+            self.current_scanline = self.scanlines.next()?;
+            self.current_scanline.next()
+        })
+    }
+}
 
-        None
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+pub struct Scanlines {
+    rows: Range<i32>,
+    columns: Range<i32>,
+    pub(super) center_2x: Point,
+    size_sq: Size,
+    threshold: u32,
+}
+
+impl Scanlines {
+    pub fn new(ellipse: &Ellipse) -> Self {
+        let bounding_box = ellipse.bounding_box();
+        let (size_sq, threshold) = compute_threshold(ellipse.size);
+
+        Self {
+            rows: bounding_box.rows(),
+            columns: bounding_box.columns(),
+            center_2x: ellipse.center_2x(),
+            size_sq,
+            threshold,
+        }
+    }
+}
+
+impl Iterator for Scanlines {
+    type Item = Scanline;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let y = self.rows.next()?;
+
+        self.columns
+            .clone()
+            // find first pixel that is inside the ellipse
+            .find(|x| {
+                is_point_inside_ellipse(
+                    self.size_sq,
+                    Point::new(*x, y) * 2 - self.center_2x,
+                    self.threshold,
+                )
+            })
+            // shorten the scanline by right side of the same amount as the left side
+            .map(|x| Scanline::new(y, x..self.columns.end - (x - self.columns.start)))
     }
 }
 

--- a/src/primitives/ellipse/styled.rs
+++ b/src/primitives/ellipse/styled.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 /// Pixel iterator for each pixel in the ellipse border
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct StyledPixels<C>
 where
     C: PixelColor,

--- a/src/primitives/ellipse/styled.rs
+++ b/src/primitives/ellipse/styled.rs
@@ -4,7 +4,8 @@ use crate::{
     iterator::IntoPixels,
     pixelcolor::PixelColor,
     primitives::{
-        ellipse::{compute_threshold, is_point_inside_ellipse, points::Points, Ellipse},
+        common::{Scanline, StyledScanline},
+        ellipse::{compute_threshold, is_point_inside_ellipse, points::Scanlines, Ellipse},
         PrimitiveStyle, Rectangle, StyledPrimitiveAreas,
     },
     Drawable, Pixel, SaturatingCast, Styled,
@@ -16,12 +17,14 @@ pub struct StyledPixels<C>
 where
     C: PixelColor,
 {
-    iter: Points,
-    outer_color: Option<C>,
-    inner_size_sq: Size,
-    inner_color: Option<C>,
-    center: Point,
-    threshold: u32,
+    styled_scanlines: StyledScanlines,
+
+    stroke_left: Scanline,
+    fill: Scanline,
+    stroke_right: Scanline,
+
+    stroke_color: Option<C>,
+    fill_color: Option<C>,
 }
 
 impl<C> StyledPixels<C>
@@ -29,22 +32,16 @@ where
     C: PixelColor,
 {
     pub(in crate::primitives) fn new(styled: &Styled<Ellipse, PrimitiveStyle<C>>) -> Self {
-        let iter = if !styled.style.is_transparent() {
-            Points::new(&styled.stroke_area())
-        } else {
-            Points::empty()
-        };
-
+        let stroke_area = styled.stroke_area();
         let fill_area = styled.fill_area();
-        let (inner_size_sq, threshold) = compute_threshold(fill_area.size);
 
         Self {
-            iter,
-            outer_color: styled.style.stroke_color,
-            inner_size_sq,
-            inner_color: styled.style.fill_color,
-            center: styled.primitive.center_2x(),
-            threshold,
+            styled_scanlines: StyledScanlines::new(&stroke_area, &fill_area),
+            stroke_left: Scanline::new_empty(0),
+            fill: Scanline::new_empty(0),
+            stroke_right: Scanline::new_empty(0),
+            stroke_color: styled.style.stroke_color,
+            fill_color: styled.style.fill_color,
         }
     }
 }
@@ -56,25 +53,47 @@ where
     type Item = Pixel<C>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        for point in &mut self.iter {
-            let inside_border = is_point_inside_ellipse(
-                self.inner_size_sq,
-                point * 2 - self.center,
-                self.threshold,
-            );
+        match (self.stroke_color, self.fill_color) {
+            (Some(stroke_color), None) => loop {
+                if let Some(pixel) = self
+                    .stroke_left
+                    .next()
+                    .or_else(|| self.stroke_right.next())
+                    .map(|p| Pixel(p, stroke_color))
+                {
+                    return Some(pixel);
+                }
 
-            let color = if inside_border {
-                self.inner_color
-            } else {
-                self.outer_color
-            };
+                let scanline = self.styled_scanlines.next()?;
+                self.stroke_left = scanline.stroke_left();
+                self.stroke_right = scanline.stroke_right();
+            },
+            (Some(stroke_color), Some(fill_color)) => loop {
+                if let Some(pixel) = self
+                    .stroke_left
+                    .next()
+                    .map(|p| Pixel(p, stroke_color))
+                    .or_else(|| self.fill.next().map(|p| Pixel(p, fill_color)))
+                    .or_else(|| self.stroke_right.next().map(|p| Pixel(p, stroke_color)))
+                {
+                    return Some(pixel);
+                }
 
-            if let Some(color) = color {
-                return Some(Pixel(point, color));
-            }
+                let scanline = self.styled_scanlines.next()?;
+                self.stroke_left = scanline.stroke_left();
+                self.fill = scanline.fill();
+                self.stroke_right = scanline.stroke_right();
+            },
+            (None, Some(fill_color)) => loop {
+                if let Some(pixel) = self.fill.next().map(|p| Pixel(p, fill_color)) {
+                    return Some(pixel);
+                }
+
+                let scanline = self.styled_scanlines.next()?;
+                self.fill = scanline.fill();
+            },
+            (None, None) => None,
         }
-
-        None
     }
 }
 
@@ -98,11 +117,30 @@ where
     type Color = C;
     type Output = ();
 
-    fn draw<D>(&self, display: &mut D) -> Result<Self::Output, D::Error>
+    fn draw<D>(&self, target: &mut D) -> Result<Self::Output, D::Error>
     where
         D: DrawTarget<Color = C>,
     {
-        display.draw_iter(self.into_pixels())
+        match (self.style.effective_stroke_color(), self.style.fill_color) {
+            (Some(stroke_color), None) => {
+                for scanline in StyledScanlines::new(&self.stroke_area(), &self.fill_area()) {
+                    scanline.draw_stroke(target, stroke_color)?;
+                }
+            }
+            (Some(stroke_color), Some(fill_color)) => {
+                for scanline in StyledScanlines::new(&self.stroke_area(), &self.fill_area()) {
+                    scanline.draw_stroke_and_fill(target, stroke_color, fill_color)?;
+                }
+            }
+            (None, Some(fill_color)) => {
+                for scanline in Scanlines::new(&self.fill_area()) {
+                    scanline.draw(target, fill_color)?;
+                }
+            }
+            (None, None) => {}
+        }
+
+        Ok(())
     }
 }
 
@@ -117,11 +155,53 @@ where
     }
 }
 
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+struct StyledScanlines {
+    scanlines: Scanlines,
+    fill_size_sq: Size,
+    fill_threshold: u32,
+}
+
+impl StyledScanlines {
+    pub fn new(stroke_area: &Ellipse, fill_area: &Ellipse) -> Self {
+        let (fill_size_sq, fill_threshold) = compute_threshold(fill_area.size);
+
+        Self {
+            scanlines: Scanlines::new(stroke_area),
+            fill_size_sq,
+            fill_threshold,
+        }
+    }
+}
+
+impl Iterator for StyledScanlines {
+    type Item = StyledScanline;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.scanlines.next().map(|scanline| {
+            let fill_range = scanline
+                .x
+                .clone()
+                .find(|x| {
+                    is_point_inside_ellipse(
+                        self.fill_size_sq,
+                        Point::new(*x, scanline.y) * 2 - self.scanlines.center_2x,
+                        self.fill_threshold,
+                    )
+                })
+                .map(|x| x..scanline.x.end - (x - scanline.x.start));
+
+            StyledScanline::new(scanline.y, scanline.x, fill_range)
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
         geometry::{Point, Size},
+        iterator::PixelIteratorExt,
         mock_display::MockDisplay,
         pixelcolor::BinaryColor,
         primitives::{Circle, Primitive, PrimitiveStyle, PrimitiveStyleBuilder, StrokeAlignment},
@@ -149,14 +229,15 @@ mod tests {
     }
 
     fn test_ellipse(size: Size, style: PrimitiveStyle<BinaryColor>, pattern: &[&str]) {
-        let mut display = MockDisplay::new();
+        let ellipse = Ellipse::new(Point::new(0, 0), size).into_styled(style);
 
-        Ellipse::new(Point::new(0, 0), size)
-            .into_styled(style)
-            .draw(&mut display)
-            .unwrap();
+        let mut drawable = MockDisplay::new();
+        ellipse.draw(&mut drawable).unwrap();
+        drawable.assert_pattern(pattern);
 
-        display.assert_pattern(pattern);
+        let mut into_pixels = MockDisplay::new();
+        ellipse.into_pixels().draw(&mut into_pixels).unwrap();
+        into_pixels.assert_pattern(pattern);
     }
 
     #[test]

--- a/src/primitives/polyline/scanline_intersections.rs
+++ b/src/primitives/polyline/scanline_intersections.rs
@@ -44,7 +44,7 @@ impl<'a> ScanlineIntersections<'a> {
             width,
             points,
             remaining_points: points,
-            scanline: Scanline::new(scanline_y),
+            scanline: Scanline::new_empty(scanline_y),
         }
     }
 
@@ -55,7 +55,7 @@ impl<'a> ScanlineIntersections<'a> {
             width: 0,
             points: EMPTY,
             remaining_points: EMPTY,
-            scanline: Scanline::new(0),
+            scanline: Scanline::new_empty(0),
         }
     }
 

--- a/src/primitives/polyline/styled.rs
+++ b/src/primitives/polyline/styled.rs
@@ -90,7 +90,9 @@ where
             StyledIter::Thin(styled.primitive.points())
         } else {
             let mut scanline_iter = ScanlineIterator::new(styled);
-            let line_iter = scanline_iter.next().unwrap_or_else(|| Scanline::new(0));
+            let line_iter = scanline_iter
+                .next()
+                .unwrap_or_else(|| Scanline::new_empty(0));
 
             StyledIter::Thick {
                 scanline_iter,

--- a/src/primitives/rectangle/styled.rs
+++ b/src/primitives/rectangle/styled.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 /// Pixel iterator for each pixel in the rect border
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct StyledPixels<C>
 where
     C: PixelColor,

--- a/src/primitives/rounded_rectangle/ellipse_quadrant.rs
+++ b/src/primitives/rounded_rectangle/ellipse_quadrant.rs
@@ -66,7 +66,7 @@ impl ContainsPoint for EllipseQuadrant {
     }
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub(in crate::primitives) struct Points {
     iter: rectangle::Points,
     size_sq: Size,

--- a/src/primitives/rounded_rectangle/ellipse_quadrant.rs
+++ b/src/primitives/rounded_rectangle/ellipse_quadrant.rs
@@ -2,8 +2,8 @@ use crate::{
     geometry::{Dimensions, Point, Size},
     primitives::{
         ellipse::{self, EllipseContains},
-        rectangle::{self, Rectangle},
-        ContainsPoint, PointsIter, Primitive,
+        rectangle::Rectangle,
+        ContainsPoint,
     },
 };
 
@@ -46,58 +46,9 @@ impl Dimensions for EllipseQuadrant {
     }
 }
 
-impl Primitive for EllipseQuadrant {}
-
-impl PointsIter for EllipseQuadrant {
-    type Iter = Points;
-
-    fn points(&self) -> Self::Iter {
-        Points::new(self)
-    }
-}
-
 impl ContainsPoint for EllipseQuadrant {
     fn contains(&self, point: Point) -> bool {
         self.ellipse.contains(point * 2 - self.center_2x)
-    }
-}
-
-#[derive(Clone, Eq, PartialEq, Hash, Debug)]
-pub(in crate::primitives) struct Points {
-    iter: rectangle::Points,
-    center_2x: Point,
-    ellipse: EllipseContains,
-}
-
-impl Points {
-    pub fn new(ellipse_quadrant: &EllipseQuadrant) -> Self {
-        Self {
-            iter: ellipse_quadrant.bounding_box().points(),
-            center_2x: ellipse_quadrant.center_2x,
-            ellipse: ellipse_quadrant.ellipse,
-        }
-    }
-
-    pub(in crate::primitives) const fn empty() -> Self {
-        Self {
-            iter: rectangle::Points::empty(),
-            center_2x: Point::zero(),
-            ellipse: EllipseContains::empty(),
-        }
-    }
-}
-
-impl Iterator for Points {
-    type Item = Point;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        for point in &mut self.iter {
-            if self.ellipse.contains(point * 2 - self.center_2x) {
-                return Some(point);
-            }
-        }
-
-        None
     }
 }
 
@@ -105,12 +56,26 @@ impl Iterator for Points {
 mod tests {
     use super::*;
     use crate::{
+        draw_target::DrawTarget,
         geometry::{Point, Size},
         iterator::PixelIteratorExt,
         mock_display::MockDisplay,
         pixelcolor::BinaryColor,
+        primitives::PointsIter,
         Pixel,
     };
+
+    fn draw_quadrant<D: DrawTarget<Color = BinaryColor>>(
+        quadrant: &EllipseQuadrant,
+        target: &mut D,
+    ) -> Result<(), D::Error> {
+        quadrant
+            .bounding_box
+            .points()
+            .filter(|p| quadrant.contains(*p))
+            .map(|p| Pixel(p, BinaryColor::On))
+            .draw(target)
+    }
 
     #[test]
     fn quadrants_even_size() {
@@ -158,14 +123,11 @@ mod tests {
         ];
 
         for (quadrant, expected) in cases.iter() {
+            let ellipse_quadrant =
+                EllipseQuadrant::new(Point::new(0, 0), Size::new(10, 5), *quadrant);
+
             let mut display = MockDisplay::new();
-
-            EllipseQuadrant::new(Point::new(0, 0), Size::new(10, 5), *quadrant)
-                .points()
-                .map(|p| Pixel(p, BinaryColor::On))
-                .draw(&mut display)
-                .unwrap();
-
+            draw_quadrant(&ellipse_quadrant, &mut display).unwrap();
             display.assert_pattern(*expected);
         }
     }
@@ -177,20 +139,26 @@ mod tests {
         let radius = Size::new(10, 5);
         let top_left = Point::new(0, 0);
 
-        EllipseQuadrant::new(top_left, radius, Quadrant::TopLeft)
-            .points()
-            .chain(
-                EllipseQuadrant::new(top_left + radius.x_axis(), radius, Quadrant::TopRight)
-                    .points(),
-            )
-            .chain(EllipseQuadrant::new(top_left + radius, radius, Quadrant::BottomRight).points())
-            .chain(
-                EllipseQuadrant::new(top_left + radius.y_axis(), radius, Quadrant::BottomLeft)
-                    .points(),
-            )
-            .map(|p| Pixel(p, BinaryColor::On))
-            .draw(&mut display)
-            .unwrap();
+        draw_quadrant(
+            &EllipseQuadrant::new(top_left, radius, Quadrant::TopLeft),
+            &mut display,
+        )
+        .unwrap();
+        draw_quadrant(
+            &EllipseQuadrant::new(top_left + radius.x_axis(), radius, Quadrant::TopRight),
+            &mut display,
+        )
+        .unwrap();
+        draw_quadrant(
+            &EllipseQuadrant::new(top_left + radius, radius, Quadrant::BottomRight),
+            &mut display,
+        )
+        .unwrap();
+        draw_quadrant(
+            &EllipseQuadrant::new(top_left + radius.y_axis(), radius, Quadrant::BottomLeft),
+            &mut display,
+        )
+        .unwrap();
 
         display.assert_pattern(&[
             "      ########      ",
@@ -213,20 +181,26 @@ mod tests {
         let radius = Size::new(7, 9);
         let top_left = Point::new(0, 0);
 
-        EllipseQuadrant::new(top_left, radius, Quadrant::TopLeft)
-            .points()
-            .chain(
-                EllipseQuadrant::new(top_left + radius.x_axis(), radius, Quadrant::TopRight)
-                    .points(),
-            )
-            .chain(EllipseQuadrant::new(top_left + radius, radius, Quadrant::BottomRight).points())
-            .chain(
-                EllipseQuadrant::new(top_left + radius.y_axis(), radius, Quadrant::BottomLeft)
-                    .points(),
-            )
-            .map(|p| Pixel(p, BinaryColor::On))
-            .draw(&mut display)
-            .unwrap();
+        draw_quadrant(
+            &EllipseQuadrant::new(top_left, radius, Quadrant::TopLeft),
+            &mut display,
+        )
+        .unwrap();
+        draw_quadrant(
+            &EllipseQuadrant::new(top_left + radius.x_axis(), radius, Quadrant::TopRight),
+            &mut display,
+        )
+        .unwrap();
+        draw_quadrant(
+            &EllipseQuadrant::new(top_left + radius, radius, Quadrant::BottomRight),
+            &mut display,
+        )
+        .unwrap();
+        draw_quadrant(
+            &EllipseQuadrant::new(top_left + radius.y_axis(), radius, Quadrant::BottomLeft),
+            &mut display,
+        )
+        .unwrap();
 
         display.assert_pattern(&[
             "     ####     ",

--- a/src/primitives/rounded_rectangle/points.rs
+++ b/src/primitives/rounded_rectangle/points.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 /// Iterator over all points inside the rounded rectangle.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct Points {
     rect_iter: rectangle::Points,
 

--- a/src/primitives/rounded_rectangle/styled.rs
+++ b/src/primitives/rounded_rectangle/styled.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 /// Pixel iterator for each pixel in the rect border
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct StyledPixels<C>
 where
     C: PixelColor,

--- a/src/primitives/sector/points.rs
+++ b/src/primitives/sector/points.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 /// Iterator over all points inside the sector.
-#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct Points {
     iter: DistanceIterator,
 

--- a/src/primitives/sector/styled.rs
+++ b/src/primitives/sector/styled.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 /// Pixel iterator for each pixel in the sector border
-#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct StyledPixels<C>
 where
     C: PixelColor,

--- a/src/primitives/triangle/mod.rs
+++ b/src/primitives/triangle/mod.rs
@@ -332,7 +332,7 @@ fn sort_two_yx(p1: Point, p2: Point) -> (Point, Point) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{geometry::Size, mock_display::MockDisplay};
+    use crate::{geometry::Size, mock_display::MockDisplay, pixelcolor::BinaryColor};
 
     #[test]
     fn dimensions() {
@@ -370,7 +370,7 @@ mod tests {
         ];
 
         for triangle in triangles.iter() {
-            let expected = MockDisplay::from_points(triangle.points());
+            let expected = MockDisplay::from_points(triangle.points(), BinaryColor::On);
 
             for point in Rectangle::new(Point::new(-5, -5), Size::new(70, 70)).points() {
                 let should_contain =

--- a/src/primitives/triangle/mod.rs
+++ b/src/primitives/triangle/mod.rs
@@ -212,7 +212,7 @@ impl Triangle {
     ) -> Scanline {
         let [p1, p2, p3] = self.sorted_yx().vertices;
 
-        let mut scanline = Scanline::new(scanline_y);
+        let mut scanline = Scanline::new_empty(scanline_y);
 
         // Triangle is colinear. We can get away with only intersecting the single line.
         if self.area_doubled() == 0 {

--- a/src/primitives/triangle/points.rs
+++ b/src/primitives/triangle/points.rs
@@ -23,7 +23,7 @@ impl Points {
             &triangle.bounding_box(),
         );
 
-        let current_line = Scanline::new(0);
+        let current_line = Scanline::new_empty(0);
 
         Self {
             scanline_iter,

--- a/src/primitives/triangle/scanline_intersections.rs
+++ b/src/primitives/triangle/scanline_intersections.rs
@@ -60,9 +60,9 @@ impl ScanlineIntersections {
     pub const fn empty() -> Self {
         Self {
             lines: LineConfig {
-                first: Scanline::new(0),
-                second: Scanline::new(0),
-                internal: Scanline::new(0),
+                first: Scanline::new_empty(0),
+                second: Scanline::new_empty(0),
+                internal: Scanline::new_empty(0),
                 internal_type: PointType::Fill,
             },
             has_fill: false,
@@ -82,8 +82,8 @@ impl ScanlineIntersections {
 
     fn edge_intersections(&self, scanline_y: i32) -> impl Iterator<Item = Scanline> + '_ {
         let mut idx = 0;
-        let mut left = Scanline::new(scanline_y);
-        let mut right = Scanline::new(scanline_y);
+        let mut left = Scanline::new_empty(scanline_y);
+        let mut right = Scanline::new_empty(scanline_y);
 
         core::iter::from_fn(move || {
             if self.stroke_width == 0 {
@@ -128,7 +128,7 @@ impl ScanlineIntersections {
 
             // Merge any overlap between final left/right results
             if left.try_extend(&right) {
-                right = Scanline::new(scanline_y);
+                right = Scanline::new_empty(scanline_y);
             }
 
             left.try_take().or_else(|| right.try_take())
@@ -142,8 +142,8 @@ impl ScanlineIntersections {
             Some(LineConfig {
                 internal: self.triangle.scanline_intersection(scanline_y),
                 internal_type: PointType::Stroke,
-                first: Scanline::new(0),
-                second: Scanline::new(0),
+                first: Scanline::new_empty(0),
+                second: Scanline::new_empty(0),
             })
         } else {
             let first = edge_intersections.next();
@@ -172,15 +172,15 @@ impl ScanlineIntersections {
                     // Because a triangle is a closed shape, a single intersection here likely means
                     // we're inside one of the borders, so no fill should be returned for this
                     // scanline.
-                    _ => Scanline::new(scanline_y),
+                    _ => Scanline::new_empty(scanline_y),
                 }
             } else {
-                Scanline::new(scanline_y)
+                Scanline::new_empty(scanline_y)
             };
 
             Some(LineConfig {
-                first: first.unwrap_or(Scanline::new(scanline_y)),
-                second: second.unwrap_or(Scanline::new(scanline_y)),
+                first: first.unwrap_or(Scanline::new_empty(scanline_y)),
+                second: second.unwrap_or(Scanline::new_empty(scanline_y)),
                 internal,
                 internal_type: PointType::Fill,
             })

--- a/src/primitives/triangle/styled.rs
+++ b/src/primitives/triangle/styled.rs
@@ -41,7 +41,7 @@ where
 
         let (current_line, point_type) = lines_iter
             .next()
-            .unwrap_or_else(|| (Scanline::new(0), PointType::Stroke));
+            .unwrap_or_else(|| (Scanline::new_empty(0), PointType::Stroke));
 
         let current_color = match point_type {
             PointType::Stroke => styled.style.effective_stroke_color(),


### PR DESCRIPTION
This PR changes the `Drawable` impls for `Circle`, `Ellipse` and `RoundedRectangle` to use scanlines for improved drawing performance.