### PR TITLE
Rename ImagePixelGetter to GetPixel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 ### Added
 
 - [#592](https://github.com/embedded-graphics/embedded-graphics/pull/592) Add support for defmt behind a feature (`defmt`).
-- [#612](https://github.com/embedded-graphics/embedded-graphics/pull/612) Added `GetPixel` trait and an implementations for `ImageRaw` and `Framebuffer`.
+- [#612](https://github.com/embedded-graphics/embedded-graphics/pull/612), [#699](https://github.com/embedded-graphics/embedded-graphics/pull/699) Added `GetPixel` trait and implementations for `ImageRaw` and `Framebuffer`.
 - [#621](https://github.com/embedded-graphics/embedded-graphics/pull/621) Added `Rgb666` and `Bgr666` color type support.
 - [#641](https://github.com/embedded-graphics/embedded-graphics/pull/641) Added `Line::with_delta` constructor.
 - [#656](https://github.com/embedded-graphics/embedded-graphics/pull/656) Added `Rgb666` and `Bgr666` conversions.
@@ -20,7 +20,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - **(breaking)** [#660](https://github.com/embedded-graphics/embedded-graphics/pull/660) Remove `RawU18` color storage type and use `RawU24` in is place for `Rgb666` and `Bgr666`.
 - [#639](https://github.com/embedded-graphics/embedded-graphics/pull/639) Made the following functions `const`:
 - **(breaking)** [#690](https://github.com/embedded-graphics/embedded-graphics/pull/690) Remove `ImageRaw::new_binary` `const` helper method. `ImageRaw::new` can now be used in `const` contexts, so use it instead of `new_binary`.
-- [#639](https://github.com/embedded-graphics/embedded-graphics/pull/639) [#699](https://github.com/embedded-graphics/embedded-graphics/pull/699) Made the following functions `const`:
+- [#639](https://github.com/embedded-graphics/embedded-graphics/pull/639), [#690](https://github.com/embedded-graphics/embedded-graphics/pull/690) Made the following functions `const`:
   - `Point::component_mul`
   - `Point::component_div`
   - `Size::saturating_add`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 ### Added
 
 - [#592](https://github.com/embedded-graphics/embedded-graphics/pull/592) Add support for defmt behind a feature (`defmt`).
-- [#612](https://github.com/embedded-graphics/embedded-graphics/pull/625) Added `ImagePixelGetter` trait and an implementation for `ImageRaw`.
+- [#612](https://github.com/embedded-graphics/embedded-graphics/pull/612) Added `GetPixel` trait and an implementations for `ImageRaw` and `Framebuffer`.
 - [#621](https://github.com/embedded-graphics/embedded-graphics/pull/621) Added `Rgb666` and `Bgr666` color type support.
 - [#641](https://github.com/embedded-graphics/embedded-graphics/pull/641) Added `Line::with_delta` constructor.
 - [#656](https://github.com/embedded-graphics/embedded-graphics/pull/656) Added `Rgb666` and `Bgr666` conversions.

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Added
 
-- [#612](https://github.com/embedded-graphics/embedded-graphics/pull/612) Added `GetPixel` trait.
+- [#612](https://github.com/embedded-graphics/embedded-graphics/pull/612), [#699](https://github.com/embedded-graphics/embedded-graphics/pull/699) Added `GetPixel` trait.
 - [#625](https://github.com/embedded-graphics/embedded-graphics/pull/625) Added CSS colors and color conversions to `Rgb666` and `Bgr666`.
 - [#656](https://github.com/embedded-graphics/embedded-graphics/pull/656) Added `Rgb666` and `Bgr666` conversions.
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Added
 
-- [#612](https://github.com/embedded-graphics/embedded-graphics/pull/625) Added `ImagePixelGetter` trait.
+- [#612](https://github.com/embedded-graphics/embedded-graphics/pull/612) Added `GetPixel` trait.
 - [#625](https://github.com/embedded-graphics/embedded-graphics/pull/625) Added CSS colors and color conversions to `Rgb666` and `Bgr666`.
 - [#656](https://github.com/embedded-graphics/embedded-graphics/pull/656) Added `Rgb666` and `Bgr666` conversions.
 

--- a/core/src/image/mod.rs
+++ b/core/src/image/mod.rs
@@ -59,9 +59,12 @@ pub trait ImageDrawable: OriginDimensions {
 }
 
 /// Pixel getter.
-pub trait ImagePixelGetter: ImageDrawable {
+pub trait GetPixel {
+    /// The color type.
+    type Color: PixelColor;
+
     /// Gets the color of a pixel.
     ///
-    /// Returns `None` if `p` is outside the image bounding box.
+    /// Returns `None` if `p` is outside the bounding box.
     fn pixel(&self, p: Point) -> Option<Self::Color>;
 }

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -5,7 +5,7 @@ use core::{convert::Infallible, marker::PhantomData};
 use crate::{
     draw_target::DrawTarget,
     geometry::{OriginDimensions, Point, Size},
-    image::{ImagePixelGetter, ImageRaw},
+    image::{GetPixel, ImageRaw},
     iterator::raw::RawDataSlice,
     pixelcolor::{
         raw::{
@@ -112,12 +112,19 @@ where
     pub fn as_image(&self) -> ImageRaw<'_, C, BO> {
         ImageRaw::new(&self.data[0..Self::BUFFER_SIZE], WIDTH as u32)
     }
+}
 
-    /// Get pixel color.
-    ///
-    /// Returns `None` is `p` is outside the framebuffer bounding box.
+impl<C, BO, const WIDTH: usize, const HEIGHT: usize, const N: usize> GetPixel
+    for Framebuffer<C, C::Raw, BO, WIDTH, HEIGHT, N>
+where
+    C: PixelColor + From<C::Raw>,
+    BO: ByteOrder,
+    for<'a> RawDataSlice<'a, C::Raw, BO>: IntoIterator<Item = C::Raw>,
+{
+    type Color = C;
+
     // TODO: Optimise implementation by moving away from `ImageRaw::pixel` and directly calculating skip value.
-    pub fn pixel(&self, p: Point) -> Option<C> {
+    fn pixel(&self, p: Point) -> Option<C> {
         self.as_image().pixel(p)
     }
 }

--- a/src/image/image_raw.rs
+++ b/src/image/image_raw.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 use crate::{
     draw_target::DrawTarget,
     geometry::{Dimensions, OriginDimensions, Point, Size},
-    image::{ImageDrawable, ImagePixelGetter},
+    image::{GetPixel, ImageDrawable},
     iterator::raw::RawDataSlice,
     pixelcolor::{
         raw::{BigEndian, ByteOrder, LittleEndian, RawData},
@@ -234,12 +234,14 @@ where
     }
 }
 
-impl<'a, C, BO> ImagePixelGetter for ImageRaw<'a, C, BO>
+impl<'a, C, BO> GetPixel for ImageRaw<'a, C, BO>
 where
     C: PixelColor + From<<C as PixelColor>::Raw>,
     BO: ByteOrder,
     RawDataSlice<'a, C::Raw, BO>: IntoIterator<Item = C::Raw>,
 {
+    type Color = C;
+
     fn pixel(&self, p: Point) -> Option<Self::Color> {
         self.bounding_box().contains(p).then(|| {
             RawDataSlice::new(self.data)

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -99,7 +99,7 @@ mod image_drawable_ext;
 mod image_raw;
 mod sub_image;
 
-pub use embedded_graphics_core::image::{ImageDrawable, ImagePixelGetter};
+pub use embedded_graphics_core::image::{GetPixel, ImageDrawable};
 pub use image_drawable_ext::ImageDrawableExt;
 pub use image_raw::{ImageRaw, ImageRawBE, ImageRawLE};
 pub use sub_image::SubImage;


### PR DESCRIPTION
This PR renames the pixel getter as discussed in #696.
