### PR TITLE
Add StyledDrawable, StyledDimensions and StyledPixels traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#571](https://github.com/embedded-graphics/embedded-graphics/pull/571) Added `MockDisplay::set_pixels` to set pixels from an iterator.
 - [#572](https://github.com/embedded-graphics/embedded-graphics/pull/572) Added `ImageRaw::new_binary` to create `const` images with binary image data.
 - [#576](https://github.com/embedded-graphics/embedded-graphics/pull/576) Added reset methods for color settings to `MonoTextStyleBuilder` and `PrimitiveStyleBuilder`.
+- [#582](https://github.com/embedded-graphics/embedded-graphics/pull/582) Added `StyledDrawable`, `StyledDimensions` and `StyledPixels` traits.
 
 ### Changed
 
@@ -29,10 +30,13 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - **(breaking)** [#572](https://github.com/embedded-graphics/embedded-graphics/pull/572) Removed the `height` argument from `ImageRaw::new`. The `height` is now calculated based on the width and data length.
 - **(breaking)** [#572](https://github.com/embedded-graphics/embedded-graphics/pull/572) Replaced `pixelcolor::raw::RawDataIter` by the types in the `iterator::raw` module.
 - **(breaking)** [#573](https://github.com/embedded-graphics/embedded-graphics/pull/573) Changed `MonoFont` from a trait to a struct.
-- **(breaking)** [#573](https://github.com/embedded-graphics/embedded-graphics/pull/573) Renamed `ContiguousIteratorExt::into_pixels` to `into_pixels_iter` to reduce possible confusion with `IntoPixels::into_pixels`.
 - **(breaking)** [#580](https://github.com/embedded-graphics/embedded-graphics/pull/580) Changed `Text` to directly contain the styling information without needing a `Styled` wrapper.
 - **(breaking)** [#580](https://github.com/embedded-graphics/embedded-graphics/pull/580) Removed `character_style` from `TextStyle`. Character and text style can now be set independently in the `Text` object.
 - **(breaking)** [#580](https://github.com/embedded-graphics/embedded-graphics/pull/580) Moved `Styled` from the crate root to the `primitives` module.
+
+### Removed
+
+- **(breaking)** [#582](https://github.com/embedded-graphics/embedded-graphics/pull/582) Removed `iterator::IntoPixels` trait. Use `Styled::pixels` instead.
 
 ### Fixed
 

--- a/src/examples.rs
+++ b/src/examples.rs
@@ -229,9 +229,10 @@
 //!     prelude::*,
 //!     text::Text,
 //! };
-//! Text::new("Hello,\nRust!", Point::new(2, 28))
-//!     .into_styled(MonoTextStyle::new(&FONT_6X10, Rgb888::GREEN))
-//!     .draw(&mut display)?;
+//!
+//! let style = MonoTextStyle::new(&FONT_6X10, Rgb888::GREEN);
+//!
+//! Text::new("Hello,\nRust!", Point::new(2, 28), style).draw(&mut display)?;
 //! ```
 //! ## Display a TGA image
 //!

--- a/src/iterator/mod.rs
+++ b/src/iterator/mod.rs
@@ -8,24 +8,6 @@ use crate::{
     draw_target::DrawTarget, geometry::Point, pixelcolor::PixelColor, primitives::Rectangle, Pixel,
 };
 
-/// Produce an iterator over all pixels in an object.
-///
-/// This trait is implemented for _references_ to all styled items in embedded-graphics, therefore
-/// does not consume the original item.
-pub trait IntoPixels {
-    /// The type of color for each pixel produced by the iterator returned from `into_pixels`.
-    type Color: PixelColor;
-
-    /// The iterator produced when calling `into_pixels`.
-    type Iter: Iterator<Item = Pixel<Self::Color>>;
-
-    /// Create an iterator over all pixels in the object.
-    ///
-    /// The iterator may return pixels in any order, however it may be beneficial for performance
-    /// reasons to return them starting at the top left corner in row-first order.
-    fn into_pixels(self) -> Self::Iter;
-}
-
 /// Extension trait for contiguous iterators.
 pub trait ContiguousIteratorExt
 where
@@ -33,7 +15,7 @@ where
     <Self as Iterator>::Item: PixelColor,
 {
     /// Converts a contiguous iterator into a pixel iterator.
-    fn into_pixels_iter(self, bounding_box: &Rectangle) -> contiguous::IntoPixels<Self>;
+    fn into_pixels(self, bounding_box: &Rectangle) -> contiguous::IntoPixels<Self>;
 }
 
 impl<I> ContiguousIteratorExt for I
@@ -41,7 +23,7 @@ where
     I: Iterator,
     I::Item: PixelColor,
 {
-    fn into_pixels_iter(self, bounding_box: &Rectangle) -> contiguous::IntoPixels<Self> {
+    fn into_pixels(self, bounding_box: &Rectangle) -> contiguous::IntoPixels<Self> {
         contiguous::IntoPixels::new(self, *bounding_box)
     }
 }

--- a/src/mono_font/draw_target.rs
+++ b/src/mono_font/draw_target.rs
@@ -27,7 +27,7 @@ impl<T: DrawTarget> DrawTarget for MonoFontDrawTarget<'_, T, Foreground<T::Color
         self.parent.draw_iter(
             colors
                 .into_iter()
-                .into_pixels_iter(area)
+                .into_pixels(area)
                 .filter(|Pixel(_, color)| color.is_on())
                 .map(|Pixel(pos, _)| Pixel(pos, foreground_color)),
         )
@@ -65,7 +65,7 @@ impl<T: DrawTarget> DrawTarget for MonoFontDrawTarget<'_, T, Background<T::Color
         self.parent.draw_iter(
             colors
                 .into_iter()
-                .into_pixels_iter(&area)
+                .into_pixels(&area)
                 .filter(|Pixel(_, color)| color.is_off())
                 .map(|Pixel(pos, _)| Pixel(pos, foreground_color)),
         )

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -10,7 +10,7 @@ pub use crate::{
         raw::{RawData, ToBytes as _},
         GrayColor, IntoStorage, PixelColor, RgbColor, WebColors,
     },
-    primitives::{ContainsPoint, OffsetOutline, PointsIter, Primitive, StyledPrimitiveAreas},
+    primitives::{ContainsPoint, OffsetOutline, PointsIter, Primitive},
     transform::Transform,
     Drawable, Pixel,
 };

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -5,7 +5,7 @@ pub use crate::{
     draw_target::{DrawTarget, DrawTargetExt},
     geometry::{Angle, AngleUnit, Dimensions, OriginDimensions, Point, Size},
     image::{ImageDrawable, ImageDrawableExt},
-    iterator::{ContiguousIteratorExt, IntoPixels, PixelIteratorExt},
+    iterator::{ContiguousIteratorExt, PixelIteratorExt},
     pixelcolor::{
         raw::{RawData, ToBytes as _},
         GrayColor, IntoStorage, PixelColor, RgbColor, WebColors,

--- a/src/primitives/arc/mod.rs
+++ b/src/primitives/arc/mod.rs
@@ -1,15 +1,16 @@
 //! The arc primitive
 
-mod points;
-mod styled;
-
 use crate::{
     geometry::{Angle, Dimensions, Point, Size},
     primitives::{Circle, PointsIter, Primitive, Rectangle},
     transform::Transform,
 };
+
+mod points;
+mod styled;
+
 pub use points::Points;
-pub use styled::StyledPixels;
+pub use styled::StyledPixelsIterator;
 
 /// Arc primitive
 ///

--- a/src/primitives/arc/points.rs
+++ b/src/primitives/arc/points.rs
@@ -58,7 +58,6 @@ mod tests {
     use super::*;
     use crate::{
         geometry::AngleUnit,
-        iterator::IntoPixels,
         pixelcolor::BinaryColor,
         primitives::{PointsIter, Primitive, PrimitiveStyle},
         Pixel,
@@ -71,7 +70,7 @@ mod tests {
         let styled_points = arc
             .clone()
             .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
-            .into_pixels()
+            .pixels()
             .map(|Pixel(p, _)| p);
 
         assert!(arc.points().eq(styled_points));

--- a/src/primitives/arc/styled.rs
+++ b/src/primitives/arc/styled.rs
@@ -1,12 +1,11 @@
 use crate::{
     draw_target::DrawTarget,
     geometry::Dimensions,
-    iterator::IntoPixels,
     pixelcolor::PixelColor,
     primitives::{
         arc::Arc,
         common::{DistanceIterator, PlaneSector},
-        styled::{Styled, StyledDimensions, StyledDrawable},
+        styled::{StyledDimensions, StyledDrawable, StyledPixels},
         OffsetOutline, PrimitiveStyle, Rectangle,
     },
     Pixel, SaturatingCast,
@@ -14,10 +13,7 @@ use crate::{
 
 /// Pixel iterator for each pixel in the arc border
 #[derive(Clone, PartialEq, Debug)]
-pub struct StyledPixels<C>
-where
-    C: PixelColor,
-{
+pub struct StyledPixelsIterator<C> {
     iter: DistanceIterator,
 
     plane_sector: PlaneSector,
@@ -28,10 +24,7 @@ where
     stroke_color: Option<C>,
 }
 
-impl<C> StyledPixels<C>
-where
-    C: PixelColor,
-{
+impl<C: PixelColor> StyledPixelsIterator<C> {
     fn new(primitive: &Arc, style: &PrimitiveStyle<C>) -> Self {
         let circle = primitive.to_circle();
 
@@ -57,10 +50,7 @@ where
     }
 }
 
-impl<C> Iterator for StyledPixels<C>
-where
-    C: PixelColor,
-{
+impl<C: PixelColor> Iterator for StyledPixelsIterator<C> {
     type Item = Pixel<C>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -91,20 +81,15 @@ impl<C: PixelColor> StyledDrawable<PrimitiveStyle<C>> for Arc {
     where
         D: DrawTarget<Color = C>,
     {
-        target.draw_iter(StyledPixels::new(self, style))
+        target.draw_iter(StyledPixelsIterator::new(self, style))
     }
 }
 
-impl<C> IntoPixels for &Styled<Arc, PrimitiveStyle<C>>
-where
-    C: PixelColor,
-{
-    type Color = C;
+impl<C: PixelColor> StyledPixels<PrimitiveStyle<C>> for Arc {
+    type Iter = StyledPixelsIterator<C>;
 
-    type Iter = StyledPixels<Self::Color>;
-
-    fn into_pixels(self) -> Self::Iter {
-        StyledPixels::new(&self.primitive, &self.style)
+    fn pixels(&self, style: &PrimitiveStyle<C>) -> Self::Iter {
+        StyledPixelsIterator::new(self, style)
     }
 }
 

--- a/src/primitives/circle/mod.rs
+++ b/src/primitives/circle/mod.rs
@@ -1,8 +1,5 @@
 //! The circle primitive
 
-mod points;
-mod styled;
-
 use crate::{
     geometry::{Dimensions, Point, PointExt, Size},
     primitives::{
@@ -10,8 +7,12 @@ use crate::{
     },
     transform::Transform,
 };
+
+mod points;
+mod styled;
+
 pub use points::Points;
-pub use styled::StyledPixels;
+pub use styled::StyledPixelsIterator;
 
 /// Circle primitive
 ///

--- a/src/primitives/ellipse/mod.rs
+++ b/src/primitives/ellipse/mod.rs
@@ -1,15 +1,16 @@
 //! The ellipse primitive
 
-mod points;
-mod styled;
-
 use crate::{
     geometry::{Dimensions, Point, Size},
     primitives::{circle, ContainsPoint, OffsetOutline, PointsIter, Primitive, Rectangle},
     transform::Transform,
 };
+
+mod points;
+mod styled;
+
 pub use points::Points;
-pub use styled::StyledPixels;
+pub use styled::StyledPixelsIterator;
 
 /// Ellipse primitive
 ///

--- a/src/primitives/ellipse/styled.rs
+++ b/src/primitives/ellipse/styled.rs
@@ -6,9 +6,10 @@ use crate::{
     primitives::{
         common::{Scanline, StyledScanline},
         ellipse::{points::Scanlines, Ellipse, EllipseContains},
-        PrimitiveStyle, Rectangle, Styled, StyledPrimitiveAreas,
+        styled::{Styled, StyledDimensions, StyledDrawable},
+        PrimitiveStyle, Rectangle,
     },
-    Drawable, Pixel, SaturatingCast,
+    Pixel, SaturatingCast,
 };
 
 /// Pixel iterator for each pixel in the ellipse border
@@ -110,30 +111,35 @@ where
     }
 }
 
-impl<C> Drawable for Styled<Ellipse, PrimitiveStyle<C>>
-where
-    C: PixelColor,
-{
+impl<C: PixelColor> StyledDrawable<PrimitiveStyle<C>> for Ellipse {
     type Color = C;
     type Output = ();
 
-    fn draw<D>(&self, target: &mut D) -> Result<Self::Output, D::Error>
+    fn draw_styled<D>(
+        &self,
+        style: &PrimitiveStyle<C>,
+        target: &mut D,
+    ) -> Result<Self::Output, D::Error>
     where
         D: DrawTarget<Color = C>,
     {
-        match (self.style.effective_stroke_color(), self.style.fill_color) {
+        match (style.effective_stroke_color(), style.fill_color) {
             (Some(stroke_color), None) => {
-                for scanline in StyledScanlines::new(&self.stroke_area(), &self.fill_area()) {
+                for scanline in
+                    StyledScanlines::new(&style.stroke_area(self), &style.fill_area(self))
+                {
                     scanline.draw_stroke(target, stroke_color)?;
                 }
             }
             (Some(stroke_color), Some(fill_color)) => {
-                for scanline in StyledScanlines::new(&self.stroke_area(), &self.fill_area()) {
+                for scanline in
+                    StyledScanlines::new(&style.stroke_area(self), &style.fill_area(self))
+                {
                     scanline.draw_stroke_and_fill(target, stroke_color, fill_color)?;
                 }
             }
             (None, Some(fill_color)) => {
-                for scanline in Scanlines::new(&self.fill_area()) {
+                for scanline in Scanlines::new(&style.fill_area(self)) {
                     scanline.draw(target, fill_color)?;
                 }
             }
@@ -144,14 +150,11 @@ where
     }
 }
 
-impl<C> Dimensions for Styled<Ellipse, PrimitiveStyle<C>>
-where
-    C: PixelColor,
-{
-    fn bounding_box(&self) -> Rectangle {
-        let offset = self.style.outside_stroke_width().saturating_cast();
+impl<C: PixelColor> StyledDimensions<PrimitiveStyle<C>> for Ellipse {
+    fn styled_bounding_box(&self, style: &PrimitiveStyle<C>) -> Rectangle {
+        let offset = style.outside_stroke_width().saturating_cast();
 
-        self.primitive.bounding_box().offset(offset)
+        self.bounding_box().offset(offset)
     }
 }
 
@@ -417,7 +420,7 @@ mod tests {
     #[test]
     fn bounding_box_is_independent_of_colors() {
         let transparent_ellipse = Ellipse::new(Point::new(5, 5), Size::new(11, 14))
-            .into_styled::<BinaryColor>(PrimitiveStyle::new());
+            .into_styled(PrimitiveStyle::<BinaryColor>::new());
         let filled_ellipse = Ellipse::new(Point::new(5, 5), Size::new(11, 14))
             .into_styled(PrimitiveStyle::with_fill(BinaryColor::On));
 

--- a/src/primitives/line/mod.rs
+++ b/src/primitives/line/mod.rs
@@ -1,11 +1,5 @@
 //! The line primitive
 
-mod bresenham;
-pub(in crate::primitives) mod intersection_params;
-mod points;
-mod styled;
-mod thick_points;
-
 use crate::{
     geometry::{Dimensions, Point},
     primitives::{
@@ -16,8 +10,15 @@ use crate::{
     transform::Transform,
     SaturatingCast,
 };
+
+mod bresenham;
+pub(in crate::primitives) mod intersection_params;
+mod points;
+mod styled;
+mod thick_points;
+
 pub use points::Points;
-pub use styled::StyledPixels;
+pub use styled::StyledPixelsIterator;
 
 /// Line primitive
 ///
@@ -207,7 +208,7 @@ impl Transform for Line {
 mod tests {
     use super::*;
     use crate::{
-        geometry::Size, iterator::IntoPixels, mock_display::MockDisplay, pixelcolor::BinaryColor,
+        geometry::Size, mock_display::MockDisplay, pixelcolor::BinaryColor,
         primitives::PrimitiveStyle, Drawable, Pixel,
     };
     use arrayvec::ArrayVec;
@@ -238,7 +239,7 @@ mod tests {
         let line =
             Line::new(start, end).into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 0));
 
-        assert!(line.into_pixels().eq(core::iter::empty()));
+        assert!(line.pixels().eq(core::iter::empty()));
     }
 
     #[test]
@@ -408,7 +409,7 @@ mod tests {
         let styled_points: ArrayVec<[_; 32]> = line
             .clone()
             .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
-            .into_pixels()
+            .pixels()
             .map(|Pixel(p, _)| p)
             .collect();
 

--- a/src/primitives/line/styled.rs
+++ b/src/primitives/line/styled.rs
@@ -1,13 +1,13 @@
 use crate::{
     draw_target::DrawTarget,
-    geometry::Dimensions,
     iterator::IntoPixels,
     pixelcolor::PixelColor,
     primitives::{
         line::{thick_points::ThickPoints, Line, StrokeOffset},
-        PrimitiveStyle, Rectangle, Styled,
+        styled::{Styled, StyledDimensions, StyledDrawable},
+        PrimitiveStyle, Rectangle,
     },
-    Drawable, Pixel, SaturatingCast,
+    Pixel, SaturatingCast,
 };
 
 /// Styled line iterator.
@@ -24,9 +24,7 @@ impl<C> StyledPixels<C>
 where
     C: PixelColor,
 {
-    pub(in crate::primitives::line) fn new(styled: &Styled<Line, PrimitiveStyle<C>>) -> Self {
-        let Styled { primitive, style } = styled;
-
+    pub(in crate::primitives::line) fn new(primitive: &Line, style: &PrimitiveStyle<C>) -> Self {
         // Note: stroke color will be None if stroke width is 0
         let stroke_color = style.effective_stroke_color();
         let stroke_width = style.stroke_width.saturating_cast();
@@ -64,33 +62,29 @@ where
     type Iter = StyledPixels<Self::Color>;
 
     fn into_pixels(self) -> Self::Iter {
-        StyledPixels::new(self)
+        StyledPixels::new(&self.primitive, &self.style)
     }
 }
 
-impl<C> Drawable for Styled<Line, PrimitiveStyle<C>>
-where
-    C: PixelColor,
-{
+impl<C: PixelColor> StyledDrawable<PrimitiveStyle<C>> for Line {
     type Color = C;
     type Output = ();
 
-    fn draw<D>(&self, display: &mut D) -> Result<Self::Output, D::Error>
+    fn draw_styled<D>(
+        &self,
+        style: &PrimitiveStyle<C>,
+        target: &mut D,
+    ) -> Result<Self::Output, D::Error>
     where
         D: DrawTarget<Color = C>,
     {
-        display.draw_iter(self.into_pixels())
+        target.draw_iter(StyledPixels::new(self, style))
     }
 }
 
-impl<C> Dimensions for Styled<Line, PrimitiveStyle<C>>
-where
-    C: PixelColor,
-{
-    fn bounding_box(&self) -> Rectangle {
-        let (l, r) = self
-            .primitive
-            .extents(self.style.stroke_width, StrokeOffset::None);
+impl<C: PixelColor> StyledDimensions<PrimitiveStyle<C>> for Line {
+    fn styled_bounding_box(&self, style: &PrimitiveStyle<C>) -> Rectangle {
+        let (l, r) = self.extents(style.stroke_width, StrokeOffset::None);
 
         let min = l
             .start
@@ -111,10 +105,11 @@ where
 mod tests {
     use super::*;
     use crate::{
-        geometry::Point,
+        geometry::{Dimensions, Point},
         mock_display::MockDisplay,
         pixelcolor::{Rgb888, RgbColor},
         primitives::{Primitive, PrimitiveStyleBuilder},
+        Drawable,
     };
 
     #[test]
@@ -165,8 +160,11 @@ mod tests {
     fn bounding_box_is_independent_of_colors() {
         let line = Line::new(Point::new(5, 5), Point::new(11, 14));
 
-        let transparent_line =
-            line.into_styled::<Rgb888>(PrimitiveStyleBuilder::new().stroke_width(10).build());
+        let transparent_line = line.into_styled(
+            PrimitiveStyleBuilder::<Rgb888>::new()
+                .stroke_width(10)
+                .build(),
+        );
         let stroked_line = line.into_styled(PrimitiveStyle::with_stroke(Rgb888::RED, 10));
 
         assert_eq!(transparent_line.bounding_box(), stroked_line.bounding_box(),);

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -21,26 +21,20 @@ pub use self::{
     ellipse::Ellipse,
     line::Line,
     polyline::Polyline,
-    primitive_style::{
-        PrimitiveStyle, PrimitiveStyleBuilder, StrokeAlignment, StyledPrimitiveAreas,
-    },
+    primitive_style::{PrimitiveStyle, PrimitiveStyleBuilder, StrokeAlignment},
     rounded_rectangle::{CornerRadii, CornerRadiiBuilder, RoundedRectangle},
     sector::Sector,
     triangle::Triangle,
 };
-use crate::{
-    geometry::{Dimensions, Point},
-    pixelcolor::PixelColor,
-};
+use crate::geometry::{Dimensions, Point};
 pub use embedded_graphics_core::primitives::PointsIter;
-pub use styled::Styled;
+pub use styled::{Styled, StyledDimensions, StyledDrawable};
 
 /// Primitive trait
-pub trait Primitive: Dimensions + PointsIter {
+pub trait Primitive: Dimensions {
     /// Converts this primitive into a `Styled`.
-    fn into_styled<C>(self, style: PrimitiveStyle<C>) -> Styled<Self, PrimitiveStyle<C>>
+    fn into_styled<S>(self, style: S) -> Styled<Self, S>
     where
-        C: PixelColor,
         Self: Sized,
     {
         Styled::new(self, style)

--- a/src/primitives/polyline/mod.rs
+++ b/src/primitives/polyline/mod.rs
@@ -1,17 +1,18 @@
 //! The polyline primitive
 
-mod points;
-pub(in crate::primitives) mod scanline_intersections;
-mod scanline_iterator;
-mod styled;
-
 use crate::{
     geometry::{Dimensions, Point, Size},
     primitives::{PointsIter, Primitive, Rectangle},
     transform::Transform,
 };
+
+mod points;
+pub(in crate::primitives) mod scanline_intersections;
+mod scanline_iterator;
+mod styled;
+
 pub use points::Points;
-pub use styled::StyledPixels;
+pub use styled::StyledPixelsIterator;
 
 /// Polyline primitive
 ///

--- a/src/primitives/polyline/scanline_iterator.rs
+++ b/src/primitives/polyline/scanline_iterator.rs
@@ -5,8 +5,11 @@ use core::ops::Range;
 use crate::{
     pixelcolor::PixelColor,
     primitives::{
-        common::Scanline, polyline::scanline_intersections::ScanlineIntersections, Polyline,
-        PrimitiveStyle, Styled,
+        common::Scanline,
+        polyline::{
+            scanline_intersections::ScanlineIntersections, styled::untranslated_bounding_box,
+        },
+        Polyline, PrimitiveStyle,
     },
 };
 
@@ -22,23 +25,17 @@ pub struct ScanlineIterator<'a> {
 
 impl<'a> ScanlineIterator<'a> {
     /// New.
-    pub fn new<C>(styled: &Styled<Polyline<'a>, PrimitiveStyle<C>>) -> Self
-    where
-        C: PixelColor,
-    {
+    pub fn new<C: PixelColor>(primitive: &Polyline<'a>, style: &PrimitiveStyle<C>) -> Self {
         debug_assert!(
-            styled.style.stroke_width > 1,
+            style.stroke_width > 1,
             "Polyline ScanlineIterator should only be used for stroke widths greater than 1"
         );
 
-        let mut rows = styled.untranslated_bounding_box().rows();
+        let mut rows = untranslated_bounding_box(primitive, style).rows();
 
         if let Some(scanline_y) = rows.next() {
-            let intersections = ScanlineIntersections::new(
-                styled.primitive.vertices,
-                styled.style.stroke_width,
-                scanline_y,
-            );
+            let intersections =
+                ScanlineIntersections::new(primitive.vertices, style.stroke_width, scanline_y);
 
             Self {
                 rows,

--- a/src/primitives/rectangle/mod.rs
+++ b/src/primitives/rectangle/mod.rs
@@ -1,14 +1,16 @@
 //! The rectangle primitive. Also good for drawing squares.
 
-mod styled;
-
 use crate::{
     geometry::{Point, Size},
     primitives::{ContainsPoint, OffsetOutline, Primitive},
     transform::Transform,
 };
+
 pub use embedded_graphics_core::primitives::{rectangle::Points, Rectangle};
-pub use styled::StyledPixels;
+
+mod styled;
+
+pub use styled::StyledPixelsIterator;
 
 impl Primitive for Rectangle {}
 

--- a/src/primitives/rounded_rectangle/mod.rs
+++ b/src/primitives/rounded_rectangle/mod.rs
@@ -1,10 +1,5 @@
 //! The rounded rectangle primitive.
 
-mod corner_radii;
-mod ellipse_quadrant;
-mod points;
-mod styled;
-
 use core::ops::Range;
 
 use crate::{
@@ -12,10 +7,16 @@ use crate::{
     primitives::{rectangle::Rectangle, ContainsPoint, OffsetOutline, PointsIter, Primitive},
     transform::Transform,
 };
+
+mod corner_radii;
+mod ellipse_quadrant;
+mod points;
+mod styled;
+
 pub use corner_radii::{CornerRadii, CornerRadiiBuilder};
 use ellipse_quadrant::{EllipseQuadrant, Quadrant};
 pub use points::Points;
-pub use styled::StyledPixels;
+pub use styled::StyledPixelsIterator;
 
 /// Rounded rectangle primitive.
 ///

--- a/src/primitives/rounded_rectangle/styled.rs
+++ b/src/primitives/rounded_rectangle/styled.rs
@@ -6,9 +6,10 @@ use crate::{
     primitives::{
         common::{Scanline, StyledScanline},
         rounded_rectangle::{points::Scanlines, RoundedRectangle},
-        PrimitiveStyle, Rectangle, Styled, StyledPrimitiveAreas,
+        styled::{Styled, StyledDimensions, StyledDrawable},
+        PrimitiveStyle, Rectangle,
     },
-    Drawable, Pixel, SaturatingCast,
+    Pixel, SaturatingCast,
 };
 
 use super::RoundedRectangleContains;
@@ -112,30 +113,35 @@ where
     }
 }
 
-impl<C> Drawable for Styled<RoundedRectangle, PrimitiveStyle<C>>
-where
-    C: PixelColor,
-{
+impl<C: PixelColor> StyledDrawable<PrimitiveStyle<C>> for RoundedRectangle {
     type Color = C;
     type Output = ();
 
-    fn draw<D>(&self, target: &mut D) -> Result<Self::Output, D::Error>
+    fn draw_styled<D>(
+        &self,
+        style: &PrimitiveStyle<C>,
+        target: &mut D,
+    ) -> Result<Self::Output, D::Error>
     where
         D: DrawTarget<Color = C>,
     {
-        match (self.style.effective_stroke_color(), self.style.fill_color) {
+        match (style.effective_stroke_color(), style.fill_color) {
             (Some(stroke_color), None) => {
-                for scanline in StyledScanlines::new(&self.stroke_area(), &self.fill_area()) {
+                for scanline in
+                    StyledScanlines::new(&style.stroke_area(self), &style.fill_area(self))
+                {
                     scanline.draw_stroke(target, stroke_color)?;
                 }
             }
             (Some(stroke_color), Some(fill_color)) => {
-                for scanline in StyledScanlines::new(&self.stroke_area(), &self.fill_area()) {
+                for scanline in
+                    StyledScanlines::new(&style.stroke_area(self), &style.fill_area(self))
+                {
                     scanline.draw_stroke_and_fill(target, stroke_color, fill_color)?;
                 }
             }
             (None, Some(fill_color)) => {
-                for scanline in Scanlines::new(&self.fill_area()) {
+                for scanline in Scanlines::new(&style.fill_area(self)) {
                     scanline.draw(target, fill_color)?;
                 }
             }
@@ -146,14 +152,11 @@ where
     }
 }
 
-impl<C> Dimensions for Styled<RoundedRectangle, PrimitiveStyle<C>>
-where
-    C: PixelColor,
-{
-    fn bounding_box(&self) -> Rectangle {
-        let offset = self.style.outside_stroke_width().saturating_cast();
+impl<C: PixelColor> StyledDimensions<PrimitiveStyle<C>> for RoundedRectangle {
+    fn styled_bounding_box(&self, style: &PrimitiveStyle<C>) -> Rectangle {
+        let offset = style.outside_stroke_width().saturating_cast();
 
-        self.primitive.bounding_box().offset(offset)
+        self.bounding_box().offset(offset)
     }
 }
 
@@ -454,7 +457,7 @@ mod tests {
             },
         );
 
-        let transparent_rect = rect.into_styled::<Rgb888>(PrimitiveStyle::new());
+        let transparent_rect = rect.into_styled(PrimitiveStyle::<Rgb888>::new());
         let filled_rect = rect.into_styled(PrimitiveStyle::with_fill(Rgb888::RED));
 
         assert_eq!(transparent_rect.bounding_box(), filled_rect.bounding_box(),);

--- a/src/primitives/sector/mod.rs
+++ b/src/primitives/sector/mod.rs
@@ -1,8 +1,5 @@
 //! The sector primitive
 
-mod points;
-mod styled;
-
 use crate::{
     geometry::{Angle, Dimensions, Point, Size},
     primitives::{
@@ -10,8 +7,12 @@ use crate::{
     },
     transform::Transform,
 };
+
+mod points;
+mod styled;
+
 pub use points::Points;
-pub use styled::StyledPixels;
+pub use styled::StyledPixelsIterator;
 
 /// Sector primitive
 ///

--- a/src/primitives/sector/points.rs
+++ b/src/primitives/sector/points.rs
@@ -49,7 +49,6 @@ mod tests {
     use super::*;
     use crate::{
         geometry::AngleUnit,
-        iterator::IntoPixels,
         pixelcolor::BinaryColor,
         primitives::{PointsIter, Primitive, PrimitiveStyle},
         Pixel,
@@ -62,7 +61,7 @@ mod tests {
         let styled_points = sector
             .clone()
             .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
-            .into_pixels()
+            .pixels()
             .map(|Pixel(p, _)| p);
 
         assert!(sector.points().eq(styled_points));

--- a/src/primitives/styled.rs
+++ b/src/primitives/styled.rs
@@ -1,4 +1,12 @@
-use crate::{geometry::Point, transform::Transform};
+use crate::{
+    draw_target::DrawTarget,
+    geometry::{Dimensions, Point},
+    pixelcolor::PixelColor,
+    primitives::OffsetOutline,
+    primitives::{PrimitiveStyle, Rectangle},
+    transform::Transform,
+    Drawable,
+};
 
 /// Styled.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
@@ -16,11 +24,37 @@ impl<T, S> Styled<T, S> {
     }
 }
 
-impl<T, S> Transform for Styled<T, S>
-where
-    T: Transform,
-    S: Clone,
-{
+impl<T: OffsetOutline, C: PixelColor> Styled<T, PrimitiveStyle<C>> {
+    /// TODO: docs
+    pub fn fill_area(&self) -> T {
+        self.style.fill_area(&self.primitive)
+    }
+
+    /// TODO: docs
+    pub fn stroke_area(&self) -> T {
+        self.style.stroke_area(&self.primitive)
+    }
+}
+
+impl<T: StyledDimensions<S>, S> Dimensions for Styled<T, S> {
+    fn bounding_box(&self) -> Rectangle {
+        self.primitive.styled_bounding_box(&self.style)
+    }
+}
+
+impl<T: StyledDrawable<S>, S> Drawable for Styled<T, S> {
+    type Color = T::Color;
+    type Output = T::Output;
+
+    fn draw<D>(&self, target: &mut D) -> Result<Self::Output, D::Error>
+    where
+        D: DrawTarget<Color = Self::Color>,
+    {
+        self.primitive.draw_styled(&self.style, target)
+    }
+}
+
+impl<T: Transform, S: Clone> Transform for Styled<T, S> {
     fn translate(&self, by: Point) -> Self {
         Self {
             primitive: self.primitive.translate(by),
@@ -33,4 +67,23 @@ where
 
         self
     }
+}
+
+/// Styled drawable.
+pub trait StyledDrawable<S> {
+    /// Color type.
+    type Color: PixelColor;
+    /// Output type.
+    type Output;
+
+    /// Draws the primitive using the given style.
+    fn draw_styled<D>(&self, style: &S, target: &mut D) -> Result<Self::Output, D::Error>
+    where
+        D: DrawTarget<Color = Self::Color>;
+}
+
+/// Styled dimensions.
+pub trait StyledDimensions<S> {
+    /// Returns the bounding box using the given style.
+    fn styled_bounding_box(&self, style: &S) -> Rectangle;
 }

--- a/src/primitives/styled.rs
+++ b/src/primitives/styled.rs
@@ -96,6 +96,13 @@ impl<T: OffsetOutline, C: PixelColor> Styled<T, PrimitiveStyle<C>> {
     }
 }
 
+impl<T: StyledPixels<S>, S> Styled<T, S> {
+    /// Returns an iterator over the pixels in this styled primitive.
+    pub fn pixels(&self) -> T::Iter {
+        self.primitive.pixels(&self.style)
+    }
+}
+
 impl<T: StyledDimensions<S>, S> Dimensions for Styled<T, S> {
     fn bounding_box(&self) -> Rectangle {
         self.primitive.styled_bounding_box(&self.style)
@@ -146,4 +153,13 @@ pub trait StyledDrawable<S> {
 pub trait StyledDimensions<S> {
     /// Returns the bounding box using the given style.
     fn styled_bounding_box(&self, style: &S) -> Rectangle;
+}
+
+/// Styled drawable.
+pub trait StyledPixels<S> {
+    /// Iterator type.
+    type Iter;
+
+    /// Returns an iterator over all pixels in this styled primitive.
+    fn pixels(&self, style: &S) -> Self::Iter;
 }

--- a/src/primitives/styled.rs
+++ b/src/primitives/styled.rs
@@ -25,12 +25,72 @@ impl<T, S> Styled<T, S> {
 }
 
 impl<T: OffsetOutline, C: PixelColor> Styled<T, PrimitiveStyle<C>> {
-    /// TODO: docs
+    /// Returns the fill area.
+    ///
+    /// The returned primitive coincides with the area that would be filled by calling [`draw`]
+    /// on this styled primitive.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use embedded_graphics::{
+    ///     pixelcolor::Rgb888,
+    ///     prelude::*,
+    ///     primitives::{Circle, PrimitiveStyleBuilder},
+    /// };
+    ///
+    /// let style = PrimitiveStyleBuilder::new()
+    ///     .fill_color(Rgb888::RED)
+    ///     .stroke_color(Rgb888::GREEN)
+    ///     .stroke_width(6)
+    ///     .build();
+    ///
+    /// let center = Point::new(10, 20);
+    /// let diameter = 10;
+    ///
+    /// let circle = Circle::with_center(center, diameter).into_styled(style);
+    ///
+    /// assert_eq!(circle.fill_area(), Circle::with_center(center, diameter - style.stroke_width));
+    /// ```
+    ///
+    /// [`draw`]: ../trait.Drawable.html#tymethod.draw
     pub fn fill_area(&self) -> T {
         self.style.fill_area(&self.primitive)
     }
 
-    /// TODO: docs
+    /// Returns the stroke area.
+    ///
+    /// The outer edge of the returned primitive coincides with the outer edge of the stroke that
+    /// would be drawn by calling [`draw`] on this styled primitive.
+    ///
+    /// # Examples
+    ///
+    /// This example tests if a point lies on the stroke. Because the stoke area surrounds the
+    /// stoke and fill an additional test is required to check that the point is not inside the fill
+    /// area.
+    ///
+    /// ```
+    /// use embedded_graphics::{
+    ///     pixelcolor::Rgb888,
+    ///     prelude::*,
+    ///     primitives::{Circle, PrimitiveStyle},
+    /// };
+    ///
+    /// let style = PrimitiveStyle::with_stroke(Rgb888::RED, 6);
+    ///
+    /// let center = Point::new(10, 20);
+    /// let diameter = 10;
+    ///
+    /// let circle = Circle::with_center(center, diameter).into_styled(style);
+    ///
+    /// // A point lies on the stroke if it is inside the stroke area but not in the fill area.
+    /// let is_on_stroke = |p| circle.stroke_area().contains(p) && !circle.fill_area().contains(p);
+    ///
+    /// assert!(is_on_stroke(center + Size::new(0, diameter / 2)));
+    /// assert!(!is_on_stroke(center));
+    /// ```
+    ///
+    /// [`draw`]: ../trait.Drawable.html#tymethod.draw
     pub fn stroke_area(&self) -> T {
         self.style.stroke_area(&self.primitive)
     }

--- a/src/primitives/triangle/mod.rs
+++ b/src/primitives/triangle/mod.rs
@@ -1,9 +1,6 @@
 //! The triangle primitive.
 
-mod points;
-mod scanline_intersections;
-mod scanline_iterator;
-mod styled;
+use core::cmp::{max, min, Ordering};
 
 use crate::{
     geometry::{Dimensions, Point},
@@ -13,9 +10,14 @@ use crate::{
     },
     transform::Transform,
 };
-use core::cmp::{max, min, Ordering};
+
+mod points;
+mod scanline_intersections;
+mod scanline_iterator;
+mod styled;
+
 pub use points::Points;
-pub use styled::StyledPixels;
+pub use styled::StyledPixelsIterator;
 
 /// Triangle primitive
 ///

--- a/src/primitives/triangle/points.rs
+++ b/src/primitives/triangle/points.rs
@@ -48,7 +48,6 @@ impl Iterator for Points {
 mod tests {
     use super::*;
     use crate::{
-        iterator::IntoPixels,
         pixelcolor::BinaryColor,
         primitives::{PointsIter, Primitive, PrimitiveStyle},
         transform::Transform,
@@ -62,7 +61,7 @@ mod tests {
         let styled_points = triangle
             .clone()
             .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
-            .into_pixels()
+            .pixels()
             .map(|Pixel(p, _)| p);
 
         assert!(triangle.points().eq(styled_points));

--- a/tests/chaining.rs
+++ b/tests/chaining.rs
@@ -44,11 +44,11 @@ fn it_supports_chaining() -> Result<(), core::convert::Infallible> {
 
     let chained = Rectangle::new(Point::new(0, 0), Size::new(1, 1))
         .into_styled(PrimitiveStyle::default())
-        .into_pixels()
+        .pixels()
         .chain(
             Circle::new(Point::new(1, 1), 3)
                 .into_styled(PrimitiveStyle::default())
-                .into_pixels(),
+                .pixels(),
         );
 
     chained.draw(&mut display)
@@ -57,11 +57,11 @@ fn it_supports_chaining() -> Result<(), core::convert::Infallible> {
 fn multi() -> impl Iterator<Item = Pixel<TestPixelColor>> {
     let line = Line::new(Point::new(0, 1), Point::new(2, 3))
         .into_styled(PrimitiveStyle::with_stroke(1u8.into(), 1))
-        .into_pixels();
+        .pixels();
 
     let circle = Circle::new(Point::new(2, 2), 7)
         .into_styled(PrimitiveStyle::with_stroke(1u8.into(), 1))
-        .into_pixels();
+        .pixels();
 
     line.chain(circle)
 }

--- a/tests/custom_primitive.rs
+++ b/tests/custom_primitive.rs
@@ -1,0 +1,75 @@
+use embedded_graphics::{
+    mock_display::MockDisplay,
+    pixelcolor::Rgb888,
+    prelude::*,
+    primitives::{PrimitiveStyle, Rectangle, StyledDimensions, StyledDrawable},
+};
+
+struct Square {
+    top_left: Point,
+    size: u32,
+}
+
+impl Square {
+    fn new(top_left: Point, size: u32) -> Self {
+        Self { top_left, size }
+    }
+
+    fn to_rectangle(&self) -> Rectangle {
+        Rectangle::new(self.top_left, Size::new_equal(self.size))
+    }
+}
+
+impl Primitive for Square {}
+
+impl Dimensions for Square {
+    fn bounding_box(&self) -> Rectangle {
+        self.to_rectangle()
+    }
+}
+
+impl<C: PixelColor> StyledDrawable<PrimitiveStyle<C>> for Square {
+    type Color = C;
+    type Output = ();
+
+    fn draw_styled<D>(
+        &self,
+        style: &PrimitiveStyle<C>,
+        target: &mut D,
+    ) -> Result<Self::Output, D::Error>
+    where
+        D: DrawTarget<Color = Self::Color>,
+    {
+        self.to_rectangle().draw_styled(style, target)
+    }
+}
+
+impl<C: PixelColor> StyledDimensions<PrimitiveStyle<C>> for Square {
+    fn styled_bounding_box(&self, style: &PrimitiveStyle<C>) -> Rectangle {
+        self.to_rectangle().styled_bounding_box(style)
+    }
+}
+
+#[test]
+fn draw_custom_primitive() {
+    let mut display = MockDisplay::new();
+    Square::new(Point::new(1, 0), 2)
+        .into_styled(PrimitiveStyle::with_fill(Rgb888::RED))
+        .draw(&mut display)
+        .unwrap();
+    display.assert_pattern(&[
+        " RR", //
+        " RR", //
+    ]);
+}
+
+#[test]
+fn custom_primitive_dimensions() {
+    let styled_square =
+        Square::new(Point::new(1, 0), 2).into_styled(PrimitiveStyle::with_stroke(Rgb888::RED, 2));
+
+    assert_eq!(
+        styled_square.bounding_box(),
+        Rectangle::new(Point::new(1, 0), Size::new_equal(2)).offset(1)
+    );
+}

--- a/tests/custom_primitive_style.rs
+++ b/tests/custom_primitive_style.rs
@@ -1,0 +1,49 @@
+use embedded_graphics::{
+    mock_display::MockDisplay,
+    pixelcolor::Rgb888,
+    prelude::*,
+    primitives::{Rectangle, StyledDrawable},
+};
+
+struct CheckerboardStyle<C>(C, C);
+
+impl<C: PixelColor> StyledDrawable<CheckerboardStyle<C>> for Rectangle {
+    type Color = C;
+    type Output = ();
+
+    fn draw_styled<D>(
+        &self,
+        style: &CheckerboardStyle<C>,
+        target: &mut D,
+    ) -> Result<Self::Output, D::Error>
+    where
+        D: DrawTarget<Color = Self::Color>,
+    {
+        target.fill_contiguous(
+            self,
+            self.points().map(|p| {
+                if (p.x % 2 == 0) ^ (p.y % 2 == 0) {
+                    style.1
+                } else {
+                    style.0
+                }
+            }),
+        )
+    }
+}
+
+#[test]
+fn custom_primitive_style() {
+    let style = CheckerboardStyle(Rgb888::RED, Rgb888::GREEN);
+
+    let mut display = MockDisplay::new();
+    Rectangle::new(Point::zero(), Size::new(4, 3))
+        .into_styled(style)
+        .draw(&mut display)
+        .unwrap();
+    display.assert_pattern(&[
+        "RGRG", //
+        "GRGR", //
+        "RGRG", //
+    ]);
+}


### PR DESCRIPTION
This PR changes the way styled primitives are implemented. Instead of requiring the primitives to implement traits like `Drawable` for `Styled<PrimitiveType, PrimitiveStyle<C>>` there are now dedicated `StyledDrawable`  and `StyledDimensions` traits. The advantage of this approach is that these new types can also be implemented externally, which wasn't possible before because of the orphan rules. The `tests` directory contains two examples how external styles for existing primitives and new primitives for the existing `PrimitiveStyle` can be implemented.