### PR TITLE
Fix link to migration guide from 0.6 to 0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ calculation.
 ## Migrating from older versions
 
 * [Migration guide from 0.5 to 0.6](https://github.com/embedded-graphics/embedded-graphics/blob/master/MIGRATING-0.5-0.6.md).
-* [Migration guide from 0.6 to 0.7](https://github.com/embedded-graphics/embedded-graphics/blob/master/MIGRATING-0.5-0.6.md).
+* [Migration guide from 0.6 to 0.7](https://github.com/embedded-graphics/embedded-graphics/blob/master/MIGRATING-0.6-0.7.md).
 
 ## Implementing `embedded_graphics` support for a display driver
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@
 //! # Migrating from older versions
 //!
 //! * [Migration guide from 0.5 to 0.6](https://github.com/embedded-graphics/embedded-graphics/blob/master/MIGRATING-0.5-0.6.md).
-//! * [Migration guide from 0.6 to 0.7](https://github.com/embedded-graphics/embedded-graphics/blob/master/MIGRATING-0.5-0.6.md).
+//! * [Migration guide from 0.6 to 0.7](https://github.com/embedded-graphics/embedded-graphics/blob/master/MIGRATING-0.6-0.7.md).
 //!
 //! # Implementing `embedded_graphics` support for a display driver
 //!


### PR DESCRIPTION
Just fixes the link to the migration guide from 0.6 to 0.7 in `README.md`. Checked the link target in the preview of `README.md` manually.
