### PR TITLE
Implement Display for Point and Size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- [#602](https://github.com/embedded-graphics/embedded-graphics/pull/602) Implemented `core::fmt::Display` for `Point` and `Size`.
+
 ### Changed
 
 - **(breaking)** - [#600](https://github.com/embedded-graphics/embedded-graphics/pull/600) Renamed `Mapping::all` to `Mapping::iter`.

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- [#602](https://github.com/embedded-graphics/embedded-graphics/pull/602) Implemented `core::fmt::Display` for `Point` and `Size`.
+
 ## [0.3.1] - 2021-05-03
 
 ### Added

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,6 +24,7 @@ byteorder = { version = "1.3.4", default-features = false }
 
 [dev-dependencies]
 embedded-graphics = { path = ".." }
+arrayvec = { version = "0.5.2", default-features = false }
 
 [features]
 default = []

--- a/core/src/geometry/point.rs
+++ b/core/src/geometry/point.rs
@@ -1,8 +1,10 @@
-use crate::geometry::Size;
 use core::{
     convert::{TryFrom, TryInto},
+    fmt,
     ops::{Add, AddAssign, Div, DivAssign, Index, Mul, MulAssign, Neg, Sub, SubAssign},
 };
+
+use crate::geometry::Size;
 
 /// 2D point.
 ///
@@ -459,6 +461,12 @@ impl TryFrom<&[u32; 2]> for Point {
     }
 }
 
+impl fmt::Display for Point {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}, {}", self.x, self.y)
+    }
+}
+
 #[cfg(feature = "nalgebra_support")]
 use nalgebra::{base::Scalar, Vector2};
 
@@ -485,6 +493,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use core::fmt::Write;
 
     #[test]
     fn convert_positive_to_u32_tuple() {
@@ -738,5 +748,13 @@ mod tests {
 
         assert_eq!(a.component_min(b), Point::new(15, 30));
         assert_eq!(a.component_max(b), Point::new(20, 50));
+    }
+
+    #[test]
+    fn display() {
+        let mut buffer = arrayvec::ArrayString::<[u8; 32]>::new();
+        write!(buffer, "{}", Point::new(123, -456)).unwrap();
+
+        assert_eq!(&buffer, "123, -456");
     }
 }

--- a/core/src/geometry/size.rs
+++ b/core/src/geometry/size.rs
@@ -1,5 +1,9 @@
+use core::{
+    fmt,
+    ops::{Add, AddAssign, Div, DivAssign, Index, Mul, MulAssign, Sub, SubAssign},
+};
+
 use crate::geometry::Point;
-use core::ops::{Add, AddAssign, Div, DivAssign, Index, Mul, MulAssign, Sub, SubAssign};
 
 /// 2D size.
 ///
@@ -344,6 +348,12 @@ impl From<&Size> for (u32, u32) {
     }
 }
 
+impl fmt::Display for Size {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} x {}", self.width, self.height)
+    }
+}
+
 #[cfg(feature = "nalgebra_support")]
 use nalgebra::{base::Scalar, Vector2};
 
@@ -370,6 +380,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use core::fmt::Write;
 
     #[test]
     fn sizes_can_be_added() {
@@ -470,5 +482,13 @@ mod tests {
 
         assert_eq!(a.component_min(b), Size::new(15, 30));
         assert_eq!(a.component_max(b), Size::new(20, 50));
+    }
+
+    #[test]
+    fn display() {
+        let mut buffer = arrayvec::ArrayString::<[u8; 32]>::new();
+        write!(buffer, "{}", Size::new(123, 456)).unwrap();
+
+        assert_eq!(&buffer, "123 x 456");
     }
 }


### PR DESCRIPTION
This PR implements the `Display` trait for `Point` and `Size`, as discussed in #601.

I've slightly changed the output for `Size`s: `123 x 456` instead of `123x456`, because it makes the output more readable IMO.

Closes #601 
