### PR TITLE
Add From impls for MonoFontBuilder and TextStyleBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- [#587](https://github.com/embedded-graphics/embedded-graphics/pull/587) Added `From<&TextStyle>` impl for `TextStyleBuilder` and `From<&MonoFont>` for `MonoFontBuilder`.
+
 ## [0.7.0-beta.1] - 2021-04-19
 
 ### Added

--- a/src/mono_font/mod.rs
+++ b/src/mono_font/mod.rs
@@ -211,6 +211,12 @@ impl<'a, 'b> MonoFontBuilder<'a, 'b> {
     }
 }
 
+impl<'a, 'b> From<&MonoFont<'a, 'b>> for MonoFontBuilder<'a, 'b> {
+    fn from(font: &MonoFont<'a, 'b>) -> Self {
+        Self { font: *font }
+    }
+}
+
 /// Glyph indices.
 ///
 /// Maps characters to glyph indices.

--- a/src/text/text_style.rs
+++ b/src/text/text_style.rs
@@ -88,6 +88,12 @@ impl TextStyleBuilder {
     }
 }
 
+impl From<&TextStyle> for TextStyleBuilder {
+    fn from(style: &TextStyle) -> Self {
+        Self { style: *style }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
This PR adds the missing `From` impl for `TextStyleBuilder` that was reported by @bugadani  in https://github.com/embedded-graphics/embedded-graphics/issues/511#issuecomment-823582640.


