### PR TITLE
ensure fill_solid does not infinity-loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 ## [Unreleased] - ReleaseDate
 
+- ensure `DrawTarget::fill_solid` does not cause endless loop in case `DrawTarget::fill_contiguous` is used without limiting `colors` iterator with `take`
+
 ## [0.7.1] - 2021-06-15
 
 ### Changed

--- a/core/src/draw_target/mod.rs
+++ b/core/src/draw_target/mod.rs
@@ -405,7 +405,15 @@ pub trait DrawTarget: Dimensions {
     /// The default implementation of this method calls [`fill_contiguous`](#method.fill_contiguous)
     /// with an iterator that repeats the given `color` for every point in `area`.
     fn fill_solid(&mut self, area: &Rectangle, color: Self::Color) -> Result<(), Self::Error> {
-        self.fill_contiguous(area, area.points().map(|_| color))
+        let mut count = 0u32;
+        let max = area.size.width * area.size.height;
+        self.fill_contiguous(
+            area,
+            core::iter::repeat(color).take_while(|_| {
+                count += 1;
+                count <= max
+            }),
+        )
     }
 
     /// Fill the entire display with a solid color.

--- a/core/src/draw_target/mod.rs
+++ b/core/src/draw_target/mod.rs
@@ -407,8 +407,7 @@ pub trait DrawTarget: Dimensions {
     fn fill_solid(&mut self, area: &Rectangle, color: Self::Color) -> Result<(), Self::Error> {
         self.fill_contiguous(
             area,
-            core::iter::repeat(color)
-                .take((area.size.width * area.size.height) as usize)
+            core::iter::repeat(color).take((area.size.width * area.size.height) as usize),
         )
     }
 

--- a/core/src/draw_target/mod.rs
+++ b/core/src/draw_target/mod.rs
@@ -405,7 +405,11 @@ pub trait DrawTarget: Dimensions {
     /// The default implementation of this method calls [`fill_contiguous`](#method.fill_contiguous)
     /// with an iterator that repeats the given `color` for every point in `area`.
     fn fill_solid(&mut self, area: &Rectangle, color: Self::Color) -> Result<(), Self::Error> {
-        self.fill_contiguous(area, core::iter::repeat(color))
+        self.fill_contiguous(
+            area,
+            core::iter::repeat(color)
+                .take((area.size.width * area.size.height) as usize)
+        )
     }
 
     /// Fill the entire display with a solid color.

--- a/core/src/draw_target/mod.rs
+++ b/core/src/draw_target/mod.rs
@@ -405,10 +405,7 @@ pub trait DrawTarget: Dimensions {
     /// The default implementation of this method calls [`fill_contiguous`](#method.fill_contiguous)
     /// with an iterator that repeats the given `color` for every point in `area`.
     fn fill_solid(&mut self, area: &Rectangle, color: Self::Color) -> Result<(), Self::Error> {
-        self.fill_contiguous(
-            area,
-            core::iter::repeat(color).take((area.size.width * area.size.height) as usize),
-        )
+        self.fill_contiguous(area, area.points().map(|_| color))
     }
 
     /// Fill the entire display with a solid color.


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Ensure `DrawTarget::fill_solid` default implementation does not cause a driver to loop endlessly if they override `DrawTarget::fill_congiuous` without clamping the `colors` iterator with `take` or other finity enforcement.
