### PR TITLE
Fix invalid MonoStyle text dimensions calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
   - `Sector::to_circle`
   - `Styled::new`
 
+### Fixed
+
+- [#648](https://github.com/embedded-graphics/embedded-graphics/pull/648) Fixed incorrect text bounding box calculation when multi-byte characters are used.
+
 ## [0.7.1] - 2021-06-15
 
 ### Changed


### PR DESCRIPTION
The method len() on &str does return the number of bytes of a character.
Using characters such as '°' (which are two bytes long) caused an
incorrect calculation of the text bounding box.