### PR TITLE
Add `u8g2-fonts` external crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ this are adding support for different image formats or implementing custom fonts
 * [BMP images - `tinybmp`](https://crates.io/crates/tinybmp)
 * [TGA images - `tinytga`](https://crates.io/crates/tinytga)
 * [QOI images - `tinyqoi`](https://crates.io/crates/tinyqoi)
-* [Large collection of fonts - `u8g2-fonts`](https://crates.io/crates/u8g2-fonts)
+* [External font renderer with large collection of fonts - `u8g2-fonts`](https://crates.io/crates/u8g2-fonts)
 * [ProFont monospace font - `profont`](https://crates.io/crates/profont)
 * [Picofont Pico8 font - `embedded-picofont`](https://crates.io/crates/embedded_picofont)
 * [IBM437 font - `ibm437`](https://crates.io/crates/ibm437)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ this are adding support for different image formats or implementing custom fonts
 * [BMP images - `tinybmp`](https://crates.io/crates/tinybmp)
 * [TGA images - `tinytga`](https://crates.io/crates/tinytga)
 * [QOI images - `tinyqoi`](https://crates.io/crates/tinyqoi)
+* [Large collection of fonts - `u8g2-fonts`](https://crates.io/crates/u8g2-fonts)
 * [ProFont monospace font - `profont`](https://crates.io/crates/profont)
 * [Picofont Pico8 font - `embedded-picofont`](https://crates.io/crates/embedded_picofont)
 * [IBM437 font - `ibm437`](https://crates.io/crates/ibm437)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! * [BMP images - `tinybmp`](https://crates.io/crates/tinybmp)
 //! * [TGA images - `tinytga`](https://crates.io/crates/tinytga)
 //! * [QOI images - `tinyqoi`](https://crates.io/crates/tinyqoi)
-//! * [Large collection of fonts - `u8g2-fonts`](https://crates.io/crates/u8g2-fonts)
+//! * [External font renderer with large collection of fonts - `u8g2-fonts`](https://crates.io/crates/u8g2-fonts)
 //! * [ProFont monospace font - `profont`](https://crates.io/crates/profont)
 //! * [Picofont Pico8 font - `embedded-picofont`](https://crates.io/crates/embedded_picofont)
 //! * [IBM437 font - `ibm437`](https://crates.io/crates/ibm437)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@
 //! * [BMP images - `tinybmp`](https://crates.io/crates/tinybmp)
 //! * [TGA images - `tinytga`](https://crates.io/crates/tinytga)
 //! * [QOI images - `tinyqoi`](https://crates.io/crates/tinyqoi)
+//! * [Large collection of fonts - `u8g2-fonts`](https://crates.io/crates/u8g2-fonts)
 //! * [ProFont monospace font - `profont`](https://crates.io/crates/profont)
 //! * [Picofont Pico8 font - `embedded-picofont`](https://crates.io/crates/embedded_picofont)
 //! * [IBM437 font - `ibm437`](https://crates.io/crates/ibm437)


### PR DESCRIPTION
Add external crate `u8g2-fonts` to `README` and the `lib.rs` documentation.