### PR TITLE
Use released version of tinytga in tools folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 ### Changed
 
-- **(breaking)** - [#596](https://github.com/embedded-graphics/embedded-graphics/pull/596) Added more ISO8859 glyph subsets as well as JIS_X0201 for bundled `MonoFont`s, supporting more languages. The `latin1` subset was renamed to `iso8859-1`.
+- **(breaking)** - [#596](https://github.com/embedded-graphics/embedded-graphics/pull/596) Added more ISO8859 glyph subsets as well as JIS_X0201 for bundled `MonoFont`s, supporting more languages. The `latin1` subset was renamed to `iso_8859_1`.
 
 ## [0.7.0-beta.1] - 2021-04-19
 
@@ -637,10 +637,10 @@ A big release, focussed on ergonomics. There are new macros to make drawing and 
   ```
 
 <!-- next-url -->
+
 [unreleased]: https://github.com/embedded-graphics/embedded-graphics/compare/embedded-graphics-v0.7.0-beta.2...HEAD
 [0.7.0-beta.2]: https://github.com/embedded-graphics/embedded-graphics/compare/embedded-graphics-v0.7.0-beta.1...embedded-graphics-v0.7.0-beta.2
 [0.7.0-beta.1]: https://github.com/embedded-graphics/embedded-graphics/compare/embedded-graphics-v0.7.0-alpha.3...embedded-graphics-v0.7.0-beta.1
-
 [0.7.0-alpha.3]: https://github.com/embedded-graphics/embedded-graphics/compare/embedded-graphics-v0.7.0-alpha.2...embedded-graphics-v0.7.0-alpha.3
 [0.7.0-alpha.2]: https://github.com/embedded-graphics/embedded-graphics/compare/embedded-graphics-v0.7.0-alpha.1...embedded-graphics-v0.7.0-alpha.2
 [0.7.0-alpha.1]: https://github.com/embedded-graphics/embedded-graphics/compare/embedded-graphics-v0.6.2...embedded-graphics-v0.7.0-alpha.1

--- a/tools/generate-drawing-examples/Cargo.toml
+++ b/tools/generate-drawing-examples/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 [dependencies]
 embedded-graphics = { path = "../../" }
 png-target = { path = "../png-target/" }
-# TODO: remove git dependency
-tinytga = { git = "https://github.com/embedded-graphics/tinytga.git", rev = "9e26fe986f0eae436f4f7fafd4e9c55ff1c09d00"}
+tinytga = "0.4.0-beta.1"
 regex = "1.4.3"
 unindent = "0.1.7"


### PR DESCRIPTION
A really quick fix to remove a Git dependency.
