### PR TITLE
Add missing color conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 ### Added
 
 - [#587](https://github.com/embedded-graphics/embedded-graphics/pull/587) Added `From<&TextStyle>` impl for `TextStyleBuilder` and `From<&MonoFont>` for `MonoFontBuilder`.
+- [#589](https://github.com/embedded-graphics/embedded-graphics/pull/589) Implemented `From` trait to convert from RGB colors to grayscale colors, between different grayscale colors and from grayscale and RGB colors to `BinaryColor`.
+
 
 ## [0.7.0-beta.1] - 2021-04-19
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Added
 
-- **(breaking)** [#589](https://github.com/embedded-graphics/embedded-graphics/pull/589) Implemented `From` trait to convert from RGB colors to grayscale colors, between different grayscale colors and from grayscale and RGB colors to `BinaryColor`.
+- [#589](https://github.com/embedded-graphics/embedded-graphics/pull/589) Implemented `From` trait to convert from RGB colors to grayscale colors, between different grayscale colors and from grayscale and RGB colors to `BinaryColor`.
 
 ## [0.3.0] - 2021-04-19
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- **(breaking)** [#589](https://github.com/embedded-graphics/embedded-graphics/pull/589) Implemented `From` trait to convert from RGB colors to grayscale colors, between different grayscale colors and from grayscale and RGB colors to `BinaryColor`.
+
 ## [0.3.0] - 2021-04-19
 
 ### Added

--- a/core/src/pixelcolor/gray_color.rs
+++ b/core/src/pixelcolor/gray_color.rs
@@ -11,9 +11,6 @@ pub trait GrayColor: PixelColor {
     /// Black color (0% luma).
     const BLACK: Self;
 
-    /// Middle gray color (50% luma).
-    const GRAY_50: Self;
-
     /// White color (100% luma).
     const WHITE: Self;
 }
@@ -26,6 +23,8 @@ macro_rules! gray_color {
         pub struct $type($raw_type);
 
         impl $type {
+            pub(crate) const GRAY_50: Self = Self::new(0x80 >> (8 - $raw_type::BITS_PER_PIXEL));
+
             /// Creates a new grayscale color.
             ///
             /// Too large luma values are masked to the valid range by setting
@@ -45,7 +44,6 @@ macro_rules! gray_color {
             }
 
             const BLACK: Self = Self::new(0);
-            const GRAY_50: Self = Self::new(0x80 >> (8 - $raw_type::BITS_PER_PIXEL));
             const WHITE: Self = Self::new(255);
         }
 

--- a/core/src/pixelcolor/gray_color.rs
+++ b/core/src/pixelcolor/gray_color.rs
@@ -8,10 +8,13 @@ pub trait GrayColor: PixelColor {
     /// Returns the luma channel value.
     fn luma(&self) -> u8;
 
-    /// Black color (0% luma)
+    /// Black color (0% luma).
     const BLACK: Self;
 
-    /// White color (100% luma)
+    /// Middle gray color (50% luma).
+    const GRAY_50: Self;
+
+    /// White color (100% luma).
     const WHITE: Self;
 }
 
@@ -41,10 +44,8 @@ macro_rules! gray_color {
                 self.0.into_inner()
             }
 
-            /// Black color (0% luma)
             const BLACK: Self = Self::new(0);
-
-            /// White color (100% luma)
+            const GRAY_50: Self = Self::new(0x80 >> (8 - $raw_type::BITS_PER_PIXEL));
             const WHITE: Self = Self::new(255);
         }
 
@@ -83,6 +84,10 @@ mod tests {
         assert_eq!(Gray2::BLACK.luma(), 0);
         assert_eq!(Gray4::BLACK.luma(), 0);
         assert_eq!(Gray8::BLACK.luma(), 0);
+
+        assert_eq!(Gray2::GRAY_50.luma(), 0x2);
+        assert_eq!(Gray4::GRAY_50.luma(), 0x8);
+        assert_eq!(Gray8::GRAY_50.luma(), 0x80);
 
         assert_eq!(Gray2::WHITE.luma(), 0x3);
         assert_eq!(Gray4::WHITE.luma(), 0xF);


### PR DESCRIPTION
This PR fills the gaps in the color conversions.

We had previously decided not to implement any conversions which can be handled in different ways. But this makes it harder to use color types generically, because some colors don't implement `From` for other color types. One example where this causes problems is `DynamicTga`, which can currently only be used with RGB targets.

While the conversions implemented in this PR might not be ideal for every use case, I think it's a good idea to provide an implementation that should work in most cases. And as long as we document the conversions (in a later PR) this shouldn't be confusing to the user.

@bugadani: I think this should let you replace `Rgb` with `Rgb888` in e-t and should also make it work with `BgrXXX` targets.