### PR TITLE
Fix RAW file output of bdf-to-mono

### DIFF
--- a/tools/bdf-to-mono/src/main.rs
+++ b/tools/bdf-to-mono/src/main.rs
@@ -36,7 +36,7 @@ fn main() {
     }
 
     if let Some(raw_file) = &args.raw {
-        bitmap.save_png(raw_file).unwrap();
+        bitmap.save_raw(raw_file).unwrap();
         println!(
             "{}",
             bitmap.rust(


### PR DESCRIPTION
The bdf-to-mono did save the PNG file twice instead of saving the actual raw image data.
