### PR TITLE
Bump MSRV to 1.61

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ commands:
 jobs:
   # Check that everything (tests, benches, etc) builds using the MSRV
   precheck-msrv:
+    resource_class: large
     docker: &docker
       - image: jamwaffles/circleci-embedded-graphics:1.61.0-0
         auth:
@@ -33,6 +34,7 @@ jobs:
 
   # Check that everything (tests, benches, etc) builds using the latest stable Rust version
   precheck-stable:
+    resource_class: large
     docker: *docker
     steps:
       - run: rustup default stable
@@ -42,6 +44,7 @@ jobs:
 
   # Check that everything (tests, benches, etc) builds using the latest Rust beta
   precheck-beta:
+    resource_class: large
     docker: *docker
     steps:
       - run: rustup default beta
@@ -51,6 +54,7 @@ jobs:
 
   # Build crates for embedded target
   all-targets:
+    resource_class: large
     docker: *docker
     steps:
       - eg_init

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
   # Check that everything (tests, benches, etc) builds using the MSRV
   precheck-msrv:
     docker: &docker
-      - image: jamwaffles/circleci-embedded-graphics:1.57.0-1
+      - image: jamwaffles/circleci-embedded-graphics:1.61.0-0
         auth:
           username: jamwaffles
           password: $DOCKERHUB_PASSWORD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 ### Changed
 
-- **(breaking)** [#638](https://github.com/embedded-graphics/embedded-graphics/pull/638) Bump Minimum Supported Rust Version (MSRV) to 1.57.
 - **(breaking)** [#660](https://github.com/embedded-graphics/embedded-graphics/pull/660) Remove `RawU18` color storage type and use `RawU24` in is place for `Rgb666` and `Bgr666`.
 - [#639](https://github.com/embedded-graphics/embedded-graphics/pull/639) Made the following functions `const`:
   - `Point::component_mul`
@@ -42,6 +41,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#651](https://github.com/embedded-graphics/embedded-graphics/pull/651), [#652](https://github.com/embedded-graphics/embedded-graphics/pull/652) Improved performance of color conversions.
 - [#662](https://github.com/embedded-graphics/embedded-graphics/pull/662) `ImageRaw::new` no longer panics if `width == 0`.
 - **(breaking)** [#663](https://github.com/embedded-graphics/embedded-graphics/pull/663) Upgraded Cargo dependencies to their latest versions.
+- **(breaking)** [#689](https://github.com/embedded-graphics/embedded-graphics/pull/689) Bump Minimum Supported Rust Version (MSRV) to 1.61.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Additional examples can be found in the [examples](https://github.com/embedded-g
 
 ## Minimum supported Rust version
 
-The minimum supported Rust version for embedded-graphics is `1.57` or greater.
+The minimum supported Rust version for embedded-graphics is `1.61` or greater.
 Ensure you have the correct version of Rust installed, preferably through <https://rustup.rs>.
 
 ## Development setup

--- a/README.tpl
+++ b/README.tpl
@@ -14,7 +14,7 @@
 
 ## Minimum supported Rust version
 
-The minimum supported Rust version for embedded-graphics is `1.57` or greater.
+The minimum supported Rust version for embedded-graphics is `1.61` or greater.
 Ensure you have the correct version of Rust installed, preferably through <https://rustup.rs>.
 
 ## Development setup

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -13,10 +13,10 @@
 
 ### Changed
 
-- **(breaking)** [#638](https://github.com/embedded-graphics/embedded-graphics/pull/638) Bump Minimum Supported Rust Version (MSRV) to 1.57.
 - **(breaking)** [#660](https://github.com/embedded-graphics/embedded-graphics/pull/660) Remove `RawU18` color storage type and use `RawU24` in is place for `Rgb666` and `Bgr666`.
 - [#651](https://github.com/embedded-graphics/embedded-graphics/pull/651), [#652](https://github.com/embedded-graphics/embedded-graphics/pull/652) Improved performance of color conversions.
 - **(breaking)** [#663](https://github.com/embedded-graphics/embedded-graphics/pull/663) Upgraded Cargo dependencies to their latest versions.
+- **(breaking)** [#689](https://github.com/embedded-graphics/embedded-graphics/pull/689) Bump Minimum Supported Rust Version (MSRV) to 1.61.
 
 ## [0.3.3] - 2021-09-09
 

--- a/core/README.md
+++ b/core/README.md
@@ -65,7 +65,7 @@ a spritemap.
 
 ## Minimum supported Rust version
 
-The minimum supported Rust version for embedded-graphics-core is `1.57` or greater.
+The minimum supported Rust version for embedded-graphics-core is `1.61` or greater.
 Ensure you have the correct version of Rust installed, preferably through <https://rustup.rs>.
 
 ## Development setup

--- a/core/README.tpl
+++ b/core/README.tpl
@@ -14,7 +14,7 @@
 
 ## Minimum supported Rust version
 
-The minimum supported Rust version for embedded-graphics-core is `1.57` or greater.
+The minimum supported Rust version for embedded-graphics-core is `1.61` or greater.
 Ensure you have the correct version of Rust installed, preferably through <https://rustup.rs>.
 
 ## Development setup

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -12,7 +12,7 @@ Target audience: crate maintainers who wish to release `embedded-graphics` or `e
 ## On your local machine
 
 - `cd` to the repository root
-- Use the crate MSRV of 1.57 by running `rustup override set 1.57`
+- Use the crate MSRV of 1.61 by running `rustup override set 1.61`
 - Check that `just` and `cargo-release` are installed and available in `$PATH`.
   - `just --version`
   - `cargo release --version`


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Closes #683 

For a speed boost, I also changed the CircleCI resource class to "large". I can't find the announcement, but I vaguely remember them moving the free tier up to "large" class from the previous medium. 
