### PR TITLE
Add conversion from Rgb666 and Bgr666 to Grey8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 - [#621](https://github.com/embedded-graphics/embedded-graphics/pull/621) Added `Rgb666` and `Bgr666` color type support.
 - [#641](https://github.com/embedded-graphics/embedded-graphics/pull/641) Added `Line::with_delta` constructor.
-- [#561](https://github.com/embedded-graphics/embedded-graphics/pull/656) Added `Rgb666` and `Bgr666` conversions and tests.
+- [#656](https://github.com/embedded-graphics/embedded-graphics/pull/656) Added `Rgb666` and `Bgr666` conversions.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 - [#621](https://github.com/embedded-graphics/embedded-graphics/pull/621) Added `Rgb666` and `Bgr666` color type support.
 - [#641](https://github.com/embedded-graphics/embedded-graphics/pull/641) Added `Line::with_delta` constructor.
+- [#561](https://github.com/embedded-graphics/embedded-graphics/pull/656) Added `Rgb666` and `Bgr666` conversions and tests.
 
 ### Changed
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Added
 
 - [#625](https://github.com/embedded-graphics/embedded-graphics/pull/625) Added CSS colors and color conversions to `Rgb666` and `Bgr666`.
-- [#561](https://github.com/embedded-graphics/embedded-graphics/pull/656) Added `Rgb666` and `Bgr666` conversions and tests.
+- [#656](https://github.com/embedded-graphics/embedded-graphics/pull/656) Added `Rgb666` and `Bgr666` conversions.
 
 ### Changed
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Added
 
 - [#625](https://github.com/embedded-graphics/embedded-graphics/pull/625) Added CSS colors and color conversions to `Rgb666` and `Bgr666`.
+- [#561](https://github.com/embedded-graphics/embedded-graphics/pull/656) Added `Rgb666` and `Bgr666` conversions and tests.
 
 ### Changed
 

--- a/core/src/pixelcolor/conversion.rs
+++ b/core/src/pixelcolor/conversion.rs
@@ -118,7 +118,9 @@ macro_rules! impl_from_binary {
     };
 }
 
-impl_from_binary!(Rgb555, Bgr555, Rgb565, Bgr565, Rgb888, Bgr888, Gray2, Gray4, Gray8);
+impl_from_binary!(
+    Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888, Gray2, Gray4, Gray8
+);
 
 /// Macro to implement conversion from grayscale types to `BinaryColor`.
 macro_rules! impl_gray_to_binary {
@@ -144,7 +146,7 @@ macro_rules! impl_rgb_to_binary {
     };
 }
 
-impl_rgb_to_binary!(Rgb555, Bgr555, Rgb565, Bgr565, Rgb888, Bgr888);
+impl_rgb_to_binary!(Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
 
 #[cfg(test)]
 mod tests {

--- a/core/src/pixelcolor/conversion.rs
+++ b/core/src/pixelcolor/conversion.rs
@@ -217,7 +217,7 @@ mod tests {
             assert_eq!(ToC::from(FromC::WHITE), ToC::WHITE);
         }
 
-        type_matrix!(test_rgb_to_rgb; Rgb555, Bgr555, Rgb565, Bgr565, Rgb888, Bgr888);
+        type_matrix!(test_rgb_to_rgb; Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
     }
 
     #[test]
@@ -227,7 +227,7 @@ mod tests {
             assert_eq!(ToC::from(FromC::WHITE), ToC::WHITE);
         }
 
-        type_matrix!(test_rgb_to_gray; Rgb555, Bgr555, Rgb565, Bgr565, Rgb888, Bgr888 => Gray2, Gray4, Gray8);
+        type_matrix!(test_rgb_to_gray; Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888 => Gray2, Gray4, Gray8);
     }
 
     #[test]
@@ -240,7 +240,7 @@ mod tests {
             assert_eq!(BinaryColor::from(FromC::WHITE), BinaryColor::On);
         }
 
-        type_matrix!(test_rgb_to_binary; Rgb555, Bgr555, Rgb565, Bgr565, Rgb888, Bgr888 => BinaryColor);
+        type_matrix!(test_rgb_to_binary; Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888 => BinaryColor);
     }
 
     #[test]
@@ -260,7 +260,7 @@ mod tests {
             assert_eq!(ToC::from(FromC::WHITE), ToC::WHITE);
         }
 
-        type_matrix!(test_gray_to_rgb; Gray2, Gray4, Gray8 => Rgb555, Bgr555, Rgb565, Bgr565, Rgb888, Bgr888);
+        type_matrix!(test_gray_to_rgb; Gray2, Gray4, Gray8 => Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
     }
 
     #[test]
@@ -283,7 +283,7 @@ mod tests {
             assert_eq!(ToC::from(BinaryColor::On), ToC::WHITE);
         }
 
-        type_matrix!(test_binary_to_rgb; BinaryColor => Rgb555, Bgr555, Rgb565, Bgr565, Rgb888, Bgr888);
+        type_matrix!(test_binary_to_rgb; BinaryColor => Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
     }
 
     #[test]

--- a/core/src/pixelcolor/conversion.rs
+++ b/core/src/pixelcolor/conversion.rs
@@ -105,7 +105,7 @@ macro_rules! impl_rgb_to_and_from_gray {
     }
 }
 
-impl_rgb_to_and_from_gray!(Gray2, Gray4, Gray8 => Rgb555, Bgr555, Rgb565, Bgr565, Rgb888, Bgr888);
+impl_rgb_to_and_from_gray!(Gray2, Gray4, Gray8 => Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
 
 /// Macro to implement conversion from `BinaryColor` to RGB and grayscale types.
 macro_rules! impl_from_binary {


### PR DESCRIPTION
This is required for the tinytga library.

Fixes #654.