### PR TITLE
Add Image::with_center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#641](https://github.com/embedded-graphics/embedded-graphics/pull/641) Added `Line::with_delta` constructor.
 - [#656](https://github.com/embedded-graphics/embedded-graphics/pull/656) Added `Rgb666` and `Bgr666` conversions.
 - [#673](https://github.com/embedded-graphics/embedded-graphics/pull/673) Added `Framebuffer`.
+- [#709](https://github.com/embedded-graphics/embedded-graphics/pull/709) Added `Image::with_center`.
 
 ### Changed
 

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -144,6 +144,16 @@ where
             offset: position,
         }
     }
+
+    /// Creates a new `Image` centered around a given point.
+    pub fn with_center(image_drawable: &'a T, center: Point) -> Self {
+        let offset = Rectangle::with_center(center, image_drawable.size()).top_left;
+
+        Self {
+            image_drawable,
+            offset,
+        }
+    }
 }
 
 impl<T> Transform for Image<'_, T> {
@@ -282,6 +292,24 @@ mod tests {
             " .#.#", //
             " #.#.", //
             " .#.#", //
+        ]);
+    }
+
+    #[test]
+    fn with_center() {
+        let image_raw: ImageRaw<BinaryColor> = ImageRaw::new(&[0xAA, 0x55, 0xAA, 0x55], 4);
+
+        let mut display = MockDisplay::new();
+        Image::with_center(&image_raw, Point::new(1, 2))
+            .draw(&mut display)
+            .unwrap();
+
+        display.assert_pattern(&[
+            "    ", //
+            "#.#.", //
+            ".#.#", //
+            "#.#.", //
+            ".#.#", //
         ]);
     }
 }


### PR DESCRIPTION
This PR adds `Image::with_center` to position images centered around a given point.
