### PR TITLE
Use bounding_box instead of Rectangle::new

### DIFF
--- a/core/src/draw_target/mod.rs
+++ b/core/src/draw_target/mod.rs
@@ -203,7 +203,7 @@ use crate::{
 ///         // Clamp the rectangle coordinates to the valid range by determining
 ///         // the intersection of the fill area and the visible display area
 ///         // by using Rectangle::intersection.
-///         let area = area.intersection(&Rectangle::new(Point::zero(), self.size()));
+///         let area = area.intersection(&self.bounding_box());
 ///
 ///         // Do not send a draw rectangle command if the intersection size if zero.
 ///         // The size is checked by using `Rectangle::bottom_right`, which returns `None`
@@ -359,7 +359,7 @@ pub trait DrawTarget: Dimensions {
     ///         I: IntoIterator<Item = Self::Color>,
     ///     {
     ///         // Clamp area to drawable part of the display target
-    ///         let drawable_area = area.intersection(&Rectangle::new(Point::zero(), self.size()));
+    ///         let drawable_area = area.intersection(&self.bounding_box());
     ///
     ///         // Check that there are visible pixels to be drawn
     ///         if drawable_area.size != Size::zero() {

--- a/src/draw_target/cropped.rs
+++ b/src/draw_target/cropped.rs
@@ -1,6 +1,6 @@
 use crate::{
     draw_target::{DrawTarget, DrawTargetExt, Translated},
-    geometry::{Dimensions, Point, Size},
+    geometry::{OriginDimensions, Size},
     primitives::Rectangle,
     Pixel,
 };
@@ -61,12 +61,12 @@ where
     }
 }
 
-impl<T> Dimensions for Cropped<'_, T>
+impl<T> OriginDimensions for Cropped<'_, T>
 where
     T: DrawTarget,
 {
-    fn bounding_box(&self) -> Rectangle {
-        Rectangle::new(Point::zero(), self.size)
+    fn size(&self) -> Size {
+        self.size
     }
 }
 

--- a/src/mock_display/mod.rs
+++ b/src/mock_display/mod.rs
@@ -343,7 +343,7 @@ where
         if let (Some(tl), Some(br)) = (tl, br) {
             Rectangle::with_corners(tl, br)
         } else {
-            Rectangle::new(Point::zero(), Size::zero())
+            Rectangle::zero()
         }
     }
 
@@ -418,7 +418,7 @@ where
     pub fn swap_xy(&self) -> MockDisplay<C> {
         let mut mirrored = MockDisplay::new();
 
-        for point in Rectangle::new(Point::zero(), self.size()).points() {
+        for point in self.bounding_box().points() {
             mirrored.set_pixel_unchecked(point, self.get_pixel(Point::new(point.y, point.x)));
         }
 
@@ -457,7 +457,7 @@ where
     {
         let mut target = MockDisplay::new();
 
-        for point in Rectangle::new(Point::zero(), self.size()).points() {
+        for point in self.bounding_box().points() {
             target.set_pixel_unchecked(point, self.get_pixel(point).map(f))
         }
 
@@ -798,11 +798,7 @@ mod tests {
     #[test]
     fn zero_sized_affected_area() {
         let disp: MockDisplay<BinaryColor> = MockDisplay::new();
-
-        assert_eq!(
-            disp.affected_area(),
-            Rectangle::new(Point::zero(), Size::zero())
-        );
+        assert!(disp.affected_area().is_zero_sized(),);
     }
 
     #[test]

--- a/src/primitives/ellipse/mod.rs
+++ b/src/primitives/ellipse/mod.rs
@@ -227,7 +227,8 @@ mod tests {
         let ellipse = Ellipse::new(Point::zero(), Size::new(40, 20));
 
         let display = MockDisplay::from_points(
-            Rectangle::new(Point::zero(), Size::new(40, 20))
+            ellipse
+                .bounding_box()
                 .points()
                 .filter(|p| ellipse.contains(*p)),
             BinaryColor::On,

--- a/src/primitives/rectangle/mod.rs
+++ b/src/primitives/rectangle/mod.rs
@@ -167,10 +167,7 @@ mod tests {
         let rect1 = Rectangle::new(Point::new_equal(10), Size::new(20, 30));
         let rect2 = Rectangle::new(Point::new_equal(35), Size::new(30, 40));
 
-        assert_eq!(
-            rect1.intersection(&rect2),
-            Rectangle::new(Point::zero(), Size::zero())
-        );
+        assert!(rect1.intersection(&rect2).is_zero_sized());
     }
 
     #[test]


### PR DESCRIPTION
This PR changes some `Rectangle::new(Point::zero(), ...)` expressions to use `bounding_box` instead, which makes the intent of these statements clearer.

These changes are a replacement for #448. While not all instances of `Rectangle::new(Point::zero(), ...)` can be replaced by `bounding_box` some of the other code is clearer without using `Size::to_rectangle`.

Closes #448 