### PR TITLE
Inline some usages of self in closures

### DIFF
--- a/src/draw_target/clipped.rs
+++ b/src/draw_target/clipped.rs
@@ -40,11 +40,9 @@ where
     where
         I: IntoIterator<Item = Pixel<Self::Color>>,
     {
-        let clip_area = self.clip_area;
-
         let pixels = pixels
             .into_iter()
-            .filter(|Pixel(p, _)| clip_area.contains(*p));
+            .filter(|Pixel(p, _)| self.clip_area.contains(*p));
 
         self.parent.draw_iter(pixels)
     }

--- a/src/primitives/arc/points.rs
+++ b/src/primitives/arc/points.rs
@@ -39,15 +39,11 @@ impl Iterator for Points {
     type Item = Point;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let outer_threshold = self.outer_threshold;
-        let inner_threshold = self.inner_threshold;
-        let plane_sector = self.plane_sector;
-
         self.iter
             .find(|(_, delta, distance)| {
-                *distance < outer_threshold
-                    && *distance >= inner_threshold
-                    && plane_sector.contains(*delta)
+                *distance < self.outer_threshold
+                    && *distance >= self.inner_threshold
+                    && self.plane_sector.contains(*delta)
             })
             .map(|(point, ..)| point)
     }

--- a/src/primitives/arc/styled.rs
+++ b/src/primitives/arc/styled.rs
@@ -57,15 +57,12 @@ impl<C: PixelColor> Iterator for StyledPixelsIterator<C> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let stroke_color = self.stroke_color?;
-        let outer_threshold = self.outer_threshold;
-        let inner_threshold = self.inner_threshold;
-        let plane_sector = self.plane_sector;
 
         self.iter
             .find(|(_, delta, distance)| {
-                *distance < outer_threshold
-                    && *distance >= inner_threshold
-                    && plane_sector.contains(*delta)
+                *distance < self.outer_threshold
+                    && *distance >= self.inner_threshold
+                    && self.plane_sector.contains(*delta)
             })
             .map(|(point, ..)| Pixel(point, stroke_color))
     }


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR is a result of #629, although I don't really like the changes made here as I think they make the code slightly _less_ readable. Unless I've missed any egregious uses of a temporary binding of `self.<var>` somewhere, I'd be inclined to close both this PR and #629.

Closes #629