### PR TITLE
Fix possible panic in MonoFont

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 ### Fixed
 
 - [#648](https://github.com/embedded-graphics/embedded-graphics/pull/648) Fixed incorrect text bounding box calculation when multi-byte characters are used.
+- [#713](https://github.com/embedded-graphics/embedded-graphics/pull/713) Fixed possible panic when drawing an invalid `MonoFont`.
 
 ## [0.7.1] - 2021-06-15
 


### PR DESCRIPTION
This PR fixes a possible panic if an invalid `MonoFont` struct is used.
