### PR TITLE
Add support for target specific drawables and text renderers

### DIFF
--- a/core/src/drawable.rs
+++ b/core/src/drawable.rs
@@ -68,31 +68,69 @@ pub trait Drawable {
     /// The pixel color type.
     type Color: PixelColor;
 
-    // TODO: Remove `ignore` from example code when the `Text` drawable is updated
-    // CC https://github.com/embedded-graphics/embedded-graphics/pull/552#discussion_r576955191
     /// The return type of the [`draw`] method.
     ///
     /// The `Output` type can be used to return results and values produced from the drawing of the
     /// current item. For example, rendering two differently styled text items next to each other
     /// can make use of a returned value, allowing the next text to be positioned after the first:
     ///
-    /// ```rust,ignore
+    /// ```
+    /// use embedded_graphics::{
+    ///     mono_font::{
+    ///         ascii::{FONT_10X20, FONT_6X10},
+    ///         MonoTextStyle,
+    ///     },
+    ///     pixelcolor::BinaryColor,
+    ///     prelude::*,
+    ///     text::Text,
+    /// };
+    ///
+    /// # let mut display = embedded_graphics::mock_display::MockDisplay::new();
+    /// # display.set_allow_out_of_bounds_drawing(true);
+    /// let label_style = MonoTextStyle::new(&FONT_6X10, BinaryColor::On);
+    /// let value_style = MonoTextStyle::new(&FONT_10X20, BinaryColor::On);
+    ///
     /// let next_point = Text::new("Label ", Point::new(10, 20))
     ///     .into_styled(label_style)
     ///     .draw(&mut display)?;
     ///
-    /// Text::new("Value", next_point).into_styled(value_style).draw(&mut display)?;
+    /// Text::new("1234", next_point)
+    ///     .into_styled(value_style)
+    ///     .draw(&mut display)?;
+    /// # Ok::<(), core::convert::Infallible>(())
     /// ```
     ///
     /// Use `()` if no value should be returned.
     ///
-    /// [`draw`]: #method.draw
+    /// [`draw`]: #tymethod.draw
     type Output;
 
     /// Draw the graphics object using the supplied DrawTarget.
     fn draw<D>(&self, target: &mut D) -> Result<Self::Output, D::Error>
     where
         D: DrawTarget<Color = Self::Color>;
+}
+
+/// Target specific drawable.
+///
+/// This trait is a target specific version of the [`Drawable`] trait. It can be implemented if it
+/// is necessary to access target functions which aren't accessible using the [`DrawTarget`]
+/// trait implementation. This could, for example, be used to expose hardware accelerated drawing
+/// functions of a display controller to the user.
+///
+/// [`Drawable`]: trait.Drawable.html
+/// [`DrawTarget`]: draw_target/trait.DrawTarget.html
+pub trait TargetSpecificDrawable<D: DrawTarget> {
+    /// The return type of the [`draw`] method.
+    ///
+    /// See the [`Drawable::Output`] docs for more information.
+    ///
+    /// [`draw`]: #tymethod.draw
+    /// [`Drawable::Output`]: trait.Drawable.html#associatedtype.Output
+    type Output;
+
+    /// Draws the drawable to the given draw target.
+    fn draw(&self, target: &mut D) -> Result<Self::Output, D::Error>;
 }
 
 /// A single pixel.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -72,7 +72,7 @@ pub mod pixelcolor;
 pub mod prelude;
 pub mod primitives;
 
-pub use drawable::{Drawable, Pixel};
+pub use drawable::{Drawable, Pixel, TargetSpecificDrawable};
 
 /// Trait to convert unsigned into signed integer.
 trait SaturatingCast<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,7 +233,7 @@ mod styled;
 pub mod text;
 pub mod transform;
 
-pub use embedded_graphics_core::{pixelcolor, Drawable, Pixel};
+pub use embedded_graphics_core::{pixelcolor, Drawable, Pixel, TargetSpecificDrawable};
 pub use styled::Styled;
 
 /// Trait to convert unsigned into signed integer.

--- a/src/mock_display/mod.rs
+++ b/src/mock_display/mod.rs
@@ -291,7 +291,7 @@ where
     /// # Panics
     ///
     /// This method will panic if `point` is outside the display bounding box.
-    fn set_pixel(&mut self, point: Point, color: Option<C>) {
+    pub fn set_pixel(&mut self, point: Point, color: Option<C>) {
         assert!(
             point.x >= 0 && point.y >= 0 && point.x < SIZE as i32 && point.y < SIZE as i32,
             "point must be inside display bounding box: {:?}",

--- a/src/mono_font/mono_text_style.rs
+++ b/src/mono_font/mono_text_style.rs
@@ -9,7 +9,7 @@ use crate::{
     pixelcolor::{BinaryColor, PixelColor},
     primitives::Rectangle,
     text::{
-        renderer::{CharacterStyle, TextMetrics, TextRenderer},
+        renderer::{CharacterStyle, ModifyCharacterStyle, TextMetrics, TextRenderer},
         Baseline, DecorationColor,
     },
     Drawable, SaturatingCast,
@@ -255,7 +255,9 @@ impl<C: PixelColor> TextRenderer for MonoTextStyle<'_, '_, '_, C> {
 
         Ok(position + Point::new(width.saturating_cast(), self.baseline_offset(baseline)))
     }
+}
 
+impl<C: PixelColor> CharacterStyle for MonoTextStyle<'_, '_, '_, C> {
     fn measure_string(&self, text: &str, position: Point, baseline: Baseline) -> TextMetrics {
         let bb_position = position - Point::new(0, self.baseline_offset(baseline));
 
@@ -282,7 +284,7 @@ impl<C: PixelColor> TextRenderer for MonoTextStyle<'_, '_, '_, C> {
     }
 }
 
-impl<C> CharacterStyle for MonoTextStyle<'_, '_, '_, C>
+impl<C: PixelColor> ModifyCharacterStyle for MonoTextStyle<'_, '_, '_, C>
 where
     C: PixelColor,
 {
@@ -1021,12 +1023,12 @@ mod tests {
     }
 
     #[test]
-    fn character_style() {
+    fn modify_character_style() {
         let mut style = MonoTextStyle::new(&FONT_6X9, BinaryColor::On);
-        CharacterStyle::set_text_color(&mut style, None);
-        CharacterStyle::set_background_color(&mut style, Some(BinaryColor::On));
-        CharacterStyle::set_underline_color(&mut style, DecorationColor::TextColor);
-        CharacterStyle::set_strikethrough_color(
+        ModifyCharacterStyle::set_text_color(&mut style, None);
+        ModifyCharacterStyle::set_background_color(&mut style, Some(BinaryColor::On));
+        ModifyCharacterStyle::set_underline_color(&mut style, DecorationColor::TextColor);
+        ModifyCharacterStyle::set_strikethrough_color(
             &mut style,
             DecorationColor::Custom(BinaryColor::On),
         );

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -12,5 +12,5 @@ pub use crate::{
     },
     primitives::{ContainsPoint, OffsetOutline, PointsIter, Primitive, StyledPrimitiveAreas},
     transform::Transform,
-    Drawable, Pixel,
+    Drawable, Pixel, TargetSpecificDrawable,
 };

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -10,11 +10,12 @@
 //!         - Draw text with multiple styles by using the result of `Text.draw(...)`
 //!       - Link to `renderer` module docs for users who want to implement custom renderers.
 
+use crate::pixelcolor::PixelColor;
+
 pub mod renderer;
 mod text;
 mod text_style;
 
-use embedded_graphics_core::prelude::PixelColor;
 pub use text::Text;
 pub use text_style::{TextStyle, TextStyleBuilder};
 

--- a/src/text/renderer/character_style.rs
+++ b/src/text/renderer/character_style.rs
@@ -1,6 +1,34 @@
-use crate::{pixelcolor::PixelColor, text::DecorationColor};
+use crate::{
+    geometry::Point,
+    pixelcolor::PixelColor,
+    primitives::Rectangle,
+    text::{Baseline, DecorationColor},
+};
 
-/// Character style.
+/// TODO: docs
+pub trait CharacterStyle: Clone {
+    /// Returns the text metrics for a string.
+    ///
+    /// # Implementation notes
+    ///
+    /// The returned bounding box must be independent of the text color. This is different to the
+    /// `Dimensions` trait, which should return a zero sized bounding box for completely transparent
+    /// drawables. But this behavior would make it impossible to correctly layout text which
+    /// contains a mixture of transparent and non transparent words.
+    ///
+    /// This method must not interpret any control characters and only render a single line of text.
+    /// Any control character in the `text` should be handled the same way as any other character
+    /// that isn't included in the font.
+    fn measure_string(&self, text: &str, position: Point, baseline: Baseline) -> TextMetrics;
+
+    /// Returns the default line height.
+    ///
+    /// The line height is defined as the vertical distance between the baseline of two adjacent
+    /// lines in pixels.
+    fn line_height(&self) -> u32;
+}
+
+/// Modify character style.
 ///
 /// This trait is used to modify character styles programmatically, for example, to implement
 /// rendering of text with multiple colors. Applications shouldn't use this trait and instead use
@@ -12,7 +40,7 @@ use crate::{pixelcolor::PixelColor, text::DecorationColor};
 /// Text renderers don't need to support all settings in this trait. All calls to unsupported
 /// setters should be ignored by the implementation. The trait provided empty default
 /// implementations for all setters.
-pub trait CharacterStyle: Clone {
+pub trait ModifyCharacterStyle: CharacterStyle {
     /// The color type.
     type Color: PixelColor;
 
@@ -27,4 +55,18 @@ pub trait CharacterStyle: Clone {
 
     /// Sets the strikethrough color.
     fn set_strikethrough_color(&mut self, _strikethrough_color: DecorationColor<Self::Color>) {}
+}
+
+/// Text metrics.
+///
+/// See [`TextRenderer::measure_string`] for more information.
+///
+/// [`TextRenderer::measure_string`]: trait.TextRenderer.html#tymethod.measure_string
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub struct TextMetrics {
+    /// Bounding box.
+    pub bounding_box: Rectangle,
+
+    /// The position of the next text.
+    pub next_position: Point,
 }

--- a/src/text/renderer/mod.rs
+++ b/src/text/renderer/mod.rs
@@ -3,14 +3,11 @@
 //! TODO: Describe how this API can be implemented and add an example to the docs or link to an
 //!       external example.
 
-use crate::{
-    draw_target::DrawTarget, geometry::Point, pixelcolor::PixelColor, primitives::Rectangle,
-    text::Baseline,
-};
+use crate::{draw_target::DrawTarget, geometry::Point, pixelcolor::PixelColor, text::Baseline};
 
 mod character_style;
 
-pub use character_style::CharacterStyle;
+pub use character_style::{CharacterStyle, ModifyCharacterStyle, TextMetrics};
 
 /// Text renderer.
 ///
@@ -53,38 +50,41 @@ pub trait TextRenderer {
     ) -> Result<Point, D::Error>
     where
         D: DrawTarget<Color = Self::Color>;
+}
 
-    /// Returns the text metrics for a string.
+/// Target specific text renderer.
+///
+/// This trait is a target specific version of the [`TextRenderer`] trait.
+/// 
+/// [`TextRenderer`]: trait.TextRenderer.html
+pub trait TargetSpecificTextRenderer<D: DrawTarget> {
+    /// Draws a string.
+    ///
+    /// The method returns the start position of the next character to allow chaining of multiple
+    /// draw calls.
     ///
     /// # Implementation notes
-    ///
-    /// The returned bounding box must be independent of the text color. This is different to the
-    /// `Dimensions` trait, which should return a zero sized bounding box for completely transparent
-    /// drawables. But this behavior would make it impossible to correctly layout text which
-    /// contains a mixture of transparent and non transparent words.
     ///
     /// This method must not interpret any control characters and only render a single line of text.
     /// Any control character in the `text` should be handled the same way as any other character
     /// that isn't included in the font.
-    fn measure_string(&self, text: &str, position: Point, baseline: Baseline) -> TextMetrics;
+    fn draw_string(
+        &self,
+        text: &str,
+        position: Point,
+        baseline: Baseline,
+        target: &mut D,
+    ) -> Result<Point, D::Error>;
 
-    /// Returns the default line height.
+    /// Draws whitespace of the given width.
     ///
-    /// The line height is defined as the vertical distance between the baseline of two adjacent
-    /// lines in pixels.
-    fn line_height(&self) -> u32;
-}
-
-/// Text metrics.
-///
-/// See [`TextRenderer::measure_string`] for more information.
-///
-/// [`TextRenderer::measure_string`]: trait.TextRenderer.html#tymethod.measure_string
-#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
-pub struct TextMetrics {
-    /// Bounding box.
-    pub bounding_box: Rectangle,
-
-    /// The position of the next text.
-    pub next_position: Point,
+    /// The method returns the start position of the next character to allow chaining of multiple
+    /// draw calls.
+    fn draw_whitespace(
+        &self,
+        width: u32,
+        position: Point,
+        baseline: Baseline,
+        target: &mut D,
+    ) -> Result<Point, D::Error>;
 }

--- a/tests/target_specific_drawable.rs
+++ b/tests/target_specific_drawable.rs
@@ -1,0 +1,63 @@
+use embedded_graphics::{
+    mock_display::MockDisplay, pixelcolor::Rgb888, prelude::*, primitives::Rectangle,
+};
+
+type Error = <MockDisplay<Rgb888> as DrawTarget>::Error;
+
+struct TestDisplay(MockDisplay<Rgb888>);
+
+impl DrawTarget for TestDisplay {
+    type Color = Rgb888;
+    type Error = Error;
+
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        self.0.draw_iter(pixels)
+    }
+}
+
+impl OriginDimensions for TestDisplay {
+    fn size(&self) -> Size {
+        Size::new_equal(128)
+    }
+}
+
+struct TargetRectangle(Rectangle, Option<Rgb888>);
+
+impl TargetSpecificDrawable<TestDisplay> for TargetRectangle {
+    type Output = ();
+
+    fn draw(&self, target: &mut TestDisplay) -> Result<Self::Output, Error> {
+        for point in self.0.intersection(&target.bounding_box()).points() {
+            // `set_pixel` wouldn't be accessible in a regular `Drawable`.
+            target.0.set_pixel(point, self.1);
+        }
+
+        Ok(())
+    }
+}
+
+#[test]
+fn target_specific_drawable() {
+    let mut target = TestDisplay(MockDisplay::new());
+
+    TargetRectangle(
+        Rectangle::new(Point::new(1, 1), Size::new(2, 3)),
+        Some(Rgb888::RED),
+    )
+    .draw(&mut target)
+    .unwrap();
+
+    TargetRectangle(Rectangle::new(Point::new(2, 3), Size::new(1, 1)), None)
+        .draw(&mut target)
+        .unwrap();
+
+    target.0.assert_pattern(&[
+        "   ", //
+        " RR", //
+        " RR", //
+        " R ", //
+    ]);
+}

--- a/tests/text_renderer_generic.rs
+++ b/tests/text_renderer_generic.rs
@@ -4,13 +4,30 @@ use embedded_graphics::{
     prelude::*,
     primitives::Rectangle,
     text::{
-        renderer::{TextMetrics, TextRenderer},
+        renderer::{CharacterStyle, TextMetrics, TextRenderer},
         Baseline, Text,
     },
 };
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 struct GenericTextStyle<C>(C);
+
+impl<C: PixelColor> CharacterStyle for GenericTextStyle<C> {
+    fn measure_string(&self, text: &str, position: Point, _baseline: Baseline) -> TextMetrics {
+        // The `baseline` is ignored in this test, but must be used in a real impl.
+
+        let width = text.len() as u32 * 4;
+
+        TextMetrics {
+            bounding_box: Rectangle::new(position, Size::new(width, 4)),
+            next_position: position + Size::new(width, 0),
+        }
+    }
+
+    fn line_height(&self) -> u32 {
+        5
+    }
+}
 
 impl<C: PixelColor> TextRenderer for GenericTextStyle<C> {
     type Color = C;
@@ -43,21 +60,6 @@ impl<C: PixelColor> TextRenderer for GenericTextStyle<C> {
         D: DrawTarget<Color = Self::Color>,
     {
         todo!()
-    }
-
-    fn measure_string(&self, text: &str, position: Point, _baseline: Baseline) -> TextMetrics {
-        // TODO: use baseline
-
-        let width = text.len() as u32 * 4;
-
-        TextMetrics {
-            bounding_box: Rectangle::new(position, Size::new(width, 4)),
-            next_position: position + Size::new(width, 0),
-        }
-    }
-
-    fn line_height(&self) -> u32 {
-        5
     }
 }
 

--- a/tests/text_renderer_target_specific.rs
+++ b/tests/text_renderer_target_specific.rs
@@ -1,0 +1,119 @@
+use embedded_graphics::{mock_display::MockDisplay, pixelcolor::Rgb888, prelude::*, primitives::Rectangle, text::{Alignment, Baseline, Text, TextStyleBuilder, renderer::{CharacterStyle, TargetSpecificTextRenderer, TextMetrics}}};
+
+type Error = <MockDisplay<Rgb888> as DrawTarget>::Error;
+
+struct TestDisplay(MockDisplay<Rgb888>);
+
+impl DrawTarget for TestDisplay {
+    type Color = Rgb888;
+    type Error = Error;
+
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        self.0.draw_iter(pixels)
+    }
+}
+
+impl OriginDimensions for TestDisplay {
+    fn size(&self) -> Size {
+        Size::new_equal(128)
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct DummyTargetTextStyle<T>(T);
+
+impl<T: PixelColor> CharacterStyle for DummyTargetTextStyle<T> {
+    fn measure_string(&self, text: &str, position: Point, _baseline: Baseline) -> TextMetrics {
+        // The `baseline` is ignored in this test, but must be used in a real impl.
+
+        let width = text.len() as u32 * 4;
+
+        TextMetrics {
+            bounding_box: Rectangle::new(position, Size::new(width, 4)),
+            next_position: position + Size::new(width, 0),
+        }
+    }
+
+    fn line_height(&self) -> u32 {
+        5
+    }
+}
+
+impl TargetSpecificTextRenderer<TestDisplay> for DummyTargetTextStyle<Rgb888> {
+    fn draw_string(
+        &self,
+        text: &str,
+        position: Point,
+        baseline: Baseline,
+        target: &mut TestDisplay,
+    ) -> Result<Point, Error> {
+        let metrics = self.measure_string(text, position, baseline);
+
+        target.fill_solid(&metrics.bounding_box, self.0)?;
+
+        Ok(metrics.next_position)
+    }
+
+    fn draw_whitespace(
+        &self,
+        _width: u32,
+        _position: Point,
+        _baseline: Baseline,
+        _target: &mut TestDisplay,
+    ) -> Result<Point, Error> {
+        todo!()
+    }
+}
+
+#[test]
+fn target_specific_text_renderer() {
+    let mut target = TestDisplay(MockDisplay::new());
+
+    Text::new("ab\nc", Point::zero())
+        .into_styled(DummyTargetTextStyle(Rgb888::GREEN))
+        .draw(&mut target)
+        .unwrap();
+
+    target.0.assert_pattern(&[
+        "GGGGGGGG", //
+        "GGGGGGGG", //
+        "GGGGGGGG", //
+        "GGGGGGGG", //
+        "        ", //
+        "GGGG    ", //
+        "GGGG    ", //
+        "GGGG    ", //
+        "GGGG    ", //
+    ]);
+}
+
+#[test]
+fn target_specific_text_renderer_with_text_style() {
+    let mut target = TestDisplay(MockDisplay::new());
+
+    let character_style = DummyTargetTextStyle(Rgb888::BLUE);
+    let text_style = TextStyleBuilder::new()
+        .character_style(character_style)
+        .alignment(Alignment::Right)
+        .build();
+
+    Text::new("ab\nc", Point::new(7, 0))
+        .into_styled(text_style)
+        .draw(&mut target)
+        .unwrap();
+
+    target.0.assert_pattern(&[
+        "BBBBBBBB", //
+        "BBBBBBBB", //
+        "BBBBBBBB", //
+        "BBBBBBBB", //
+        "        ", //
+        "    BBBB", //
+        "    BBBB", //
+        "    BBBB", //
+        "    BBBB", //
+    ]);
+}


### PR DESCRIPTION
This PR adds support for target specific drawables and text renderers. These can be used to implement accelerated drawing and text rendering functions, which aren't implementable with the default `DrawTarget` trait.

One example use case for a target specific drawable would be to add support for `Draw Line` commands for displays with a `SSD1331` controller:
```rust
// Stripped down version of `PrimitiveStyle`, which only includes settings that are supported by the `Draw Line` command.
struct SsdLineStyle {
    stroke_color: Rgb565,
}

impl <SPI, DC> TargetSpecificDrawable<Ssd1331<SPI, DC>> for Styled<Line, SsdLineStyle> { ... }

// Using this accelerated line drawing is very similar to regular e-g code:

let style = SsdLineStyle { stroke_color: Rgb565::RED };

Line::new(Point::new(1, 2), Point::new(3, 4))
    .into_styled(style)
    .draw(&mut d)?;
```
(Reusing `Styled` won't quite work yet because of #499, but this can be fixed after this PR)

@ReeceStevens You mentioned that you wanted to try to implement accelerated text rendering for `RA8875`, which should be made possible by this PR. If you have some time to try it out I would appreciate some feedback.