### PR TITLE
Add `embedded-fps` crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ this are adding support for different image formats or implementing custom fonts
 * [Heapless plotting library for small embedded targets - `embedded-plots`](https://crates.io/crates/embedded-plots)
 * [Virtual seven-segment displays - `eg-seven-segment`](https://crates.io/crates/eg-seven-segment)
 * [Canvas for drawing onto before drawing on the display - `embedded-canvas`](https://crates.io/crates/embedded-canvas)
+* [Frames Per Second counter for embedded devices - `embedded-fps`](https://crates.io/crates/embedded-fps)
 
 Note that some of these crates may not support the latest version of embedded-graphics.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@
 //! * [Heapless plotting library for small embedded targets - `embedded-plots`](https://crates.io/crates/embedded-plots)
 //! * [Virtual seven-segment displays - `eg-seven-segment`](https://crates.io/crates/eg-seven-segment)
 //! * [Canvas for drawing onto before drawing on the display - `embedded-canvas`](https://crates.io/crates/embedded-canvas)
+//! * [Frames Per Second counter for embedded devices - `embedded-fps`](https://crates.io/crates/embedded-fps)
 //!
 //! Note that some of these crates may not support the latest version of embedded-graphics.
 //!


### PR DESCRIPTION
## PR description

This is a small crate that gives the ability to count the Frames per second on embedded devices - `no_std` & no `alloc`.

I've provided an example with `embedded_graphics` in the docs as well.
