### PR TITLE
Better Support Trailing Newline in Text draw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
   - `Sector::to_circle`
   - `Styled::new`
 - [#651](https://github.com/embedded-graphics/embedded-graphics/pull/651), [#652](https://github.com/embedded-graphics/embedded-graphics/pull/652) Improved performance of color conversions.
+- [#653](https://github.com/embedded-graphics/embedded-graphics/pull/653) Don't ignore trailing newlines in `Text`.
 - [#662](https://github.com/embedded-graphics/embedded-graphics/pull/662) `ImageRaw::new` no longer panics if `width == 0`.
 - **(breaking)** [#688](https://github.com/embedded-graphics/embedded-graphics/pull/688) `MonoFont` is now `Send + Sync`; implementations of `GlyphMapping` must be `Sync`.
 - **(breaking)** [#663](https://github.com/embedded-graphics/embedded-graphics/pull/663) Upgraded Cargo dependencies to their latest versions.


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [X] Check that you've added passing tests and documentation
- [X] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [X] Run `rustfmt` on the project
- [X] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

The previous implementation of `Text::draw` ignored a trailing newline so if you chained Text draw calls (with the returned position), the line-spacing was ignored.

There's an example failing test in the first commit of this PR and the second commit is the fix.

For context, I ran into this issue trying to use `core::writeln!` on a wrapper of the display which calls `Text::draw` on each string fragment including a bare newline for a sample string such as:
```
writeln!("Value1: {}", value1);
writeln!("Value 2: {}", value2);
```