### PR TITLE
Add envelope() method to Rectangle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- [#733](https://github.com/embedded-graphics/embedded-graphics/pull/733) Add envelope() method to `Rectangle`
+
 ## [0.8.1] - 2023-08-10
 
 ### Changed

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - (technically breaking) [#731](https://github.com/embedded-graphics/embedded-graphics/pull/731) Bump MSRV to 1.71.1
+- [#733](https://github.com/embedded-graphics/embedded-graphics/pull/733) Add envelope() method to `Rectangle`
 
 ## [0.4.0] - 2023-05-14
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Changed
 
 - (technically breaking) [#731](https://github.com/embedded-graphics/embedded-graphics/pull/731) Bump MSRV to 1.71.1
+
+### Added
 - [#733](https://github.com/embedded-graphics/embedded-graphics/pull/733) Add envelope() method to `Rectangle`
 
 ## [0.4.0] - 2023-05-14

--- a/core/src/primitives/rectangle/mod.rs
+++ b/core/src/primitives/rectangle/mod.rs
@@ -248,8 +248,9 @@ impl Rectangle {
 
     /// Returns the minimum sized `Rectangle` that envelopes both `self` and `other`.
     ///
-    /// For the purpose of this method, zero-sized [`Rectangle`]s will be treated
-    /// equivelant to 1x1 [`Rectangle`]s. This is done so that the [`Rectangle`] is
+    /// For the purpose of this method, [`Rectangle`]s will be treated as having a minimum
+    /// size of `1` along any specific axis. For example, an zero sized [`Rectangle`] will
+    /// be treated equivalent to 1x1 [`Rectangle`]. This is done so that the [`Rectangle`] is
     /// represented within the resulting bounding box, even if its [`Size`] would not
     /// result in it being drawn.
     ///

--- a/core/src/primitives/rectangle/mod.rs
+++ b/core/src/primitives/rectangle/mod.rs
@@ -246,6 +246,64 @@ impl Rectangle {
         Rectangle::zero()
     }
 
+    /// Returns the minimum sized `Rectangle` that envelopes both `self` and `other`.
+    ///
+    /// # Examples
+    ///
+    /// ## Envelope
+    ///
+    /// This example draws two rectangles to a mock display using the `.` character, along with
+    /// their enveloping rectangle shown with `#` characters.
+    ///
+    /// ```rust
+    /// use embedded_graphics::{
+    ///     mock_display::MockDisplay, pixelcolor::BinaryColor, prelude::*,
+    ///     primitives::{Rectangle, PrimitiveStyle},
+    /// };
+    ///
+    /// let mut display = MockDisplay::new();
+    /// # display.set_allow_overdraw(true);
+    ///
+    /// let rect1 = Rectangle::new(Point::zero(), Size::new(7, 8));
+    /// let rect2 = Rectangle::new(Point::new(2, 3), Size::new(10, 7));
+    ///
+    /// let envelope = rect1.envelope(&rect2);
+    ///
+    /// rect1
+    ///     .into_styled(PrimitiveStyle::with_stroke(BinaryColor::Off, 1))
+    ///     .draw(&mut display)?;
+    ///
+    /// rect2
+    ///     .into_styled(PrimitiveStyle::with_stroke(BinaryColor::Off, 1))
+    ///     .draw(&mut display)?;
+    ///
+    /// envelope
+    ///     .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
+    ///     .draw(&mut display)?;
+    ///
+    /// display.assert_pattern(&[
+    ///     "############",
+    ///     "#     .    #",
+    ///     "#     .    #",
+    ///     "# .........#",
+    ///     "# .   .    #",
+    ///     "# .   .    #",
+    ///     "# .   .    #",
+    ///     "#......    #",
+    ///     "# .        #",
+    ///     "############",
+    /// ]);
+    /// # Ok::<(), core::convert::Infallible>(())
+    /// ```
+    pub fn envelope(&self, other: &Rectangle) -> Rectangle {
+        let top_left = self.top_left.component_min(other.top_left);
+        let bottom_right = self
+            .anchor_point(AnchorPoint::BottomRight)
+            .component_max(other.anchor_point(AnchorPoint::BottomRight));
+
+        Rectangle::with_corners(top_left, bottom_right)
+    }
+
     /// Returns a resized copy of this rectangle.
     ///
     /// The rectangle is resized relative to the given anchor point.
@@ -585,6 +643,36 @@ mod tests {
 
         let even = Rectangle::new(Point::new(20, 30), Size::new(4, 8));
         assert_eq!(even.bottom_right(), Some(Point::new(23, 37)));
+    }
+
+    #[test]
+    fn rectangle_envelope() {
+        let rect1 = Rectangle::new(Point::new_equal(10), Size::new(20, 30));
+        let rect2 = Rectangle::new(Point::new_equal(20), Size::new(30, 40));
+
+        assert_eq!(
+            rect1.envelope(&rect2),
+            Rectangle::new(Point::new_equal(10), Size::new(40, 50))
+        );
+    }
+
+    #[test]
+    fn rectangle_no_envelope() {
+        let rect1 = Rectangle::new(Point::new_equal(10), Size::new(10, 10));
+        let rect2 = Rectangle::new(Point::new_equal(30), Size::new(10, 10));
+
+        assert_eq!(
+            rect1.envelope(&rect2),
+            Rectangle::new(Point::new_equal(10), Size::new(30, 30))
+        );
+    }
+
+    #[test]
+    fn rectangle_fully_envelope() {
+        let rect1 = Rectangle::new(Point::new_equal(10), Size::new(30, 30));
+        let rect2 = Rectangle::new(Point::new_equal(20), Size::new(10, 10));
+
+        assert_eq!(rect1.envelope(&rect2), rect1);
     }
 
     #[test]

--- a/core/src/primitives/rectangle/mod.rs
+++ b/core/src/primitives/rectangle/mod.rs
@@ -671,6 +671,26 @@ mod tests {
     }
 
     #[test]
+    fn rectangle_envelope_with_zero_along_axis() {
+        let rect1 = Rectangle::new(Point::new_equal(2), Size::new(5, 0));
+        let rect2 = Rectangle::new(Point::new_equal(3), Size::new(0, 6));
+
+        assert_eq!(
+            rect1.envelope(&rect2),
+            Rectangle::new(Point::new_equal(2), Size::new(5, 7))
+        );
+    }
+
+    #[test]
+    fn rectangle_envelope_zero_size_treated_as_one() {
+        let zero_sized = Rectangle::new(Point::new_equal(2), Size::zero());
+        assert_eq!(
+            zero_sized.envelope(&zero_sized),
+            Rectangle::new(Point::new_equal(2), Size::new_equal(1))
+        )
+    }
+
+    #[test]
     fn rectangle_envelope_all_zero_size() {
         let rect1 = Rectangle::new(Point::new_equal(2), Size::zero());
         let rect2 = Rectangle::new(Point::new_equal(11), Size::zero());

--- a/core/src/primitives/rectangle/mod.rs
+++ b/core/src/primitives/rectangle/mod.rs
@@ -248,9 +248,12 @@ impl Rectangle {
 
     /// Returns the minimum sized `Rectangle` that envelopes both `self` and `other`.
     ///
-    /// # Examples
+    /// For the purpose of this method, zero-sized [`Rectangle`]s will be treated
+    /// equivelant to 1x1 [`Rectangle`]s. This is done so that the [`Rectangle`] is
+    /// represented within the resulting bounding box, even if its [`Size`] would not
+    /// result in it being drawn.
     ///
-    /// ## Envelope
+    /// # Examples
     ///
     /// This example draws two rectangles to a mock display using the `.` character, along with
     /// their enveloping rectangle shown with `#` characters.
@@ -653,6 +656,28 @@ mod tests {
         assert_eq!(
             rect1.envelope(&rect2),
             Rectangle::new(Point::new_equal(10), Size::new(40, 50))
+        );
+    }
+
+    #[test]
+    fn rectangle_envelope_with_zero_size() {
+        let rect1 = Rectangle::new(Point::new_equal(2), Size::new(5, 5));
+        let rect2 = Rectangle::new(Point::new_equal(11), Size::zero());
+
+        assert_eq!(
+            rect1.envelope(&rect2),
+            Rectangle::new(Point::new_equal(2), Size::new_equal(10))
+        );
+    }
+
+    #[test]
+    fn rectangle_envelope_all_zero_size() {
+        let rect1 = Rectangle::new(Point::new_equal(2), Size::zero());
+        let rect2 = Rectangle::new(Point::new_equal(11), Size::zero());
+
+        assert_eq!(
+            rect1.envelope(&rect2),
+            Rectangle::new(Point::new_equal(2), Size::new_equal(10))
         );
     }
 


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR adds a `envelope()` method to the core `Rectangle` primitive. This method is intended to be the counter operation to the existing `intersection()`. This was added to aid development of higher level graphics libraries that may wish to group primitives and convey information about items such as bounding boxes without having to explicitly implement this logic. 

I am also happy to take any suggestions for alternatives to the term `envelope` if individuals feel strongly. 
