### PR TITLE
Make MonoFont fields public

### DIFF
--- a/src/mono_font/mono_text_style.rs
+++ b/src/mono_font/mono_text_style.rs
@@ -502,7 +502,7 @@ mod tests {
         mono_font::{
             ascii::{FONT_10X20, FONT_6X9},
             tests::*,
-            Decoration,
+            DecorationDimensions,
         },
         pixelcolor::{BinaryColor, Rgb888, RgbColor},
         text::{Text, TextStyleBuilder},
@@ -511,7 +511,7 @@ mod tests {
 
     const SPACED_FONT: MonoFont = MonoFont {
         character_spacing: 5,
-        underline: Decoration::new(9, 1),
+        underline: DecorationDimensions::new(9, 1),
         ..FONT_6X9
     };
 


### PR DESCRIPTION
The changes in PR #573 made the parameters of `MonoFont`s inaccessible outside the e-g crate. But some crates need access to this information (e-t uses the values in tests). This PR makes the fields public and adds a `non_exhaustive` attribute to `MonoFont`.
