### PR TITLE
Bump core to 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- [#606](https://github.com/embedded-graphics/embedded-graphics/pull/606) Bump minimum embedded-graphics-core version from `0.3.0` to `0.3.2`
+
 ## [0.7.0] - 2021-06-05
 
 ### Added
@@ -652,8 +656,8 @@ A big release, focussed on ergonomics. There are new macros to make drawing and 
   ```
 
 <!-- next-url -->
-[unreleased]: https://github.com/embedded-graphics/embedded-graphics/compare/embedded-graphics-v0.7.0...HEAD
 
+[unreleased]: https://github.com/embedded-graphics/embedded-graphics/compare/embedded-graphics-v0.7.0...HEAD
 [0.7.0]: https://github.com/embedded-graphics/embedded-graphics/compare/embedded-graphics-v0.7.0-beta.2...embedded-graphics-v0.7.0
 [0.7.0-beta.2]: https://github.com/embedded-graphics/embedded-graphics/compare/embedded-graphics-v0.7.0-beta.1...embedded-graphics-v0.7.0-beta.2
 [0.7.0-beta.1]: https://github.com/embedded-graphics/embedded-graphics/compare/embedded-graphics-v0.7.0-alpha.3...embedded-graphics-v0.7.0-beta.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ az = "1.1"
 fixed = { version = "0.5.7", optional = true, default-features = false }
 float-cmp = "0.8.0"
 micromath = { version = "1.1.0", default-features = false }
-embedded-graphics-core = { path = "core", version = "^0.3.2"}
+embedded-graphics-core = { path = "core", version = "0.3.2"}
 byteorder = { version = "1.3.4", default-features = false }
 
 # criterion is not listed as a dev-dependency to work around a problem with no_std compatibility

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ az = "1.1"
 fixed = { version = "0.5.7", optional = true, default-features = false }
 float-cmp = "0.8.0"
 micromath = { version = "1.1.0", default-features = false }
-embedded-graphics-core = { path = "core", version = "^0.3.0"}
+embedded-graphics-core = { path = "core", version = "^0.3.2"}
 byteorder = { version = "1.3.4", default-features = false }
 
 # criterion is not listed as a dev-dependency to work around a problem with no_std compatibility


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Bumps e-g core to minimum version 0.3.2.

Cc embedded-graphics/simulator#32
