### PR TITLE
adds Rgb444

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- [#732](https://github.com/embedded-graphics/embedded-graphics/pull/732) Added `Rgb444` to support 12bit RGB displays. Note that this type is currently stored as a 16 bit value in `ImageRaw`s and `Framebuffer`s.
+
 ### Added
 
 - [#733](https://github.com/embedded-graphics/embedded-graphics/pull/733) Added `envelope` method to `Rectangle`.

--- a/core/src/pixelcolor/conversion.rs
+++ b/core/src/pixelcolor/conversion.rs
@@ -54,14 +54,15 @@ macro_rules! impl_rgb_conversion {
     };
 }
 
-impl_rgb_conversion!(Rgb555 => Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
-impl_rgb_conversion!(Bgr555 => Rgb555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
-impl_rgb_conversion!(Rgb565 => Rgb555, Bgr555, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
-impl_rgb_conversion!(Bgr565 => Rgb555, Bgr555, Rgb565, Rgb666, Bgr666, Rgb888, Bgr888);
-impl_rgb_conversion!(Rgb666 => Rgb555, Bgr555, Rgb565, Bgr666, Bgr565, Bgr888, Rgb888);
-impl_rgb_conversion!(Bgr666 => Rgb555, Bgr555, Rgb565, Rgb666, Bgr565, Bgr888, Rgb888);
-impl_rgb_conversion!(Rgb888 => Rgb555, Bgr555, Rgb565, Rgb666, Bgr666, Bgr565, Bgr888);
-impl_rgb_conversion!(Bgr888 => Rgb555, Bgr555, Rgb565, Rgb666, Bgr666, Bgr565, Rgb888);
+impl_rgb_conversion!(Rgb444 => Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
+impl_rgb_conversion!(Rgb555 => Rgb444, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
+impl_rgb_conversion!(Bgr555 => Rgb444, Rgb555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
+impl_rgb_conversion!(Rgb565 => Rgb444, Rgb555, Bgr555, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
+impl_rgb_conversion!(Bgr565 => Rgb444, Rgb555, Bgr555, Rgb565, Rgb666, Bgr666, Rgb888, Bgr888);
+impl_rgb_conversion!(Rgb666 => Rgb444, Rgb555, Bgr555, Rgb565, Bgr666, Bgr565, Bgr888, Rgb888);
+impl_rgb_conversion!(Bgr666 => Rgb444, Rgb555, Bgr555, Rgb565, Rgb666, Bgr565, Bgr888, Rgb888);
+impl_rgb_conversion!(Rgb888 => Rgb444, Rgb555, Bgr555, Rgb565, Rgb666, Bgr666, Bgr565, Bgr888);
+impl_rgb_conversion!(Bgr888 => Rgb444, Rgb555, Bgr555, Rgb565, Rgb666, Bgr666, Bgr565, Rgb888);
 
 /// Macro to implement conversion between grayscale color types.
 macro_rules! impl_gray_conversion {
@@ -105,7 +106,7 @@ macro_rules! impl_rgb_to_and_from_gray {
     }
 }
 
-impl_rgb_to_and_from_gray!(Gray2, Gray4, Gray8 => Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
+impl_rgb_to_and_from_gray!(Gray2, Gray4, Gray8 => Rgb444, Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
 
 /// Macro to implement conversion from `BinaryColor` to RGB and grayscale types.
 macro_rules! impl_from_binary {
@@ -119,7 +120,7 @@ macro_rules! impl_from_binary {
 }
 
 impl_from_binary!(
-    Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888, Gray2, Gray4, Gray8
+    Rgb444, Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888, Gray2, Gray4, Gray8
 );
 
 /// Macro to implement conversion from grayscale types to `BinaryColor`.
@@ -146,13 +147,40 @@ macro_rules! impl_rgb_to_binary {
     };
 }
 
-impl_rgb_to_binary!(Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
+impl_rgb_to_binary!(Rgb444, Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
 
 #[cfg(test)]
 mod tests {
     use core::fmt::Debug;
 
     use super::*;
+
+    #[test]
+    fn convert_rgb444_to_rgb888_and_back() {
+        for r in 0..=Rgb444::MAX_R {
+            let c = Rgb444::new(r, 0, 0);
+            let c2 = Rgb888::from(c);
+            let c3 = Rgb444::from(c2);
+
+            assert_eq!(c, c3);
+        }
+
+        for g in 0..=Rgb444::MAX_G {
+            let c = Rgb444::new(0, g, 0);
+            let c2 = Rgb888::from(c);
+            let c3 = Rgb444::from(c2);
+
+            assert_eq!(c, c3);
+        }
+
+        for b in 0..=Rgb444::MAX_B {
+            let c = Rgb444::new(0, 0, b);
+            let c2 = Rgb888::from(c);
+            let c3 = Rgb444::from(c2);
+
+            assert_eq!(c, c3);
+        }
+    }
 
     #[test]
     fn convert_rgb565_to_rgb888_and_back() {
@@ -217,7 +245,7 @@ mod tests {
             assert_eq!(ToC::from(FromC::WHITE), ToC::WHITE);
         }
 
-        type_matrix!(test_rgb_to_rgb; Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
+        type_matrix!(test_rgb_to_rgb; Rgb444, Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
     }
 
     #[test]
@@ -227,7 +255,7 @@ mod tests {
             assert_eq!(ToC::from(FromC::WHITE), ToC::WHITE);
         }
 
-        type_matrix!(test_rgb_to_gray; Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888 => Gray2, Gray4, Gray8);
+        type_matrix!(test_rgb_to_gray; Rgb444, Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888 => Gray2, Gray4, Gray8);
     }
 
     #[test]
@@ -240,7 +268,7 @@ mod tests {
             assert_eq!(BinaryColor::from(FromC::WHITE), BinaryColor::On);
         }
 
-        type_matrix!(test_rgb_to_binary; Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888 => BinaryColor);
+        type_matrix!(test_rgb_to_binary; Rgb444, Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888 => BinaryColor);
     }
 
     #[test]
@@ -260,7 +288,7 @@ mod tests {
             assert_eq!(ToC::from(FromC::WHITE), ToC::WHITE);
         }
 
-        type_matrix!(test_gray_to_rgb; Gray2, Gray4, Gray8 => Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
+        type_matrix!(test_gray_to_rgb; Gray2, Gray4, Gray8 => Rgb444, Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
     }
 
     #[test]
@@ -283,7 +311,7 @@ mod tests {
             assert_eq!(ToC::from(BinaryColor::On), ToC::WHITE);
         }
 
-        type_matrix!(test_binary_to_rgb; BinaryColor => Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
+        type_matrix!(test_binary_to_rgb; BinaryColor => Rgb444, Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
     }
 
     #[test]

--- a/core/src/pixelcolor/raw/to_bytes.rs
+++ b/core/src/pixelcolor/raw/to_bytes.rs
@@ -116,7 +116,7 @@ where
 mod tests {
     use super::*;
     use crate::pixelcolor::{
-        Bgr565, Bgr666, Bgr888, BinaryColor, Gray2, Gray4, Gray8, Rgb565, Rgb666, Rgb888,
+        Bgr565, Bgr666, Bgr888, BinaryColor, Gray2, Gray4, Gray8, Rgb444, Rgb565, Rgb666, Rgb888,
     };
 
     fn assert_all_orders<T>(value: T, bytes: T::Bytes)

--- a/core/src/pixelcolor/rgb_color.rs
+++ b/core/src/pixelcolor/rgb_color.rs
@@ -227,6 +227,8 @@ macro_rules! rgb_color {
     };
 }
 
+rgb_color!(Rgb444, RawU16, u16, Rgb = (4, 4, 4));
+
 rgb_color!(Rgb555, RawU16, u16, Rgb = (5, 5, 5));
 rgb_color!(Bgr555, RawU16, u16, Bgr = (5, 5, 5));
 rgb_color!(Rgb565, RawU16, u16, Rgb = (5, 6, 5));
@@ -262,6 +264,13 @@ mod tests {
 
         assert_eq!(color.into(), value);
         assert_eq!(C::from(value), color);
+    }
+
+    #[test]
+    pub fn bit_positions_rgb444() {
+        test_bpp16(Rgb444::new(0b1001, 0, 0), 0b1001 << 4 + 4);
+        test_bpp16(Rgb444::new(0, 0b1001, 0), 0b1001 << 4);
+        test_bpp16(Rgb444::new(0, 0, 0b1001), 0b1001 << 0);
     }
 
     #[test]
@@ -322,6 +331,9 @@ mod tests {
 
     #[test]
     pub fn unused_bits_are_ignored() {
+        let color: Rgb444 = RawU16::from(0xFFFF).into();
+        assert_eq!(RawU16::from(color).into_inner(), 0xFFF);
+
         let color: Rgb555 = RawU16::from(0xFFFF).into();
         assert_eq!(RawU16::from(color).into_inner(), 0x7FFF);
 

--- a/src/mock_display/color_mapping.rs
+++ b/src/mock_display/color_mapping.rs
@@ -1,6 +1,6 @@
 use embedded_graphics_core::pixelcolor::{
-    Bgr555, Bgr565, Bgr888, BinaryColor, Gray2, Gray4, Gray8, GrayColor, Rgb555, Rgb565, Rgb888,
-    RgbColor, WebColors,
+    Bgr555, Bgr565, Bgr888, BinaryColor, Gray2, Gray4, Gray8, GrayColor, Rgb444, Rgb555, Rgb565,
+    Rgb888, RgbColor, WebColors,
 };
 
 /// Mapping between `char`s and colors.
@@ -122,6 +122,7 @@ macro_rules! impl_rgb_color_mapping {
     };
 }
 
+impl_rgb_color_mapping!(Rgb444);
 impl_rgb_color_mapping!(Rgb555);
 impl_rgb_color_mapping!(Bgr555);
 impl_rgb_color_mapping!(Rgb565);


### PR DESCRIPTION
This PR adds Rgb444 and RawU12 to support 12bit RGB on displays like the ST7789.

This fixes 1/2 of https://github.com/embedded-graphics/embedded-graphics/issues/726 (missing BGR444).