### PR TITLE
add rgb666 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- [#621](https://github.com/embedded-graphics/embedded-graphics/pull/621) Added `Rgb666` and `Bgr666` color type support.
+
 ## [0.7.1] - 2021-06-15
 
 ### Changed

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- [#621](https://github.com/embedded-graphics/embedded-graphics/pull/621) Added `Rgb666` and `Bgr666` color type support.
+
 ## [0.3.2] - 2021-06-05
 
 ### Added

--- a/core/src/pixelcolor/raw/mod.rs
+++ b/core/src/pixelcolor/raw/mod.rs
@@ -240,6 +240,7 @@ impl_raw_data!(RawU2: u8, 2, 0x03, "2 bits");
 impl_raw_data!(RawU4: u8, 4, 0x0F, "4 bits");
 impl_raw_data!(RawU8: u8, 8, 0xFF, "8 bits");
 impl_raw_data!(RawU16: u16, 16, 0xFFFF, "16 bits");
+impl_raw_data!(RawU18: u32, 18, 0x3FFFF, "18 bits");
 impl_raw_data!(RawU24: u32, 24, 0xFF_FFFF, "24 bits");
 impl_raw_data!(RawU32: u32, 32, 0xFFFF_FFFF, "32 bits");
 

--- a/core/src/pixelcolor/raw/to_bytes.rs
+++ b/core/src/pixelcolor/raw/to_bytes.rs
@@ -1,5 +1,5 @@
 use crate::pixelcolor::{
-    raw::{RawU1, RawU16, RawU2, RawU24, RawU32, RawU4, RawU8},
+    raw::{RawU1, RawU16, RawU18, RawU2, RawU24, RawU32, RawU4, RawU8},
     PixelColor,
 };
 
@@ -48,6 +48,36 @@ impl_to_bytes!(RawU4, [u8; 1]);
 impl_to_bytes!(RawU8, [u8; 1]);
 impl_to_bytes!(RawU16, [u8; 2]);
 impl_to_bytes!(RawU32, [u8; 4]);
+
+impl ToBytes for RawU18 {
+    type Bytes = [u8; 3];
+
+    fn to_be_bytes(self) -> Self::Bytes {
+        let mut ret = [0; 3];
+
+        ret.copy_from_slice(&self.0.to_be_bytes()[1..4]);
+
+        ret
+    }
+
+    fn to_le_bytes(self) -> Self::Bytes {
+        let mut ret = [0; 3];
+
+        ret.copy_from_slice(&self.0.to_le_bytes()[0..3]);
+
+        ret
+    }
+
+    #[cfg(target_endian = "big")]
+    fn to_ne_bytes(self) -> Self::Bytes {
+        self.to_be_bytes()
+    }
+
+    #[cfg(target_endian = "little")]
+    fn to_ne_bytes(self) -> Self::Bytes {
+        self.to_le_bytes()
+    }
+}
 
 impl ToBytes for RawU24 {
     type Bytes = [u8; 3];
@@ -117,7 +147,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pixelcolor::{Bgr565, Bgr888, BinaryColor, Gray2, Gray4, Gray8, Rgb565, Rgb888};
+    use crate::pixelcolor::{
+        Bgr565, Bgr666, Bgr888, BinaryColor, Gray2, Gray4, Gray8, Rgb565, Rgb666, Rgb888,
+    };
 
     fn assert_all_orders<T>(value: T, bytes: T::Bytes)
     where
@@ -214,6 +246,70 @@ mod tests {
         assert_eq!(
             Bgr565::new(0, 0, 255).to_le_bytes(),
             [0b000_00000, 0b11111_000]
+        );
+    }
+
+    #[test]
+    fn bpp18_bgr_be() {
+        assert_eq!(
+            Bgr666::new(0xFF, 0x00, 0x00).to_be_bytes(),
+            [0b000000000, 0b000000000, 0b00_111111]
+        );
+        assert_eq!(
+            Bgr666::new(0x0, 0xFF, 0x00).to_be_bytes(),
+            [0b000000000, 0b0000_1111, 0b11_000000]
+        );
+        assert_eq!(
+            Bgr666::new(0x00, 0x00, 0xFF).to_be_bytes(),
+            [0b0000000_11, 0b1111_0000, 0b000000000]
+        );
+    }
+
+    #[test]
+    fn bpp18_bgr_le() {
+        assert_eq!(
+            Bgr666::new(0xFF, 0x00, 0x00).to_le_bytes(),
+            [0b00_111111, 0b000000000, 0b000000000]
+        );
+        assert_eq!(
+            Bgr666::new(0x0, 0xFF, 0x00).to_le_bytes(),
+            [0b11_000000, 0b0000_1111, 0b000000000]
+        );
+        assert_eq!(
+            Bgr666::new(0x00, 0x00, 0xFF).to_le_bytes(),
+            [0b000000000, 0b1111_0000, 0b0000000_11]
+        );
+    }
+
+    #[test]
+    fn bpp18_rgb_be() {
+        assert_eq!(
+            Rgb666::new(0xFF, 0x00, 0x00).to_be_bytes(),
+            [0b0000000_11, 0b1111_0000, 0b000000000]
+        );
+        assert_eq!(
+            Rgb666::new(0x0, 0xFF, 0x00).to_be_bytes(),
+            [0b000000000, 0b0000_1111, 0b11_000000]
+        );
+        assert_eq!(
+            Rgb666::new(0x00, 0x00, 0xFF).to_be_bytes(),
+            [0b000000000, 0b000000000, 0b00_111111]
+        );
+    }
+
+    #[test]
+    fn bpp18_rgb_le() {
+        assert_eq!(
+            Rgb666::new(0xFF, 0x00, 0x00).to_le_bytes(),
+            [0b000000000, 0b1111_0000, 0b0000000_11]
+        );
+        assert_eq!(
+            Rgb666::new(0x0, 0xFF, 0x00).to_le_bytes(),
+            [0b11_000000, 0b0000_1111, 0b000000000]
+        );
+        assert_eq!(
+            Rgb666::new(0x00, 0x00, 0xFF).to_le_bytes(),
+            [0b00_111111, 0b000000000, 0b000000000]
         );
     }
 

--- a/core/src/pixelcolor/rgb_color.rs
+++ b/core/src/pixelcolor/rgb_color.rs
@@ -220,6 +220,9 @@ rgb_color!(Bgr555, RawU16, u16, Bgr = (5, 5, 5));
 rgb_color!(Rgb565, RawU16, u16, Rgb = (5, 6, 5));
 rgb_color!(Bgr565, RawU16, u16, Bgr = (5, 6, 5));
 
+rgb_color!(Rgb666, RawU24, u32, Rgb = (6, 6, 6));
+rgb_color!(Bgr666, RawU24, u32, Bgr = (6, 6, 6));
+
 rgb_color!(Rgb888, RawU24, u32, Rgb = (8, 8, 8));
 rgb_color!(Bgr888, RawU24, u32, Bgr = (8, 8, 8));
 
@@ -276,6 +279,20 @@ mod tests {
         test_bpp16(Bgr565::new(0b10001, 0, 0), 0b10001 << 0);
         test_bpp16(Bgr565::new(0, 0b100001, 0), 0b100001 << 5);
         test_bpp16(Bgr565::new(0, 0, 0b10001), 0b10001 << 5 + 6);
+    }
+
+    #[test]
+    pub fn bit_positions_rgb666() {
+        test_bpp24(Rgb666::new(0b100001, 0, 0), 0b100001 << 6 + 6);
+        test_bpp24(Rgb666::new(0, 0b100001, 0), 0b100001 << 6);
+        test_bpp24(Rgb666::new(0, 0, 0b100001), 0b100001 << 0);
+    }
+
+    #[test]
+    pub fn bit_positions_bgr666() {
+        test_bpp24(Bgr666::new(0b100001, 0, 0), 0b100001 << 0);
+        test_bpp24(Bgr666::new(0, 0b100001, 0), 0b100001 << 6);
+        test_bpp24(Bgr666::new(0, 0, 0b100001), 0b100001 << 6 + 6);
     }
 
     #[test]

--- a/core/src/pixelcolor/rgb_color.rs
+++ b/core/src/pixelcolor/rgb_color.rs
@@ -1,5 +1,5 @@
 use crate::pixelcolor::{
-    raw::{RawData, RawU16, RawU24},
+    raw::{RawData, RawU16, RawU18, RawU24},
     PixelColor,
 };
 use core::fmt;
@@ -220,8 +220,8 @@ rgb_color!(Bgr555, RawU16, u16, Bgr = (5, 5, 5));
 rgb_color!(Rgb565, RawU16, u16, Rgb = (5, 6, 5));
 rgb_color!(Bgr565, RawU16, u16, Bgr = (5, 6, 5));
 
-rgb_color!(Rgb666, RawU24, u32, Rgb = (6, 6, 6));
-rgb_color!(Bgr666, RawU24, u32, Bgr = (6, 6, 6));
+rgb_color!(Rgb666, RawU18, u32, Rgb = (6, 6, 6));
+rgb_color!(Bgr666, RawU18, u32, Bgr = (6, 6, 6));
 
 rgb_color!(Rgb888, RawU24, u32, Rgb = (8, 8, 8));
 rgb_color!(Bgr888, RawU24, u32, Bgr = (8, 8, 8));
@@ -237,6 +237,17 @@ mod tests {
         C: RgbColor + From<RawU16> + Into<RawU16> + core::fmt::Debug,
     {
         let value = RawU16::new(value);
+
+        assert_eq!(color.into(), value);
+        assert_eq!(C::from(value), color);
+    }
+
+    /// Convert color to integer and back again to test bit positions
+    fn test_bpp18<C>(color: C, value: u32)
+    where
+        C: RgbColor + From<RawU18> + Into<RawU18> + core::fmt::Debug,
+    {
+        let value = RawU18::new(value);
 
         assert_eq!(color.into(), value);
         assert_eq!(C::from(value), color);
@@ -283,16 +294,16 @@ mod tests {
 
     #[test]
     pub fn bit_positions_rgb666() {
-        test_bpp24(Rgb666::new(0b100001, 0, 0), 0b100001 << 6 + 6);
-        test_bpp24(Rgb666::new(0, 0b100001, 0), 0b100001 << 6);
-        test_bpp24(Rgb666::new(0, 0, 0b100001), 0b100001 << 0);
+        test_bpp18(Rgb666::new(0b100001, 0, 0), 0b100001 << 6 + 6);
+        test_bpp18(Rgb666::new(0, 0b100001, 0), 0b100001 << 6);
+        test_bpp18(Rgb666::new(0, 0, 0b100001), 0b100001 << 0);
     }
 
     #[test]
     pub fn bit_positions_bgr666() {
-        test_bpp24(Bgr666::new(0b100001, 0, 0), 0b100001 << 0);
-        test_bpp24(Bgr666::new(0, 0b100001, 0), 0b100001 << 6);
-        test_bpp24(Bgr666::new(0, 0, 0b100001), 0b100001 << 6 + 6);
+        test_bpp18(Bgr666::new(0b100001, 0, 0), 0b100001 << 0);
+        test_bpp18(Bgr666::new(0, 0b100001, 0), 0b100001 << 6);
+        test_bpp18(Bgr666::new(0, 0, 0b100001), 0b100001 << 6 + 6);
     }
 
     #[test]


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Adds `Rgb666` support for displays such as the [ILI9486](https://www.aliexpress.com/item/1005002632269797.html?spm=a2g0s.9042311.0.0.68974c4dmBHD93)
