### PR TITLE
Require `GlyphMapping` implementors to also be `Sync`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
   - `Styled::new`
 - [#651](https://github.com/embedded-graphics/embedded-graphics/pull/651), [#652](https://github.com/embedded-graphics/embedded-graphics/pull/652) Improved performance of color conversions.
 - [#662](https://github.com/embedded-graphics/embedded-graphics/pull/662) `ImageRaw::new` no longer panics if `width == 0`.
+- **(breaking)** [#688](https://github.com/embedded-graphics/embedded-graphics/pull/688) `MonoFont` is now `Send + Sync`; implementations of `GlyphMapping` must be `Sync`.
 - **(breaking)** [#663](https://github.com/embedded-graphics/embedded-graphics/pull/663) Upgraded Cargo dependencies to their latest versions.
 - **(breaking)** [#689](https://github.com/embedded-graphics/embedded-graphics/pull/689) Bump Minimum Supported Rust Version (MSRV) to 1.61.
 

--- a/src/mono_font/mapping.rs
+++ b/src/mono_font/mapping.rs
@@ -46,7 +46,7 @@
 use core::ops::RangeInclusive;
 
 /// Mapping from characters to glyph indices.
-pub trait GlyphMapping {
+pub trait GlyphMapping: Sync {
     /// Maps a character to a glyph index.
     ///
     /// If `c` isn't included in the font the index of a suitable replacement glyph is returned.
@@ -55,7 +55,7 @@ pub trait GlyphMapping {
 
 impl<F> GlyphMapping for F
 where
-    F: Fn(char) -> usize,
+    F: Sync + Fn(char) -> usize,
 {
     fn index(&self, c: char) -> usize {
         self(c)

--- a/src/mono_font/mod.rs
+++ b/src/mono_font/mod.rs
@@ -275,4 +275,11 @@ pub(crate) mod tests {
         test_baseline(&ascii::FONT_9X18);
         test_baseline(&ascii::FONT_10X20);
     }
+
+    /// (Statically) test that [`MonoFont: Send + Sync`].
+    fn _mono_font_is_sync()
+    where
+        for<'a> MonoFont<'a>: Send + Sync,
+    {
+    }
 }


### PR DESCRIPTION
- [X] Check that you've added passing tests and documentation
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [X] Run `rustfmt` on the project
- [X] Run `just build`

## PR description

Added `Sync` as a supertrait to `GlyphMapping`. This means that the `&dyn GlyphMapping` in `MonoFont` no longer causes `MonoFont` to be `!Send + !Sync`. Now, it is `Send + Sync`.

This is a semver breaking change because it imposes a new requirement on implementors of `GlyphMapping`. This should not be onerous since the mapping should generally be a stateless function.

Closes #687.