### PR TITLE
Replace MockDisplay::eq by PartialEq impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 ### Changed
 
 - **(breaking)** - [#600](https://github.com/embedded-graphics/embedded-graphics/pull/600) Renamed `Mapping::all` to `Mapping::iter`.
+- **(breaking)** - [#603](https://github.com/embedded-graphics/embedded-graphics/pull/603) `MockDisplay::eq` was replaced by a `PartialEq` implementation for `MockDisplay`.
 
 ## [0.7.0-beta.2] - 2021-05-24
 

--- a/MIGRATING-0.6-0.7.md
+++ b/MIGRATING-0.6-0.7.md
@@ -250,7 +250,7 @@ let height = display.bounding_box().size.height;
 
 An advanced visual representation of failing `MockDisplay` assertions can be enabled by setting the `EG_FANCY_PANIC` environment variable to `1`, for example, by calling `EG_FANCY_PANIC=1 cargo test`.
 
-To make this output format possible assertions need to use the new `MockDisplay::assert_eq` and `assert_eq_with_message` methods instead of the `assert_eq!` macro. To ensure that the new methods are used the `PartialEq` implementation for `MockDisplay` was removed. In case that the equality of two mock `MockDisplay` needs to be tested outside of an assertion the `MockDisplay::eq` method can be used.
+To use `EG_FANCY_PANIC` the new `MockDisplay::assert_eq` and `assert_eq_with_message` must be used instead of the `assert_eq!` macro.
 
 ```rust
 #[test]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -129,10 +129,9 @@ New methods:
 - `assert_pattern_with_message` - the same as above, but with the ability to write custom messages in the test output.
 - `assert_pattern` - check for equality against a pattern and panic if they do not match.
 - `diff` - compare the display against another `MockDisplay`, producing a new `MockDisplay` containing the colored difference between them.
-- `eq` - check for equality between two `MockDisplay`s.
 - `from_points` - create a `MockDisplay` from an iterator over `Point`s.
 - `map` - create a copy of the current display with a predicate applied to all pixels.
-- `set_allow_out_of_bounds_drawing` - if set to `true`, disables the panicking behaviour when a drawing operation attempts to draw pixels outside the visible mock display area.
-- `set_allow_overdraw` - if set to `true`, disables the panicking behaviour when a pixel is drawn to twice.
+- `set_allow_out_of_bounds_drawing` - if set to `true`, disables the panicking behavior when a drawing operation attempts to draw pixels outside the visible mock display area.
+- `set_allow_overdraw` - if set to `true`, disables the panicking behavior when a pixel is drawn to twice.
 - `set_pixels` - sets the points in an iterator to the given color.
 - `swap_xy` - copies the current display with X and Y coordinates swapped.

--- a/src/mock_display/mod.rs
+++ b/src/mock_display/mod.rs
@@ -493,12 +493,10 @@ where
 
         display
     }
+}
 
-    /// Returns `true` if `self` and `other` are equal.
-    ///
-    /// `MockDisplay` doesn't implement the `PartialEq` to make sure that the `assert_eq` and
-    /// `assert_pattern` methods are used instead of the `assert_eq!` macro.
-    pub fn eq(&self, other: &MockDisplay<C>) -> bool {
+impl<C: PixelColor> PartialEq for MockDisplay<C> {
+    fn eq(&self, other: &Self) -> bool {
         self.pixels.iter().eq(other.pixels.iter())
     }
 }


### PR DESCRIPTION
When we introduced `EG_FANCY_PANIC` I had decided to remove the `PartialEq` impl for `MockDisplay` to make sure the new assertions are used. I think this was useful for the transition, but it might not be the best permanent solution. This PR reverts this change, which simplifies the migration guide and makes clippy a little happier.