### PR TITLE
Implement DrawTarget for &mut T: DrawTarget

### DIFF
--- a/benches/common.rs
+++ b/benches/common.rs
@@ -1,4 +1,4 @@
-use embedded_graphics::prelude::*;
+use embedded_graphics::{prelude::*, primitives::Rectangle};
 use std::convert::TryFrom;
 
 const SIZE: usize = 256;
@@ -54,5 +54,11 @@ where
 impl<C> OriginDimensions for Framebuffer<C> {
     fn size(&self) -> Size {
         Size::new_equal(SIZE as u32)
+    }
+}
+
+impl<C> Dimensions for Framebuffer<C> {
+    fn bounding_box(&self) -> Rectangle {
+        Rectangle::new(Point::zero(), Size::new_equal(SIZE as u32))
     }
 }

--- a/core/src/draw_target/mod.rs
+++ b/core/src/draw_target/mod.rs
@@ -423,3 +423,34 @@ pub trait DrawTarget: Dimensions {
         self.fill_solid(&self.bounding_box(), color)
     }
 }
+
+impl<T> DrawTarget for &mut T
+where
+    T: DrawTarget,
+{
+    type Color = T::Color;
+
+    type Error = T::Error;
+
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        (**self).draw_iter(pixels)
+    }
+
+    fn fill_contiguous<I>(&mut self, area: &Rectangle, colors: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Self::Color>,
+    {
+        (**self).fill_contiguous(area, colors)
+    }
+
+    fn fill_solid(&mut self, area: &Rectangle, color: Self::Color) -> Result<(), Self::Error> {
+        (**self).fill_solid(area, color)
+    }
+
+    fn clear(&mut self, color: Self::Color) -> Result<(), Self::Error> {
+        (**self).clear(color)
+    }
+}

--- a/core/src/geometry/mod.rs
+++ b/core/src/geometry/mod.rs
@@ -65,6 +65,24 @@ pub trait Dimensions {
     fn bounding_box(&self) -> Rectangle;
 }
 
+impl<D> Dimensions for &D
+where
+    D: Dimensions,
+{
+    fn bounding_box(&self) -> Rectangle {
+        (**self).bounding_box()
+    }
+}
+
+impl<D> Dimensions for &mut D
+where
+    D: Dimensions,
+{
+    fn bounding_box(&self) -> Rectangle {
+        (**self).bounding_box()
+    }
+}
+
 /// Dimensions with `top_left` of the bounding box at `(0, 0)`.
 ///
 /// A blanket implementation of `Dimensions` is provided for all types that implement this trait.
@@ -77,19 +95,37 @@ pub trait Dimensions {
 /// require a bounding box that starts at the origin and can only be used if [`OriginDimensions`] is implemented.
 ///
 /// [`ImageDrawable`]: super::image::ImageDrawable
-pub trait OriginDimensions {
+pub trait OriginDimensions: Dimensions {
     /// Returns the size of the bounding box.
     fn size(&self) -> Size;
 }
 
-impl<T> Dimensions for T
+impl<D> OriginDimensions for &D
 where
-    T: OriginDimensions,
+    D: OriginDimensions,
 {
-    fn bounding_box(&self) -> Rectangle {
-        Rectangle::new(Point::zero(), self.size())
+    fn size(&self) -> Size {
+        (**self).size()
     }
 }
+
+impl<D> OriginDimensions for &mut D
+where
+    D: OriginDimensions,
+{
+    fn size(&self) -> Size {
+        (**self).size()
+    }
+}
+
+// impl<T> Dimensions for T
+// where
+//     T: OriginDimensions,
+// {
+//     fn bounding_box(&self) -> Rectangle {
+//         Rectangle::new(Point::zero(), self.size())
+//     }
+// }
 
 /// Anchor point.
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Copy, Clone)]

--- a/core/src/image/mod.rs
+++ b/core/src/image/mod.rs
@@ -2,8 +2,9 @@
 
 use crate::{
     draw_target::DrawTarget,
-    geometry::{OriginDimensions, Point},
+    geometry::Point,
     pixelcolor::PixelColor,
+    prelude::{Dimensions, OriginDimensions},
     primitives::Rectangle,
 };
 
@@ -22,7 +23,7 @@ use crate::{
 ///
 /// [`Image`]: https://docs.rs/embedded-graphics/latest/embedded_graphics/image/struct.Image.html
 /// [`OriginDimensions`]: crate::geometry::OriginDimensions
-pub trait ImageDrawable: OriginDimensions {
+pub trait ImageDrawable: OriginDimensions + Dimensions {
     /// The color type.
     type Color: PixelColor;
 

--- a/src/draw_target/clipped.rs
+++ b/src/draw_target/clipped.rs
@@ -10,26 +10,26 @@ use crate::{
 ///
 /// [`clipped`]: crate::draw_target::DrawTargetExt::clipped
 #[derive(Debug)]
-pub struct Clipped<'a, T>
+pub struct Clipped<T>
 where
     T: DrawTarget,
 {
-    parent: &'a mut T,
+    parent: T,
     clip_area: Rectangle,
 }
 
-impl<'a, T> Clipped<'a, T>
+impl<T> Clipped<T>
 where
     T: DrawTarget,
 {
-    pub(super) fn new(parent: &'a mut T, clip_area: &Rectangle) -> Self {
+    pub(super) fn new(parent: T, clip_area: &Rectangle) -> Self {
         let clip_area = clip_area.intersection(&parent.bounding_box());
 
         Self { parent, clip_area }
     }
 }
 
-impl<T> DrawTarget for Clipped<'_, T>
+impl<T> DrawTarget for Clipped<T>
 where
     T: DrawTarget,
 {
@@ -69,7 +69,7 @@ where
     }
 }
 
-impl<T> Dimensions for Clipped<'_, T>
+impl<T> Dimensions for Clipped<T>
 where
     T: DrawTarget,
 {
@@ -95,7 +95,7 @@ mod tests {
         let mut display = MockDisplay::new();
 
         let area = Rectangle::new(Point::new(2, 1), Size::new(2, 4));
-        let mut clipped = display.clipped(&area);
+        let mut clipped = (&mut display).clipped(&area);
 
         let pixels = [
             Pixel(Point::new(0, 1), BinaryColor::On),
@@ -125,7 +125,7 @@ mod tests {
         let mut display = MockDisplay::new();
 
         let area = Rectangle::new(Point::new(3, 2), Size::new(2, 3));
-        let mut clipped = display.clipped(&area);
+        let mut clipped = (&mut display).clipped(&area);
 
         let colors = [
             1, 1, 1, 1, 1, //
@@ -152,7 +152,7 @@ mod tests {
         let mut display = MockDisplay::new();
 
         let area = Rectangle::new(Point::new(3, 2), Size::new(4, 2));
-        let mut clipped = display.clipped(&area);
+        let mut clipped = (&mut display).clipped(&area);
 
         let area = Rectangle::new(Point::new(2, 1), Size::new(6, 4));
         clipped.fill_solid(&area, BinaryColor::On).unwrap();
@@ -170,7 +170,7 @@ mod tests {
         let mut display = MockDisplay::new();
 
         let area = Rectangle::new(Point::new(1, 3), Size::new(3, 4));
-        let mut clipped = display.clipped(&area);
+        let mut clipped = (&mut display).clipped(&area);
         clipped.clear(BinaryColor::On).unwrap();
 
         let mut expected = MockDisplay::new();
@@ -183,7 +183,7 @@ mod tests {
 
     #[test]
     fn bounding_box() {
-        let mut display: MockDisplay<BinaryColor> = MockDisplay::new();
+        let display: MockDisplay<BinaryColor> = MockDisplay::new();
 
         let area = Rectangle::new(Point::new(1, 3), Size::new(2, 4));
         let clipped = display.clipped(&area);
@@ -193,7 +193,7 @@ mod tests {
 
     #[test]
     fn bounding_box_is_clipped() {
-        let mut display: MockDisplay<BinaryColor> = MockDisplay::new();
+        let display: MockDisplay<BinaryColor> = MockDisplay::new();
         let display_bb = display.bounding_box();
 
         let top_left = Point::new(10, 20);

--- a/src/draw_target/color_converted.rs
+++ b/src/draw_target/color_converted.rs
@@ -11,20 +11,20 @@ use core::marker::PhantomData;
 ///
 /// [`color_converted`]: crate::draw_target::DrawTargetExt::color_converted
 #[derive(Debug)]
-pub struct ColorConverted<'a, T, C> {
+pub struct ColorConverted<T, C> {
     /// The parent draw target.
-    parent: &'a mut T,
+    parent: T,
 
     /// The input color type.
     color_type: PhantomData<C>,
 }
 
-impl<'a, T, C> ColorConverted<'a, T, C>
+impl<T, C> ColorConverted<T, C>
 where
     T: DrawTarget,
     C: PixelColor + Into<T::Color>,
 {
-    pub(super) fn new(parent: &'a mut T) -> Self {
+    pub(super) fn new(parent: T) -> Self {
         Self {
             parent,
             color_type: PhantomData,
@@ -32,7 +32,7 @@ where
     }
 }
 
-impl<T, C> DrawTarget for ColorConverted<'_, T, C>
+impl<T, C> DrawTarget for ColorConverted<T, C>
 where
     T: DrawTarget,
     C: PixelColor + Into<T::Color>,
@@ -65,7 +65,7 @@ where
     }
 }
 
-impl<T, C> Dimensions for ColorConverted<'_, T, C>
+impl<T, C> Dimensions for ColorConverted<T, C>
 where
     T: DrawTarget,
 {

--- a/src/draw_target/mod.rs
+++ b/src/draw_target/mod.rs
@@ -33,7 +33,7 @@ pub trait DrawTargetExt: DrawTarget + Sized {
     /// };
     ///
     /// let mut display = MockDisplay::new();
-    /// let mut translated_display = display.translated(Point::new(5, 10));
+    /// let mut translated_display = (&mut display).translated(Point::new(5, 10));
     ///
     /// let style = MonoTextStyle::new(&FONT_6X9, BinaryColor::On);
     ///
@@ -48,7 +48,7 @@ pub trait DrawTargetExt: DrawTarget + Sized {
     /// #
     /// # Ok::<(), core::convert::Infallible>(())
     /// ```
-    fn translated(&mut self, offset: Point) -> Translated<'_, Self>;
+    fn translated(self, offset: Point) -> Translated<Self>;
 
     /// Creates a cropped draw target based on this draw target.
     ///
@@ -104,7 +104,7 @@ pub trait DrawTargetExt: DrawTarget + Sized {
     /// #
     /// # Ok::<(), core::convert::Infallible>(())
     /// ```
-    fn cropped(&mut self, area: &Rectangle) -> Cropped<'_, Self>;
+    fn cropped(self, area: &Rectangle) -> Cropped<Self>;
 
     /// Creates a clipped draw target based on this draw target.
     ///
@@ -131,7 +131,7 @@ pub trait DrawTargetExt: DrawTarget + Sized {
     /// let mut display = MockDisplay::new();
     ///
     /// let area = Rectangle::new(Point::zero(), Size::new(4 * 10, 20));
-    /// let mut clipped_display = display.clipped(&area);
+    /// let mut clipped_display = (&mut display).clipped(&area);
     ///
     /// let style = MonoTextStyle::new(&FONT_10X20, BinaryColor::On);
     ///
@@ -147,7 +147,7 @@ pub trait DrawTargetExt: DrawTarget + Sized {
     /// #
     /// # Ok::<(), core::convert::Infallible>(())
     /// ```
-    fn clipped(&mut self, area: &Rectangle) -> Clipped<'_, Self>;
+    fn clipped(self, area: &Rectangle) -> Clipped<Self>;
 
     /// Creates a color conversion draw target.
     ///
@@ -194,7 +194,7 @@ pub trait DrawTargetExt: DrawTarget + Sized {
     /// // image.draw(&mut display)?;
     ///
     /// // To fix this `color_converted` is added to enable color conversion.
-    /// image.draw(&mut display.color_converted())?;
+    /// image.draw(&mut (&mut display).color_converted())?;
     /// #
     /// # let mut expected = MockDisplay::from_pattern(&[
     /// #     "WWWW", //
@@ -207,7 +207,7 @@ pub trait DrawTargetExt: DrawTarget + Sized {
     /// #
     /// # Ok::<(), core::convert::Infallible>(())
     /// ```
-    fn color_converted<C>(&mut self) -> ColorConverted<'_, Self, C>
+    fn color_converted<C>(self) -> ColorConverted<Self, C>
     where
         C: PixelColor + Into<Self::Color>;
 }
@@ -216,19 +216,19 @@ impl<T> DrawTargetExt for T
 where
     T: DrawTarget,
 {
-    fn translated(&mut self, offset: Point) -> Translated<'_, Self> {
+    fn translated(self, offset: Point) -> Translated<Self> {
         Translated::new(self, offset)
     }
 
-    fn cropped(&mut self, area: &Rectangle) -> Cropped<'_, Self> {
+    fn cropped(self, area: &Rectangle) -> Cropped<Self> {
         Cropped::new(self, area)
     }
 
-    fn clipped(&mut self, area: &Rectangle) -> Clipped<'_, Self> {
+    fn clipped(self, area: &Rectangle) -> Clipped<Self> {
         Clipped::new(self, area)
     }
 
-    fn color_converted<C>(&mut self) -> ColorConverted<'_, Self, C>
+    fn color_converted<C>(self) -> ColorConverted<Self, C>
     where
         C: PixelColor + Into<Self::Color>,
     {
@@ -252,7 +252,7 @@ mod tests {
         let mut display = MockDisplay::new();
 
         let area = Rectangle::new(Point::new(2, 1), Size::new(2, 4));
-        let mut clipped = display.clipped(&area);
+        let mut clipped = (&mut display).clipped(&area);
 
         let pixels = [
             Pixel(Point::new(0, 1), BinaryColor::On),
@@ -282,7 +282,7 @@ mod tests {
         let mut display = MockDisplay::new();
 
         let area = Rectangle::new(Point::new(3, 2), Size::new(2, 3));
-        let mut clipped = display.clipped(&area);
+        let mut clipped = (&mut display).clipped(&area);
 
         let colors = [
             1, 1, 1, 1, 1, //
@@ -309,7 +309,7 @@ mod tests {
         let mut display = MockDisplay::new();
 
         let area = Rectangle::new(Point::new(3, 2), Size::new(4, 2));
-        let mut clipped = display.clipped(&area);
+        let mut clipped = (&mut display).clipped(&area);
 
         let area = Rectangle::new(Point::new(2, 1), Size::new(6, 4));
         clipped.fill_solid(&area, BinaryColor::On).unwrap();
@@ -327,7 +327,7 @@ mod tests {
         let mut display = MockDisplay::new();
 
         let area = Rectangle::new(Point::new(1, 3), Size::new(3, 4));
-        let mut clipped = display.clipped(&area);
+        let mut clipped = (&mut display).clipped(&area);
         clipped.clear(BinaryColor::On).unwrap();
 
         let mut expected = MockDisplay::new();
@@ -340,7 +340,7 @@ mod tests {
 
     #[test]
     fn bounding_box() {
-        let mut display: MockDisplay<BinaryColor> = MockDisplay::new();
+        let display: MockDisplay<BinaryColor> = MockDisplay::new();
 
         let area = Rectangle::new(Point::new(1, 3), Size::new(2, 4));
         let clipped = display.clipped(&area);
@@ -350,7 +350,7 @@ mod tests {
 
     #[test]
     fn bounding_box_is_clipped() {
-        let mut display: MockDisplay<BinaryColor> = MockDisplay::new();
+        let display: MockDisplay<BinaryColor> = MockDisplay::new();
         let display_bb = display.bounding_box();
 
         let top_left = Point::new(10, 20);

--- a/src/draw_target/translated.rs
+++ b/src/draw_target/translated.rs
@@ -15,24 +15,24 @@ use crate::{
 /// [`translated`]: crate::draw_target::DrawTargetExt::translated
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(::defmt::Format))]
-pub struct Translated<'a, T>
+pub struct Translated<T>
 where
     T: DrawTarget,
 {
-    parent: &'a mut T,
+    parent: T,
     offset: Point,
 }
 
-impl<'a, T> Translated<'a, T>
+impl<T> Translated<T>
 where
     T: DrawTarget,
 {
-    pub(super) fn new(parent: &'a mut T, offset: Point) -> Self {
+    pub(super) fn new(parent: T, offset: Point) -> Self {
         Self { parent, offset }
     }
 }
 
-impl<T> DrawTarget for Translated<'_, T>
+impl<T> DrawTarget for Translated<T>
 where
     T: DrawTarget,
 {
@@ -65,7 +65,7 @@ where
     }
 }
 
-impl<T> Dimensions for Translated<'_, T>
+impl<T> Dimensions for Translated<T>
 where
     T: DrawTarget,
 {
@@ -91,7 +91,7 @@ mod tests {
     fn draw_iter() {
         let mut display = MockDisplay::new();
 
-        let mut translated = display.translated(Point::new(2, 3));
+        let mut translated = (&mut display).translated(Point::new(2, 3));
 
         let pixels = [
             Pixel(Point::new(0, 0), BinaryColor::On),
@@ -113,7 +113,7 @@ mod tests {
     fn fill_contiguous() {
         let mut display = MockDisplay::new();
 
-        let mut translated = display.translated(Point::new(3, 2));
+        let mut translated = (&mut display).translated(Point::new(3, 2));
 
         let colors = [
             1, 1, 1, 1, 1, //
@@ -142,7 +142,7 @@ mod tests {
     fn fill_solid() {
         let mut display = MockDisplay::new();
 
-        let mut translated = display.translated(Point::new(1, 3));
+        let mut translated = (&mut display).translated(Point::new(1, 3));
 
         let area = Rectangle::new(Point::new(2, 1), Size::new(3, 4));
         translated.fill_solid(&area, BinaryColor::On).unwrap();
@@ -162,7 +162,7 @@ mod tests {
     #[test]
     fn clear() {
         let mut display = MockDisplay::new();
-        let mut translated = display.translated(Point::new(1, 3));
+        let mut translated = (&mut display).translated(Point::new(1, 3));
         translated.clear(BinaryColor::On).unwrap();
 
         let mut expected = MockDisplay::new();
@@ -173,7 +173,7 @@ mod tests {
 
     #[test]
     fn bounding_box() {
-        let mut display: MockDisplay<BinaryColor> = MockDisplay::new();
+        let display: MockDisplay<BinaryColor> = MockDisplay::new();
         let display_bb = display.bounding_box();
 
         let translated = display.translated(Point::new(1, 3));

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -2,9 +2,14 @@
 
 use core::{convert::Infallible, marker::PhantomData};
 
+use embedded_graphics_core::{
+    prelude::{Dimensions, OriginDimensions},
+    primitives::Rectangle,
+};
+
 use crate::{
     draw_target::DrawTarget,
-    geometry::{OriginDimensions, Point, Size},
+    geometry::{Point, Size},
     image::{GetPixel, ImageRaw},
     iterator::raw::RawDataSlice,
     pixelcolor::{
@@ -286,6 +291,14 @@ impl<C, R, BO, const WIDTH: usize, const HEIGHT: usize, const N: usize> OriginDi
 {
     fn size(&self) -> Size {
         Size::new(WIDTH as u32, HEIGHT as u32)
+    }
+}
+
+impl<C, R, BO, const WIDTH: usize, const HEIGHT: usize, const N: usize> Dimensions
+    for Framebuffer<C, R, BO, WIDTH, HEIGHT, N>
+{
+    fn bounding_box(&self) -> Rectangle {
+        Rectangle::new(Point::zero(), Size::new(WIDTH as _, HEIGHT as _))
     }
 }
 

--- a/src/image/image_raw.rs
+++ b/src/image/image_raw.rs
@@ -234,6 +234,16 @@ where
     }
 }
 
+impl<C, BO> Dimensions for ImageRaw<'_, C, BO>
+where
+    C: PixelColor + From<<C as PixelColor>::Raw>,
+    BO: ByteOrder,
+{
+    fn bounding_box(&self) -> Rectangle {
+        Rectangle::new(Point::zero(), self.size)
+    }
+}
+
 impl<'a, C, BO> GetPixel for ImageRaw<'a, C, BO>
 where
     C: PixelColor + From<<C as PixelColor>::Raw>,

--- a/src/image/sub_image.rs
+++ b/src/image/sub_image.rs
@@ -1,3 +1,5 @@
+use embedded_graphics_core::prelude::Point;
+
 use crate::{
     draw_target::DrawTarget,
     geometry::{Dimensions, OriginDimensions},
@@ -41,6 +43,12 @@ where
 impl<T> OriginDimensions for SubImage<'_, T> {
     fn size(&self) -> crate::prelude::Size {
         self.area.size
+    }
+}
+
+impl<T> Dimensions for SubImage<'_, T> {
+    fn bounding_box(&self) -> Rectangle {
+        Rectangle::new(Point::zero(), self.area.size)
     }
 }
 
@@ -104,6 +112,12 @@ mod tests {
     impl OriginDimensions for MockImageDrawable {
         fn size(&self) -> Size {
             Size::new(8, 10)
+        }
+    }
+
+    impl Dimensions for MockImageDrawable {
+        fn bounding_box(&self) -> Rectangle {
+            Rectangle::new(Point::zero(), Size::new(8, 10))
         }
     }
 

--- a/src/mock_display/mod.rs
+++ b/src/mock_display/mod.rs
@@ -727,6 +727,15 @@ where
     }
 }
 
+impl<C> Dimensions for MockDisplay<C>
+where
+    C: PixelColor,
+{
+    fn bounding_box(&self) -> Rectangle {
+        Rectangle::new(Point::zero(), DISPLAY_AREA.size)
+    }
+}
+
 /// Wrapper to implement `Display` for formatting function.
 struct MessageWrapper<F>(F);
 

--- a/src/primitives/arc/styled.rs
+++ b/src/primitives/arc/styled.rs
@@ -156,7 +156,9 @@ mod tests {
 
                 // Draw expected display by clipping the circle to the quadrant.
                 let mut expected = MockDisplay::new();
-                circle.draw(&mut expected.clipped(&clip_rect)).unwrap();
+                circle
+                    .draw(&mut (&mut expected).clipped(&clip_rect))
+                    .unwrap();
 
                 // Draw the arc.
                 let mut display = MockDisplay::new();

--- a/tests/chaining.rs
+++ b/tests/chaining.rs
@@ -38,6 +38,12 @@ impl OriginDimensions for FakeDisplay {
     }
 }
 
+impl Dimensions for FakeDisplay {
+    fn bounding_box(&self) -> Rectangle {
+        Rectangle::new(Point::zero(), Size::zero())
+    }
+}
+
 #[test]
 fn it_supports_chaining() -> Result<(), core::convert::Infallible> {
     let mut display = FakeDisplay {};


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Is there any reason why `DrawTarget` is not implemented for `&mut T where T: DrawTarget`?
The major inconvenience of the above is that `Clipped`, `Translated`, `Cropped` and - overall - the `DrawTargetExt` decorator decorates **only** `&mut DrawTarget` references, and not generic `DrawTarget` instances where these can be either moved or passed by a mutable reference.

As a result, I cannot fulfill the simple use case of creating a display driver, then decorating it and finally **moving it** into a generic drawing code that needs to own the display. Passing the display to the drawing code by `&mut` reference is simply not an option for a variety of reasons.

Here's a concrete use case:
- Creating a Display driver  
- Decorating it - say - using `Cropped` - as the display is weird and does not start at (0, 0), nor does it report correct `Dimensions` bounding box
- Decorating it - say - using `ColorConverted` so that my drawing code always use a fixed, custom `Color` color and is thus display color independent

Sure, implementing `&mut T where T: DrawTarget` also means implementing `& mut T` and `&T` for `Dimensions` and `OriginDimensions`, but that's OK. What is not so ideal is that once these are implemented, the implementation of `Dimensions` for `T: OriginDimensions` conflicts and should be removed, but the question is what is the better compromise:
- Option 1: (What I suggest) - implement `DrawTarget` for `&mut T` (similarly to the traits in `embedded-hal` and the `Read` / `Write` traits in STD and allow the user to decorate `DrawTarget` instances by move or by `&mut` reference
- Option 2: Stay with the status quo, where `Dimensions` is auto-implemented for types implementing `OriginDimensions`, but then `DrawTarget` decoration capabilities of the library are severely limited


With Option 1, there is the extra benefit, that `Drawable` no longer needs to take `&mut DrawTarget` and can just switch to plain `DrawTarget`.