### PR TITLE
Use const fn for constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
   - `Circle::with_center`
   - `Ellipse::with_center`
   - `Sector::with_center`
+  - `Sector::from_circle`
+  - `Sector::to_circle`
   - `Styled::new`
 
 ## [0.7.1] - 2021-06-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,27 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 ### Changed
 
 - **(breaking)** - [#638](https://github.com/embedded-graphics/embedded-graphics/pull/638) Bump Minimum Supported Rust Version (MSRV) to 1.57.
+- [#639](https://github.com/embedded-graphics/embedded-graphics/pull/639) Made the following functions `const`:
+  - `Point::component_mul`
+  - `Point::component_div`
+  - `Size::saturating_add`
+  - `Size::saturating_sub`
+  - `Size::component_mul`
+  - `Size::component_div`
+  - `BinaryColor::invert`
+  - `BinaryColor::is_on`
+  - `BinaryColor::is_off`
+  - `Rectangle::with_center`
+  - `Rectangle::is_zero_sized`
+  - `RawDataSlice::new`
+  - `MonoTextStyle::new`
+  - `Arc::with_center`
+  - `Arc::from_circle`
+  - `Arc::to_circle`
+  - `Circle::with_center`
+  - `Ellipse::with_center`
+  - `Sector::with_center`
+  - `Styled::new`
 
 ## [0.7.1] - 2021-06-15
 

--- a/core/src/geometry/point.rs
+++ b/core/src/geometry/point.rs
@@ -196,7 +196,7 @@ impl Point {
     ///
     /// assert_eq!(result, Point::new(-40, 90));
     /// ```
-    pub fn component_mul(self, other: Self) -> Self {
+    pub const fn component_mul(self, other: Self) -> Self {
         Self::new(self.x * other.x, self.y * other.y)
     }
 
@@ -213,7 +213,7 @@ impl Point {
     ///
     /// assert_eq!(result, Point::new(2, -10));
     /// ```
-    pub fn component_div(self, other: Self) -> Self {
+    pub const fn component_div(self, other: Self) -> Self {
         Self::new(self.x / other.x, self.y / other.y)
     }
 }

--- a/core/src/geometry/point.rs
+++ b/core/src/geometry/point.rs
@@ -157,6 +157,24 @@ impl Point {
         Point::new(self.x.abs(), self.y.abs())
     }
 
+    /// Offsets a point by subtracting a size.
+    ///
+    /// This method provides a workaround for the `Sub` trait not being usable in `const` contexts.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `width` or `height` are too large to be represented as an `i32`
+    /// and debug assertions are enabled.
+    pub const fn sub_size(self, other: Size) -> Point {
+        let width = other.width as i32;
+        let height = other.height as i32;
+
+        debug_assert!(width >= 0, "width is too large");
+        debug_assert!(height >= 0, "height is too large");
+
+        Point::new(self.x - width, self.y - height)
+    }
+
     /// Returns the componentwise minimum of two `Point`s
     ///
     /// # Examples
@@ -290,13 +308,7 @@ impl Sub<Size> for Point {
     /// This function will panic if `width` or `height` are too large to be represented as an `i32`
     /// and debug assertions are enabled.
     fn sub(self, other: Size) -> Point {
-        let width = other.width as i32;
-        let height = other.height as i32;
-
-        debug_assert!(width >= 0, "width is too large");
-        debug_assert!(height >= 0, "height is too large");
-
-        Point::new(self.x - width, self.y - height)
+        self.sub_size(other)
     }
 }
 

--- a/core/src/geometry/point.rs
+++ b/core/src/geometry/point.rs
@@ -165,7 +165,7 @@ impl Point {
     ///
     /// This function will panic if `width` or `height` are too large to be represented as an `i32`
     /// and debug assertions are enabled.
-    pub const fn sub_size(self, other: Size) -> Point {
+    pub(crate) const fn sub_size(self, other: Size) -> Point {
         let width = other.width as i32;
         let height = other.height as i32;
 

--- a/core/src/geometry/size.rs
+++ b/core/src/geometry/size.rs
@@ -157,7 +157,7 @@ impl Size {
     /// Saturating addition.
     ///
     /// Returns `u32::max_value()` for `width` and/or `height` instead of overflowing.
-    pub fn saturating_add(self, other: Self) -> Self {
+    pub const fn saturating_add(self, other: Self) -> Self {
         Self {
             width: self.width.saturating_add(other.width),
             height: self.height.saturating_add(other.height),
@@ -168,7 +168,7 @@ impl Size {
     ///
     /// Returns `0` for `width` and/or `height` instead of overflowing, if the
     /// value in `other` is larger then in `self`.
-    pub fn saturating_sub(self, other: Self) -> Self {
+    pub const fn saturating_sub(self, other: Self) -> Self {
         Self {
             width: self.width.saturating_sub(other.width),
             height: self.height.saturating_sub(other.height),
@@ -218,7 +218,7 @@ impl Size {
     ///
     /// assert_eq!(result, Size::new(40, 90));
     /// ```
-    pub fn component_mul(self, other: Self) -> Self {
+    pub const fn component_mul(self, other: Self) -> Self {
         Self::new(self.width * other.width, self.height * other.height)
     }
 
@@ -235,7 +235,7 @@ impl Size {
     ///
     /// assert_eq!(result, Size::new(4, 3));
     /// ```
-    pub fn component_div(self, other: Self) -> Self {
+    pub const fn component_div(self, other: Self) -> Self {
         Self::new(self.width / other.width, self.height / other.height)
     }
 }

--- a/core/src/geometry/size.rs
+++ b/core/src/geometry/size.rs
@@ -175,6 +175,13 @@ impl Size {
         }
     }
 
+    /// Division.
+    ///
+    /// This method provides a workaround for the `Div` trait not being usable in `const` contexts.
+    pub const fn div_u32(self, rhs: u32) -> Size {
+        Size::new(self.width / rhs, self.height / rhs)
+    }
+
     /// Creates a size from two corner points of a bounding box.
     pub(crate) const fn from_bounding_box(corner_1: Point, corner_2: Point) -> Self {
         let width = (corner_1.x - corner_2.x).abs() as u32 + 1;
@@ -289,7 +296,7 @@ impl Div<u32> for Size {
     type Output = Size;
 
     fn div(self, rhs: u32) -> Size {
-        Size::new(self.width / rhs, self.height / rhs)
+        self.div_u32(rhs)
     }
 }
 

--- a/core/src/geometry/size.rs
+++ b/core/src/geometry/size.rs
@@ -178,7 +178,7 @@ impl Size {
     /// Division.
     ///
     /// This method provides a workaround for the `Div` trait not being usable in `const` contexts.
-    pub const fn div_u32(self, rhs: u32) -> Size {
+    pub(crate) const fn div_u32(self, rhs: u32) -> Size {
         Size::new(self.width / rhs, self.height / rhs)
     }
 

--- a/core/src/pixelcolor/binary_color.rs
+++ b/core/src/pixelcolor/binary_color.rs
@@ -84,10 +84,7 @@ impl BinaryColor {
     /// ```
     #[inline]
     pub const fn is_on(self) -> bool {
-        match self {
-            BinaryColor::On => true,
-            BinaryColor::Off => false,
-        }
+        matches!(self, BinaryColor::On)
     }
 
     /// Returns `true` if this color is `Off`.
@@ -101,10 +98,7 @@ impl BinaryColor {
     /// ```
     #[inline]
     pub const fn is_off(self) -> bool {
-        match self {
-            BinaryColor::On => false,
-            BinaryColor::Off => true,
-        }
+        matches!(self, BinaryColor::Off)
     }
 
     /// Maps active and inactive colors to a different type.

--- a/core/src/pixelcolor/binary_color.rs
+++ b/core/src/pixelcolor/binary_color.rs
@@ -66,7 +66,7 @@ impl BinaryColor {
     /// assert_eq!(BinaryColor::On.invert(), BinaryColor::Off);
     /// ```
     #[inline]
-    pub fn invert(self) -> Self {
+    pub const fn invert(self) -> Self {
         match self {
             BinaryColor::On => BinaryColor::Off,
             BinaryColor::Off => BinaryColor::On,
@@ -83,8 +83,11 @@ impl BinaryColor {
     /// assert!(BinaryColor::On.is_on());
     /// ```
     #[inline]
-    pub fn is_on(self) -> bool {
-        self == BinaryColor::On
+    pub const fn is_on(self) -> bool {
+        match self {
+            BinaryColor::On => true,
+            BinaryColor::Off => false,
+        }
     }
 
     /// Returns `true` if this color is `Off`.
@@ -97,8 +100,11 @@ impl BinaryColor {
     /// assert!(BinaryColor::Off.is_off());
     /// ```
     #[inline]
-    pub fn is_off(self) -> bool {
-        self == BinaryColor::Off
+    pub const fn is_off(self) -> bool {
+        match self {
+            BinaryColor::On => false,
+            BinaryColor::Off => true,
+        }
     }
 
     /// Maps active and inactive colors to a different type.

--- a/core/src/primitives/rectangle/mod.rs
+++ b/core/src/primitives/rectangle/mod.rs
@@ -72,8 +72,8 @@ impl PointsIter for Rectangle {
 ///
 /// The center offset is defined as the offset between the top left corner and
 /// the center point of a rectangle with the given size.
-fn center_offset(size: Size) -> Size {
-    size.saturating_sub(Size::new_equal(1)) / 2
+const fn center_offset(size: Size) -> Size {
+    size.saturating_sub(Size::new_equal(1)).div_u32(2)
 }
 
 impl Rectangle {
@@ -98,9 +98,9 @@ impl Rectangle {
     /// For rectangles with even width and/or height the top left corner doesn't
     /// align with the pixel grid. Because of this the coordinates of the top left
     /// corner will be rounded up to the nearest integer coordinate.
-    pub fn with_center(center: Point, size: Size) -> Self {
+    pub const fn with_center(center: Point, size: Size) -> Self {
         Rectangle {
-            top_left: center - center_offset(size),
+            top_left: center.sub_size(center_offset(size)),
             size,
         }
     }

--- a/core/src/primitives/rectangle/mod.rs
+++ b/core/src/primitives/rectangle/mod.rs
@@ -429,8 +429,7 @@ impl Rectangle {
     /// let rect = Rectangle::new(Point::new(10, 20), Size::zero());
     /// assert_eq!(rect.is_zero_sized(), true);
     /// ```
-    // MSRV: Add const when upgrading to at least 1.46.0
-    pub fn is_zero_sized(&self) -> bool {
+    pub const fn is_zero_sized(&self) -> bool {
         self.size.height == 0 || self.size.width == 0
     }
 }

--- a/src/iterator/raw.rs
+++ b/src/iterator/raw.rs
@@ -49,7 +49,7 @@ pub struct RawDataSlice<'a, R, BO> {
 
 impl<'a, R, BO> RawDataSlice<'a, R, BO> {
     /// Creates a new raw data slice.
-    pub fn new(data: &'a [u8]) -> Self {
+    pub const fn new(data: &'a [u8]) -> Self {
         Self {
             data,
             raw_type: PhantomData,

--- a/src/mono_font/mono_text_style.rs
+++ b/src/mono_font/mono_text_style.rs
@@ -386,7 +386,7 @@ pub struct MonoTextStyleBuilder<'a, C> {
 
 impl<C> MonoTextStyleBuilder<'_, C> {
     /// Creates a new text style builder.
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             style: MonoTextStyle {
                 font: &super::NULL_FONT,

--- a/src/mono_font/mono_text_style.rs
+++ b/src/mono_font/mono_text_style.rs
@@ -386,7 +386,7 @@ pub struct MonoTextStyleBuilder<'a, C> {
 
 impl<C> MonoTextStyleBuilder<'_, C> {
     /// Creates a new text style builder.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             style: MonoTextStyle {
                 font: &super::NULL_FONT,

--- a/src/primitives/arc/mod.rs
+++ b/src/primitives/arc/mod.rs
@@ -75,7 +75,7 @@ impl Arc {
     }
 
     /// Create a new arc centered around a given point with a specific diameter and start and sweep angles
-    pub fn with_center(
+    pub const fn with_center(
         center: Point,
         diameter: u32,
         angle_start: Angle,
@@ -91,7 +91,7 @@ impl Arc {
     /// Creates an arc based on a circle.
     ///
     /// The resulting arc will match the `top_left` and `diameter` of the base circle.
-    pub fn from_circle(circle: Circle, angle_start: Angle, angle_sweep: Angle) -> Self {
+    pub const fn from_circle(circle: Circle, angle_start: Angle, angle_sweep: Angle) -> Self {
         Self {
             top_left: circle.top_left,
             diameter: circle.diameter,
@@ -101,7 +101,7 @@ impl Arc {
     }
 
     /// Returns a circle with the same `top_left` and `diameter` as this arc.
-    pub fn to_circle(&self) -> Circle {
+    pub const fn to_circle(&self) -> Circle {
         Circle::new(self.top_left, self.diameter)
     }
 

--- a/src/primitives/circle/mod.rs
+++ b/src/primitives/circle/mod.rs
@@ -70,7 +70,7 @@ impl Circle {
     }
 
     /// Create a new circle centered around a given point with a specific diameter
-    pub fn with_center(center: Point, diameter: u32) -> Self {
+    pub const fn with_center(center: Point, diameter: u32) -> Self {
         let top_left = Rectangle::with_center(center, Size::new_equal(diameter)).top_left;
 
         Circle { top_left, diameter }

--- a/src/primitives/ellipse/mod.rs
+++ b/src/primitives/ellipse/mod.rs
@@ -68,7 +68,7 @@ impl Ellipse {
     }
 
     /// Create a new ellipse centered around a given point with a specific size
-    pub fn with_center(center: Point, size: Size) -> Self {
+    pub const fn with_center(center: Point, size: Size) -> Self {
         let top_left = Rectangle::with_center(center, size).top_left;
 
         Ellipse { top_left, size }

--- a/src/primitives/sector/mod.rs
+++ b/src/primitives/sector/mod.rs
@@ -104,7 +104,7 @@ impl Sector {
     /// Creates an arc based on a circle.
     ///
     /// The resulting sector will match the `top_left` and `diameter` of the base circle.
-    pub fn from_circle(circle: Circle, angle_start: Angle, angle_sweep: Angle) -> Self {
+    pub const fn from_circle(circle: Circle, angle_start: Angle, angle_sweep: Angle) -> Self {
         Sector {
             top_left: circle.top_left,
             diameter: circle.diameter,
@@ -114,7 +114,7 @@ impl Sector {
     }
 
     /// Returns a circle with the same `top_left` and `diameter` as this sector.
-    pub fn to_circle(&self) -> Circle {
+    pub const fn to_circle(&self) -> Circle {
         Circle::new(self.top_left, self.diameter)
     }
 

--- a/src/primitives/sector/mod.rs
+++ b/src/primitives/sector/mod.rs
@@ -85,7 +85,7 @@ impl Sector {
     }
 
     /// Create a new sector centered around a given point with a specific diameter and start and sweep angles
-    pub fn with_center(
+    pub const fn with_center(
         center: Point,
         diameter: u32,
         angle_start: Angle,

--- a/src/primitives/styled.rs
+++ b/src/primitives/styled.rs
@@ -19,7 +19,7 @@ pub struct Styled<T, S> {
 
 impl<T, S> Styled<T, S> {
     /// Creates a styled.
-    pub fn new(primitive: T, style: S) -> Self {
+    pub const fn new(primitive: T, style: S) -> Self {
         Self { primitive, style }
     }
 }


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This makes the following functions `const`:

- `Point::component_mul`
- `Point::component_div`
- `Size::saturating_add`
- `Size::saturating_sub`
- `Size::component_mul`
- `Size::component_div`
- `BinaryColor::invert`
- `BinaryColor::is_on`
- `BinaryColor::is_off`
- `Rectangle::with_center`
- `Rectangle::is_zero_sized`
- `RawDataSlice::new`
- `MonoTextStyle::new`
- `Arc::with_center`
- `Arc::from_circle`
- `Arc::to_circle`
- `Circle::with_center`
- `Ellipse::with_center`
- `Sector::with_center`
- `Sector::from_circle`
- `Sector::to_circle`
- `Styled::new`

One of biggest obstacles to making functions `const` was that the arithmetic operators can't be used in a `const` context except on integers. `Rectangle::with_center` in particular couldn't be `const` because of that limitation, and is used by several other constructors, so I added `const` versions of the necessary `sub` and `div` functions to `Point` and `Size` as a workaround so that I could make it `const`. I also had to bump the MSRV up to 1.57 since it stabilized panicking in `const` functions because `Point`'s implementation of `Sub<Size>` panics. Do you think it's worth it?

## Related

https://github.com/embedded-graphics/embedded-graphics/issues/205
https://github.com/embedded-graphics/embedded-graphics/pull/638