### PR TITLE
Add rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.40.0"
+components = [ "rustfmt" ]
+profile = "minimal"


### PR DESCRIPTION
I've deliberately left extra stuff like different targets and non-standard-development stuff used in CI out of this config as the build image we use preinstalls a few things for itself anyway.