### PR TITLE
Text module docs

### DIFF
--- a/core/src/drawable.rs
+++ b/core/src/drawable.rs
@@ -68,7 +68,7 @@ pub trait Drawable {
     /// The pixel color type.
     type Color: PixelColor;
 
-    /// The return type of the [`draw`] method.
+    /// The return type of the `draw` method.
     ///
     /// The `Output` type can be used to return results and values produced from the drawing of the
     /// current item. For example, rendering two differently styled text items next to each other
@@ -98,8 +98,6 @@ pub trait Drawable {
     /// ```
     ///
     /// Use `()` if no value should be returned.
-    ///
-    /// [`draw`]: #tymethod.draw
     type Output;
 
     /// Draw the graphics object using the supplied DrawTarget.

--- a/core/src/drawable.rs
+++ b/core/src/drawable.rs
@@ -68,25 +68,38 @@ pub trait Drawable {
     /// The pixel color type.
     type Color: PixelColor;
 
-    // TODO: Remove `ignore` from example code when the `Text` drawable is updated
-    // CC https://github.com/embedded-graphics/embedded-graphics/pull/552#discussion_r576955191
     /// The return type of the [`draw`] method.
     ///
     /// The `Output` type can be used to return results and values produced from the drawing of the
     /// current item. For example, rendering two differently styled text items next to each other
     /// can make use of a returned value, allowing the next text to be positioned after the first:
     ///
-    /// ```rust,ignore
-    /// let next_point = Text::new("Label ", Point::new(10, 20))
-    ///     .into_styled(label_style)
+    /// ```
+    /// use embedded_graphics::{
+    ///     mono_font::{
+    ///         ascii::{FONT_10X20, FONT_6X10},
+    ///         MonoTextStyle,
+    ///     },
+    ///     pixelcolor::BinaryColor,
+    ///     prelude::*,
+    ///     text::Text,
+    /// };
+    ///
+    /// # let mut display = embedded_graphics::mock_display::MockDisplay::new();
+    /// # display.set_allow_out_of_bounds_drawing(true);
+    /// let label_style = MonoTextStyle::new(&FONT_6X10, BinaryColor::On);
+    /// let value_style = MonoTextStyle::new(&FONT_10X20, BinaryColor::On);
+    ///
+    /// let next_point = Text::new("Label ", Point::new(10, 20), label_style)
     ///     .draw(&mut display)?;
     ///
-    /// Text::new("Value", next_point).into_styled(value_style).draw(&mut display)?;
+    /// Text::new("1234", next_point, value_style).draw(&mut display)?;
+    /// # Ok::<(), core::convert::Infallible>(())
     /// ```
     ///
     /// Use `()` if no value should be returned.
     ///
-    /// [`draw`]: #method.draw
+    /// [`draw`]: #tymethod.draw
     type Output;
 
     /// Draw the graphics object using the supplied DrawTarget.

--- a/src/mock_display/mod.rs
+++ b/src/mock_display/mod.rs
@@ -291,7 +291,7 @@ where
     /// # Panics
     ///
     /// This method will panic if `point` is outside the display bounding box.
-    fn set_pixel(&mut self, point: Point, color: Option<C>) {
+    pub fn set_pixel(&mut self, point: Point, color: Option<C>) {
         assert!(
             point.x >= 0 && point.y >= 0 && point.x < SIZE as i32 && point.y < SIZE as i32,
             "point must be inside display bounding box: {:?}",

--- a/src/mono_font/ascii/mod.rs
+++ b/src/mono_font/ascii/mod.rs
@@ -1,6 +1,4 @@
-//! ASCII.
-//!
-//! TODO: docs
+//! ASCII variant of built-in fonts.
 //!
 //START-FONT-TABLE-ASCII
 //! | Type | Screenshot | | Type | Screenshot |
@@ -25,7 +23,7 @@ pub use generated::*;
 use crate::mono_font::{GlyphIndices, GlyphRange};
 
 /// Glyph ranges for ASCII fonts.
-pub const ASCII_GLYPH_RANGES: &[GlyphRange] = &[GlyphRange::new(' ', '\x7F', 0)];
+const ASCII_GLYPH_RANGES: &[GlyphRange] = &[GlyphRange::new(' ', '\x7F', 0)];
 
 /// Glyph indices for ASCII fonts.
 pub const ASCII_GLYPH_INDICES: GlyphIndices =

--- a/src/mono_font/latin1/mod.rs
+++ b/src/mono_font/latin1/mod.rs
@@ -1,6 +1,4 @@
-//! Latin1.
-//!
-//! TODO: docs
+//! Latin 1 variant of built-in fonts.
 //!
 //START-FONT-TABLE-LATIN1
 //! | Type | Screenshot | | Type | Screenshot |

--- a/src/mono_font/mod.rs
+++ b/src/mono_font/mod.rs
@@ -12,7 +12,7 @@
 //!
 //! # Built-in fonts
 //!
-//! Each build-in font is provided in an ASCII and a Latin 1 (ISO 8859-1) variant. The ASCII variant
+//! Each built-in font is provided in an ASCII and a Latin 1 (ISO 8859-1) variant. The ASCII variant
 //! contains a smaller subset of characters which saves memory in embedded application, but only
 //! covers all characters of the English language. The Latin 1 variant has complete coverage for
 //! [the languages listed here](https://en.wikipedia.org/wiki/ISO/IEC_8859-1#Modern_languages_with_complete_coverage),

--- a/src/mono_font/mod.rs
+++ b/src/mono_font/mod.rs
@@ -4,111 +4,22 @@
 //! several [built-in fonts].
 //!
 //! Additional custom fonts can be added by the application or other crates. This
-//! is demonstrated in the `text-custom-font` example in the simulator crate.
+//! is demonstrated in the `text-custom-font` example in the [examples repository].
 //!
 //! # Examples
 //!
-//! The examples below use the `Font6x8` font, however any of the [built-in fonts]
-//! in this module or custom fonts can be substituted.
-//!
-//! ## Print styled "Hello Rust!"
-//!
-//! TODO: `Text` no longer use `Styled`.
-//!
-//! Text can be drawn to a display by creating a [`Text`] object and attaching a
-//! text style to it by using a `Styled` object. This example prints
-//! "Hello Rust" with a yellow text on a blue background.
-//!
-//! ```rust
-//! use embedded_graphics::{
-//!     mono_font::{ascii::FONT_6X9, MonoTextStyle, MonoTextStyleBuilder},
-//!     pixelcolor::Rgb565,
-//!     prelude::*,
-//!     text::Text,
-//! };
-//! # use embedded_graphics::mock_display::MockDisplay;
-//! # let mut display: MockDisplay<Rgb565> = MockDisplay::default();
-//! # display.set_allow_out_of_bounds_drawing(true);
-//!
-//! // Create a new character style
-//! let style = MonoTextStyleBuilder::new()
-//!     .font(&FONT_6X9)
-//!     .text_color(Rgb565::YELLOW)
-//!     .background_color(Rgb565::BLUE)
-//!     .build();
-//!
-//! // Create a text at position (20, 30) and draw it using the previously defined style
-//! Text::new("Hello Rust!", Point::new(20, 30), style).draw(&mut display)?;
-//! # Ok::<(), core::convert::Infallible>(())
-//! ```
-//!
-//! ## Translate text by (20px, 30px)
-//!
-//! ```rust
-//! use embedded_graphics::{
-//!     mono_font::{ascii::FONT_6X9, MonoTextStyle},
-//!     pixelcolor::BinaryColor,
-//!     prelude::*,
-//!     text::Text,
-//! };
-//! # use embedded_graphics::mock_display::MockDisplay;
-//! # let mut display: MockDisplay<BinaryColor> = MockDisplay::default();
-//! # display.set_allow_out_of_bounds_drawing(true);
-//!
-//! let style = MonoTextStyle::new(&FONT_6X9, BinaryColor::On);
-//!
-//! Text::new("Hello Rust!", Point::zero(), style)
-//!     .translate(Point::new(20, 30))
-//!     .draw(&mut display)?;
-//!
-//! // this is equivalent to:
-//!
-//! # let mut display: MockDisplay<BinaryColor> = MockDisplay::default();
-//! # display.set_allow_out_of_bounds_drawing(true);
-//! Text::new("Hello Rust!", Point::new(20, 30), style).draw(&mut display)?;
-//! # Ok::<(), core::convert::Infallible>(())
-//! ```
-//!
-//! ## Use `write!()` and arrayvec to render a formatted string
-//!
-//! This example uses arrayvec's [`ArrayString`] to render a floating point value using the
-//! [`write!()`] macro. These strings have a fixed maximum length, but allow the use of
-//! Rust's builtin string formatting.
-//!
-//! ```rust
-//! use arrayvec::ArrayString;
-//! use core::fmt::Write;
-//! use embedded_graphics::{
-//!     mono_font::{ascii::FONT_6X9, MonoTextStyleBuilder},
-//!     pixelcolor::Rgb565,
-//!     prelude::*,
-//!     text::Text,
-//! };
-//! # use embedded_graphics::mock_display::MockDisplay;
-//! # let mut display = MockDisplay::default();
-//! # display.set_allow_out_of_bounds_drawing(true);
-//!
-//! let value = 12.34567;
-//!
-//! // Create a fixed buffer of length 12
-//! let mut buf = ArrayString::<[_; 12]>::new();
-//!
-//! // Output `Value: 12.35`
-//! write!(&mut buf, "Value: {:.2}", value).expect("Failed to write to buffer");
-//!
-//! let style = MonoTextStyleBuilder::new()
-//!     .font(&FONT_6X9)
-//!     .text_color(Rgb565::YELLOW)
-//!     .background_color(Rgb565::BLUE)
-//!     .build();
-//!
-//! Text::new(&buf, Point::zero(), style).draw(&mut display)?;
-//! # Ok::<(), core::convert::Infallible>(())
-//! ```
+//! The [`text` module] contains examples how these fonts can be used in an application.
 //!
 //! # Built-in fonts
 //!
-//! TODO: Describe the difference between `ascii` and `latin1` and mention the `latin1` table in the `latin1` module.
+//! Each build-in font is provided in an ASCII and a Latin 1 (ISO 8859-1) variant. The ASCII variant
+//! contains a smaller subset of characters which saves memory in embedded application, but only
+//! covers all characters of the English language. The Latin 1 variant has complete coverage for
+//! [the languages listed here](https://en.wikipedia.org/wiki/ISO/IEC_8859-1#Modern_languages_with_complete_coverage),
+//! and partial coverage for [these languages](https://en.wikipedia.org/wiki/ISO/IEC_8859-1#Languages_with_incomplete_coverage).
+//!
+//! The table below shows the ASCII variant of the built-in fonts. See the [`latin1` module] for
+//! an overview of the complete character set included in the Latin 1 variants.
 //!
 // WARNING: The table between START-FONT-TABLE and END-FONT-TABLE is generated.
 //          Use `just convert-fonts` to update the table.
@@ -129,10 +40,10 @@
 //END-FONT-TABLE
 //!
 //! [built-in fonts]: #built-in-fonts
-//! [`Text`]: ../text/struct.Text.html
+//! [`latin1` module]: latin1/index.html
+//! [`text` module]: ../text/index.html#examples
 //! [`MonoTextStyle`]: struct.MonoTextStyle.html
-//! [`ArrayString`]: https://docs.rs/arrayvec/0.4.11/arrayvec/struct.ArrayString.html
-//! [`write!()`]: https://doc.rust-lang.org/nightly/std/macro.write.html
+//! [examples repository]:  https://github.com/embedded-graphics/examples
 
 pub mod ascii;
 mod draw_target;
@@ -301,6 +212,8 @@ impl<'a, 'b> MonoFontBuilder<'a, 'b> {
 }
 
 /// Glyph indices.
+///
+/// Maps characters to glyph indices.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct GlyphIndices<'a> {
     ranges: &'a [GlyphRange],

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -26,8 +26,7 @@
 //! The [`alignment`] setting sets the horizontal alignment of the text. With the default value
 //! `Left` the text will be rendered to the right of the given text position. Analogously `Right`
 //! aligned text will be rendered to the left of the given position. `Center`ed text will extend
-//! equally to the left and right of the text position. If the text contains multiple lines each
-//! line will be aligned independently of the other lines.
+//! equally to the left and right of the text position.
 //!
 //! The [`baseline`] setting defines the vertical alignment of the first line of text. With the default
 //! setting of `Alphabetic` the glyphs will be drawn with their descenders below the given position.

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -156,9 +156,9 @@
 //!
 //! [`Text`]: struct.Text.html
 //! [`Text::new`]: struct.TextStyle.html#method.new
-//! [`with_alignment`]: struct.TextStyle.html#method.with_alignment
-//! [`with_baseline`]: struct.TextStyle.html#method.with_baseline
-//! [`with_text_style`]: struct.TextStyle.html#method.with_text_style
+//! [`with_alignment`]: struct.Text.html#method.with_alignment
+//! [`with_baseline`]: struct.Text.html#method.with_baseline
+//! [`with_text_style`]: struct.Text.html#method.with_text_style
 //! [`TextStyle`]: struct.TextStyle.html
 //! [`alignment`]: struct.TextStyle.html#structfield.alignment
 //! [`baseline`]: struct.TextStyle.html#structfield.baseline

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -36,7 +36,7 @@
 //! to the EM box, without considering the baseline.
 //!
 //! If the text contains multiple lines only the first line will be vertically aligned based on the
-//! baseline setting. All following lines will be spaced according to the [`line_height`] setting.
+//! baseline setting. All following lines will be spaced relative to the first line, according to the [`line_height`] setting.
 //!
 //! # Examples
 //!
@@ -149,7 +149,7 @@
 //! // Draw the first text at (20, 30) using the small character style.
 //! let next = Text::new("small ", Point::new(20, 30), small_style).draw(&mut display)?;
 //!
-//! // Draw the second text after the first text using the large  character style.
+//! // Draw the second text after the first text using the large character style.
 //! let next = Text::new("large", next, large_style).draw(&mut display)?;
 //! # Ok::<(), core::convert::Infallible>(())
 //! ```

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -1,14 +1,173 @@
-//! Text drawable.
+//! Text drawing.
 //!
-//! TODO: - Add an overview of the e-g text rendering, e.g. what a `Text` object is used for and
-//!         how it can be used with different text styles/renderers.
-//!       - Describe the difference between `TextStyle` and `MonoTextStyle`
-//!       - How is `Text::position` used by text renders dependent on `TextStyle::baseline`
-//!       - Add examples:
-//!         - Basic text without `TextStyle`
-//!         - Advanced text with `TextStyle`
-//!         - Draw text with multiple styles by using the result of `Text.draw(...)`
-//!       - Link to `renderer` module docs for users who want to implement custom renderers.
+//! The [`Text`] drawable can be used to draw text on a draw target. To construct a [`Text`] object
+//! at least a text string, position and character style are required. For advanced formatting
+//! options an additional [`TextStyle`] object might be required.
+//!
+//! Text rendering in embedded-graphics is designed to be extendable by text renderers for different
+//! font formats. To use a text renderer in an embedded-graphics project each renderer provides a
+//! character style object. This object is used to set the appearance of characters, like the text
+//! color or the used font. The available settings vary between different text renderer and are
+//! documented in the text renderer documentation.
+//!
+//! See the [`renderer` module] docs for more information about implementing custom text renderers.
+//!
+//! Embedded-graphics includes a text renderer for monospaced fonts in the [`mono_font`] module.
+//! Most examples will use this renderer and the associated [`MonoTextStyle`] character style.
+//! But they should be easily adaptable to any external renderer listed in the
+//! [external crates list].
+//!
+//! # Text style
+//!
+//! In addition to styling the individual characters the [`Text`] drawable also contains a
+//! [`TextStyle`] setting. The text style is used to set the alignment and line spacing of text
+//! objects.
+//!
+//! The [`alignment`] setting sets the horizontal alignment of the text. With the default value
+//! `Left` the text will be rendered to the right of the given text position. Analogously `Right`
+//! aligned text will be rendered to the left of the given position. `Center`ed text will extend
+//! equally to the left and right of the text position. If the text contains multiple lines each
+//! line will be aligned independently of the other lines.
+//!
+//! The [`baseline`] setting defines the vertical alignment of the first line of text. With the default
+//! setting of `Alphabetic` the glyphs will be drawn with their descenders below the given position.
+//! This means that the bottom of glyphs without descender (like 'A') will be on the same Y
+//! coordinate as the given position. The other baseline settings will position the glyphs relative
+//! to the EM box, without considering the baseline.
+//!
+//! If the text contains multiple lines only the first line will be vertically aligned based on the
+//! baseline setting. All following lines will be spaced according to the [`line_height`] setting.
+//!
+//! # Examples
+//!
+//! ## Draw basic text
+//!
+//! ```
+//! use embedded_graphics::{
+//!     mono_font::{ascii::FONT_6X10, MonoTextStyle},
+//!     pixelcolor::Rgb565,
+//!     prelude::*,
+//!     text::Text,
+//! };
+//! # use embedded_graphics::mock_display::MockDisplay;
+//! # let mut display: MockDisplay<Rgb565> = MockDisplay::default();
+//! # display.set_allow_out_of_bounds_drawing(true);
+//!
+//! // Create a new character style
+//! let style = MonoTextStyle::new(&FONT_6X10, Rgb565::WHITE);
+//!
+//! // Create a text at position (20, 30) and draw it using the previously defined style
+//! Text::new("Hello Rust!", Point::new(20, 30), style).draw(&mut display)?;
+//! # Ok::<(), core::convert::Infallible>(())
+//! ```
+//! ## Draw centered text
+//!
+//! [`Text`] provides the [`with_alignment`] and [`with_baseline`] constructors to easily set
+//! these commonly used settings without having to build a [`TextStyle`] object first.
+//!
+//! ```
+//! use embedded_graphics::{
+//!     mono_font::{ascii::FONT_6X10, MonoTextStyle},
+//!     pixelcolor::Rgb565,
+//!     prelude::*,
+//!     text::{Text, Alignment},
+//! };
+//! # use embedded_graphics::mock_display::MockDisplay;
+//! # let mut display: MockDisplay<Rgb565> = MockDisplay::default();
+//! # display.set_allow_out_of_bounds_drawing(true);
+//!
+//! // Create a new character style
+//! let style = MonoTextStyle::new(&FONT_6X10, Rgb565::WHITE);
+//!
+//! // Create a text at position (20, 30) and draw it using the previously defined style
+//! Text::with_alignment(
+//!     "First line\nSecond line",
+//!     Point::new(20, 30),
+//!     style,
+//!     Alignment::Center,
+//! )
+//! .draw(&mut display)?;
+//! # Ok::<(), core::convert::Infallible>(())
+//! ```
+//!
+//! ## Draw text with `TextStyle`
+//!
+//! For more advanced text styles a [`TextStyle`] object can be build using the
+//! [`TextStyleBuilder`] and then passed to the [`with_text_style`] constructor.
+//!
+//! ```
+//! use embedded_graphics::{
+//!     mono_font::{ascii::FONT_6X10, MonoTextStyle},
+//!     pixelcolor::Rgb565,
+//!     prelude::*,
+//!     text::{Alignment, LineHeight, Text, TextStyleBuilder},
+//! };
+//! # use embedded_graphics::mock_display::MockDisplay;
+//! # let mut display: MockDisplay<Rgb565> = MockDisplay::default();
+//! # display.set_allow_out_of_bounds_drawing(true);
+//!
+//! // Create a new character style.
+//! let character_style = MonoTextStyle::new(&FONT_6X10, Rgb565::WHITE);
+//!
+//! // Create a new text style.
+//! let text_style = TextStyleBuilder::new()
+//!     .alignment(Alignment::Center)
+//!     .line_height(LineHeight::Percent(150))
+//!     .build();
+//!
+//! // Create a text at position (20, 30) and draw it using the previously defined style.
+//! Text::with_text_style(
+//!     "First line\nSecond line",
+//!     Point::new(20, 30),
+//!     character_style,
+//!     text_style,
+//! )
+//! .draw(&mut display)?;
+//! # Ok::<(), core::convert::Infallible>(())
+//! ```
+//!
+//! ## Combine different character styles
+//!
+//! The `draw` method for text drawables returns the position of the next character. This can be
+//! used to combine text with different character styles on a single line of text.
+//!
+//! ```
+//! use embedded_graphics::{
+//!     mono_font::{ascii::{FONT_6X10, FONT_10X20}, MonoTextStyle},
+//!     pixelcolor::Rgb565,
+//!     prelude::*,
+//!     text::{Alignment, LineHeight, Text, TextStyleBuilder},
+//! };
+//! # use embedded_graphics::mock_display::MockDisplay;
+//! # let mut display: MockDisplay<Rgb565> = MockDisplay::default();
+//! # display.set_allow_out_of_bounds_drawing(true);
+//!
+//! // Create a small and a large character style.
+//! let small_style = MonoTextStyle::new(&FONT_6X10, Rgb565::WHITE);
+//! let large_style = MonoTextStyle::new(&FONT_10X20, Rgb565::WHITE);
+//!
+//! // Draw the first text at (20, 30) using the small character style.
+//! let next = Text::new("small ", Point::new(20, 30), small_style).draw(&mut display)?;
+//!
+//! // Draw the second text after the first text using the large  character style.
+//! let next = Text::new("large", next, large_style).draw(&mut display)?;
+//! # Ok::<(), core::convert::Infallible>(())
+//! ```
+//!
+//! [`Text`]: struct.Text.html
+//! [`Text::new`]: struct.TextStyle.html#method.new
+//! [`with_alignment`]: struct.TextStyle.html#method.with_alignment
+//! [`with_baseline`]: struct.TextStyle.html#method.with_baseline
+//! [`with_text_style`]: struct.TextStyle.html#method.with_text_style
+//! [`TextStyle`]: struct.TextStyle.html
+//! [`alignment`]: struct.TextStyle.html#structfield.alignment
+//! [`baseline`]: struct.TextStyle.html#structfield.baseline
+//! [`line_height`]: struct.TextStyle.html#structfield.line_height
+//! [`TextStyleBuilder`]: struct.TextStyleBuilder.html
+//! [`mono_font`]: ../mono_font/index.html
+//! [`MonoTextStyle`]: ../mono_font/struct.MonoTextStyle.html
+//! [`renderer` module]: renderer/index.html
+//! [external crates list]: ../index.html#additional-functions-provided-by-external-crates
 
 pub mod renderer;
 mod text;

--- a/src/text/text.rs
+++ b/src/text/text.rs
@@ -11,17 +11,11 @@ use crate::{
 };
 
 use super::TextStyleBuilder;
-/// A text object.
+/// Text drawable.
 ///
-/// The `Text` struct represents a string that can be drawn onto a display.
+/// A text drawable can be used to draw text to a draw target.
 ///
-/// TODO: The paragraph below needs to be updated, because `Text` no longer requires `Styled`.
-///
-/// The text object only contains the string and position and no additional styling information,
-/// like the font or color. To draw a text object it is necessary to attach a style to it by using
-/// the `into_styled` method to create a `Styled` object.
-///
-/// See the [module-level documentation] for examples how to use text objects.
+/// See the [module-level documentation] for more information about text drawables and examples.
 ///
 /// [module-level documentation]: index.html
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
@@ -30,8 +24,6 @@ pub struct Text<'a, S> {
     pub text: &'a str,
 
     /// The position.
-    ///
-    /// Defines the top-left starting pixel of the text object.
     pub position: Point,
 
     /// The character style.
@@ -42,7 +34,7 @@ pub struct Text<'a, S> {
 }
 
 impl<'a, S> Text<'a, S> {
-    /// Creates a text.
+    /// Creates a text drawable with the default text style.
     pub const fn new(text: &'a str, position: Point, character_style: S) -> Self {
         Self {
             text,
@@ -52,7 +44,7 @@ impl<'a, S> Text<'a, S> {
         }
     }
 
-    /// Creates a text.
+    /// Creates a text drawable with the given text style.
     pub const fn with_text_style(
         text: &'a str,
         position: Point,
@@ -67,7 +59,7 @@ impl<'a, S> Text<'a, S> {
         }
     }
 
-    /// Creates a text.
+    /// Creates a text drawable with the given baseline.
     pub const fn with_baseline(
         text: &'a str,
         position: Point,
@@ -82,7 +74,7 @@ impl<'a, S> Text<'a, S> {
         }
     }
 
-    /// Creates a text.
+    /// Creates a text drawable with the given alignment.
     pub const fn with_alignment(
         text: &'a str,
         position: Point,

--- a/src/text/text_style.rs
+++ b/src/text/text_style.rs
@@ -2,9 +2,9 @@ use crate::text::{Alignment, Baseline, LineHeight};
 
 /// Text style.
 ///
-/// A text style is used to set how text lines are layed out in a text drawable.
+/// A text style is used to set how text lines are laid out in a text drawable.
 ///
-/// Use [`TextStyleBuilder`] to build text style object.
+/// Use [`TextStyleBuilder`] to build a text style object.
 ///
 /// See the [module-level documentation] for more information about text styles and examples.
 ///

--- a/src/text/text_style.rs
+++ b/src/text/text_style.rs
@@ -1,6 +1,15 @@
 use crate::text::{Alignment, Baseline, LineHeight};
 
 /// Text style.
+///
+/// A text style is used to set how text lines are layed out in a text drawable.
+///
+/// Use [`TextStyleBuilder`] to build text style object.
+///
+/// See the [module-level documentation] for more information about text styles and examples.
+///
+/// [`TextStyleBuilder`]: struct.TextStyleBuilder.html
+/// [module-level documentation]: index.html
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub struct TextStyle {
@@ -32,7 +41,7 @@ impl Default for TextStyle {
     }
 }
 
-/// Text style builder.
+/// Builder for text styles.
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub struct TextStyleBuilder {
     style: TextStyle,


### PR DESCRIPTION
This PR adds some docs for the `text` and `mono_font` modules. They are still not great, but I hope they are not too confusing.

I've marked it as a draft PR, because it depends on #580.
