### PR TITLE
Faster color conversions (Part 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
   - `Sector::from_circle`
   - `Sector::to_circle`
   - `Styled::new`
-- [#651](https://github.com/embedded-graphics/embedded-graphics/pull/651) Improved performance of color conversions.
+- [#651](https://github.com/embedded-graphics/embedded-graphics/pull/651), [#652](https://github.com/embedded-graphics/embedded-graphics/pull/652) Improved performance of color conversions.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,3 +67,7 @@ name = "contains"
 [[bench]]
 harness = false
 name = "raw_data_iter"
+
+[[bench]]
+harness = false
+name = "color_conversion"

--- a/benches/color_conversion.rs
+++ b/benches/color_conversion.rs
@@ -1,0 +1,34 @@
+use criterion::*;
+use embedded_graphics::{
+    pixelcolor::{Gray8, Rgb555, Rgb565, Rgb888},
+    prelude::*,
+};
+
+fn impl_bench<CFrom, CTo>(c: &mut Criterion, name: &str)
+where
+    CFrom: PixelColor + Default + Into<CTo>,
+    CTo: PixelColor + Default,
+{
+    c.bench_function(name, |b| {
+        let input = &[CFrom::default(); 320 * 240];
+        let mut output = [CTo::default(); 320 * 240];
+
+        b.iter(|| {
+            for (i, o) in black_box(input).iter().copied().zip(output.iter_mut()) {
+                *o = i.into();
+            }
+        })
+    });
+}
+
+fn color_conversions(c: &mut Criterion) {
+    impl_bench::<Rgb555, Rgb565>(c, "Rgb555 to Rgb565");
+    impl_bench::<Rgb565, Rgb555>(c, "Rgb565 to Rgb555");
+    impl_bench::<Rgb565, Rgb888>(c, "Rgb565 to Rgb888");
+    impl_bench::<Rgb888, Rgb565>(c, "Rgb888 to Rgb565");
+    impl_bench::<Gray8, Rgb888>(c, "Gray8 to Rgb888");
+    impl_bench::<Rgb888, Gray8>(c, "Rgb888 to Gray8");
+}
+
+criterion_group!(benches, color_conversions);
+criterion_main!(benches);

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### Changed
 
 - **(breaking)** - [#638](https://github.com/embedded-graphics/embedded-graphics/pull/638) Bump Minimum Supported Rust Version (MSRV) to 1.57.
-- [#651](https://github.com/embedded-graphics/embedded-graphics/pull/651) Improved performance of color conversions.
+- [#651](https://github.com/embedded-graphics/embedded-graphics/pull/651), [#652](https://github.com/embedded-graphics/embedded-graphics/pull/652) Improved performance of color conversions.
 
 ## [0.3.3] - 2021-09-09
 

--- a/core/src/pixelcolor/conversion.rs
+++ b/core/src/pixelcolor/conversion.rs
@@ -5,14 +5,18 @@ use crate::pixelcolor::{binary_color::*, gray_color::*, rgb_color::*};
 /// Fixed point implementation of the conversion formula:
 /// `out = round(in * from_max / to_max)`
 const fn convert_channel<const FROM_MAX: u8, const TO_MAX: u8>(value: u8) -> u8 {
-    const SHIFT: usize = 24;
-    const CONST_0_5: u32 = 1 << (SHIFT - 1);
+    if TO_MAX != FROM_MAX {
+        const SHIFT: usize = 24;
+        const CONST_0_5: u32 = 1 << (SHIFT - 1);
 
-    // `value * from_max / to_max` scaled by `1 << SHIFT`.
-    let result = value as u32 * (((TO_MAX as u32) << SHIFT) / FROM_MAX as u32);
+        // `value * from_max / to_max` scaled by `1 << SHIFT`.
+        let result = value as u32 * (((TO_MAX as u32) << SHIFT) / FROM_MAX as u32);
 
-    // Scale the result back down into an u8.
-    ((result + CONST_0_5) >> SHIFT) as u8
+        // Scale the result back down into an u8.
+        ((result + CONST_0_5) >> SHIFT) as u8
+    } else {
+        value
+    }
 }
 
 /// Calculates the luma value based on ITU-R BT.601.


### PR DESCRIPTION
This PR is a small addition to #651. Color conversions between color types that share some channel bit depths, like `Rgb565` and `Rgb555`, will now only calculate the conversion for the channels with different bit depths. The effect of this change was minimal to non existing on my desktop, but I think it can't hurt to add it. The compiler seems to already optimize away some redundant calculations now that `convert_channel` uses const generics instead of parameters. 

I've also added benches for the color conversions. Here is a comparison from before #651 and after this PR:
![grafik](https://user-images.githubusercontent.com/226123/154852607-d485f97f-5aed-40f9-8d9a-8f007734197c.png)
Note that `Rgb888` to `Gray8` doesn't use any of the code that was modified in the recent PRs and is only included for completeness.