### PR TITLE
Add Line::with_delta constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 ### Added
 
 - [#621](https://github.com/embedded-graphics/embedded-graphics/pull/621) Added `Rgb666` and `Bgr666` color type support.
+- [#641](https://github.com/embedded-graphics/embedded-graphics/pull/641) Added `Line::with_delta` constructor.
 
 ### Changed
 

--- a/src/primitives/line/mod.rs
+++ b/src/primitives/line/mod.rs
@@ -77,11 +77,11 @@ impl Line {
     }
 
     /// Creates a line with a start point and a delta vector.
-    /// 
+    ///
     /// # Examples
     /// ```
     /// use embedded_graphics::{prelude::*, primitives::Line};
-    /// 
+    ///
     /// let line = Line::with_delta(Point::new(10, 20), Point::new(20, -20));
     /// # assert_eq!(line, Line::new(Point::new(10, 20), Point::new(30, 0)));
     /// ```

--- a/src/primitives/line/mod.rs
+++ b/src/primitives/line/mod.rs
@@ -71,8 +71,24 @@ impl Dimensions for Line {
 }
 
 impl Line {
-    /// Create a new line
+    /// Creates a line between two points.
     pub const fn new(start: Point, end: Point) -> Self {
+        Self { start, end }
+    }
+
+    /// Creates a line with a start point and a delta vector.
+    /// 
+    /// # Examples
+    /// ```
+    /// use embedded_graphics::{prelude::*, primitives::Line};
+    /// 
+    /// let line = Line::with_delta(Point::new(10, 20), Point::new(20, -20));
+    /// # assert_eq!(line, Line::new(Point::new(10, 20), Point::new(30, 0)));
+    /// ```
+    pub const fn with_delta(start: Point, delta: Point) -> Self {
+        // Add coordinates manually because `start + delta` isn't const.
+        let end = Point::new(start.x + delta.x, start.y + delta.y);
+
         Self { start, end }
     }
 


### PR DESCRIPTION
This PR adds a `Line::with_delta` constructor and is part of #617.
