### PR TITLE
Update u8g2-fonts description

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ this are adding support for different image formats or implementing custom fonts
 * [BMP images - `tinybmp`](https://crates.io/crates/tinybmp)
 * [TGA images - `tinytga`](https://crates.io/crates/tinytga)
 * [QOI images - `tinyqoi`](https://crates.io/crates/tinyqoi)
-* [External font renderer with large collection of fonts - `u8g2-fonts`](https://crates.io/crates/u8g2-fonts)
+* [Large collection of fonts - `u8g2-fonts`](https://crates.io/crates/u8g2-fonts)
 * [ProFont monospace font - `profont`](https://crates.io/crates/profont)
 * [Picofont Pico8 font - `embedded-picofont`](https://crates.io/crates/embedded_picofont)
 * [IBM437 font - `ibm437`](https://crates.io/crates/ibm437)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! * [BMP images - `tinybmp`](https://crates.io/crates/tinybmp)
 //! * [TGA images - `tinytga`](https://crates.io/crates/tinytga)
 //! * [QOI images - `tinyqoi`](https://crates.io/crates/tinyqoi)
-//! * [External font renderer with large collection of fonts - `u8g2-fonts`](https://crates.io/crates/u8g2-fonts)
+//! * [Large collection of fonts - `u8g2-fonts`](https://crates.io/crates/u8g2-fonts)
 //! * [ProFont monospace font - `profont`](https://crates.io/crates/profont)
 //! * [Picofont Pico8 font - `embedded-picofont`](https://crates.io/crates/embedded_picofont)
 //! * [IBM437 font - `ibm437`](https://crates.io/crates/ibm437)


### PR DESCRIPTION
u8g2-fonts just released `v0.2.0`, which integrates with `embedded_graphics::text`.

So it's no longer just an external renderer, it can also be used as a character style for the internal renderer.
