### PR TITLE
Implement many of the core traits for immutable and mutable refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 ### Added
 
 - [#733](https://github.com/embedded-graphics/embedded-graphics/pull/733) Add envelope() method to `Rectangle`
+- [#736](https://github.com/embedded-graphics/embedded-graphics/pull/736) Implement `PointsIter` for immutable and mutable references
+- [#736](https://github.com/embedded-graphics/embedded-graphics/pull/736) Implement `Drawable` for immutable references and mutable references
+- [#736](https://github.com/embedded-graphics/embedded-graphics/pull/736) Implement `StyledDimensions` for immutable and mutable references
+- [#736](https://github.com/embedded-graphics/embedded-graphics/pull/736) Implement `StyledDrawable` for immutable and mutable references
+- [#736](https://github.com/embedded-graphics/embedded-graphics/pull/736) Implement `StyledPixels` for immutable and mutable references
+- [#736](https://github.com/embedded-graphics/embedded-graphics/pull/736) Implement `ContainsPoint` for immutable and mutable references
 
 ## [0.8.1] - 2023-08-10
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Added
 - [#733](https://github.com/embedded-graphics/embedded-graphics/pull/733) Add envelope() method to `Rectangle`
+- [#736](https://github.com/embedded-graphics/embedded-graphics/pull/736) Implement `PointsIter` for immutable and mutable references
+- [#736](https://github.com/embedded-graphics/embedded-graphics/pull/736) Implement `Drawable` for immutable references and mutable references
 
 ## [0.4.0] - 2023-05-14
 

--- a/core/src/drawable.rs
+++ b/core/src/drawable.rs
@@ -106,6 +106,30 @@ pub trait Drawable {
         D: DrawTarget<Color = Self::Color>;
 }
 
+impl<T: Drawable + ?Sized> Drawable for &T {
+    type Color = T::Color;
+    type Output = T::Output;
+
+    fn draw<D>(&self, target: &mut D) -> Result<Self::Output, D::Error>
+    where
+        D: DrawTarget<Color = Self::Color>,
+    {
+        (**self).draw(target)
+    }
+}
+
+impl<T: Drawable + ?Sized> Drawable for &mut T {
+    type Color = T::Color;
+    type Output = T::Output;
+
+    fn draw<D>(&self, target: &mut D) -> Result<Self::Output, D::Error>
+    where
+        D: DrawTarget<Color = Self::Color>,
+    {
+        (**self).draw(target)
+    }
+}
+
 /// A single pixel.
 ///
 /// `Pixel` objects are used to specify the position and color of drawn pixels.

--- a/core/src/primitives/mod.rs
+++ b/core/src/primitives/mod.rs
@@ -13,3 +13,19 @@ pub trait PointsIter {
     /// Returns an iterator over all points inside the primitive.
     fn points(&self) -> Self::Iter;
 }
+
+impl<T: PointsIter + ?Sized> PointsIter for &T {
+    type Iter = T::Iter;
+
+    fn points(&self) -> Self::Iter {
+        (**self).points()
+    }
+}
+
+impl<T: PointsIter + ?Sized> PointsIter for &mut T {
+    type Iter = T::Iter;
+
+    fn points(&self) -> Self::Iter {
+        (**self).points()
+    }
+}

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -47,6 +47,18 @@ pub trait ContainsPoint {
     fn contains(&self, point: Point) -> bool;
 }
 
+impl<T: ContainsPoint + ?Sized> ContainsPoint for &T {
+    fn contains(&self, point: Point) -> bool {
+        (**self).contains(point)
+    }
+}
+
+impl<T: ContainsPoint + ?Sized> ContainsPoint for &mut T {
+    fn contains(&self, point: Point) -> bool {
+        (**self).contains(point)
+    }
+}
+
 /// Offset outline trait.
 pub trait OffsetOutline {
     /// Offsets the outline of the shape.

--- a/src/primitives/styled.rs
+++ b/src/primitives/styled.rs
@@ -150,17 +150,69 @@ pub trait StyledDrawable<S> {
         D: DrawTarget<Color = Self::Color>;
 }
 
+impl<S, T: StyledDrawable<S> + ?Sized> StyledDrawable<S> for &T {
+    type Color = T::Color;
+    type Output = T::Output;
+
+    fn draw_styled<D>(&self, style: &S, target: &mut D) -> Result<Self::Output, D::Error>
+    where
+        D: DrawTarget<Color = Self::Color>,
+    {
+        (**self).draw_styled(style, target)
+    }
+}
+
+impl<S, T: StyledDrawable<S> + ?Sized> StyledDrawable<S> for &mut T {
+    type Color = T::Color;
+    type Output = T::Output;
+
+    fn draw_styled<D>(&self, style: &S, target: &mut D) -> Result<Self::Output, D::Error>
+    where
+        D: DrawTarget<Color = Self::Color>,
+    {
+        (**self).draw_styled(style, target)
+    }
+}
+
 /// Styled dimensions.
 pub trait StyledDimensions<S> {
     /// Returns the bounding box using the given style.
     fn styled_bounding_box(&self, style: &S) -> Rectangle;
 }
 
-/// Styled drawable.
+impl<S, T: StyledDimensions<S> + ?Sized> StyledDimensions<S> for &T {
+    fn styled_bounding_box(&self, style: &S) -> Rectangle {
+        (**self).styled_bounding_box(style)
+    }
+}
+
+impl<S, T: StyledDimensions<S> + ?Sized> StyledDimensions<S> for &mut T {
+    fn styled_bounding_box(&self, style: &S) -> Rectangle {
+        (**self).styled_bounding_box(style)
+    }
+}
+
+/// Styled Pixels.
 pub trait StyledPixels<S> {
     /// Iterator type.
     type Iter;
 
     /// Returns an iterator over all pixels in this styled primitive.
     fn pixels(&self, style: &S) -> Self::Iter;
+}
+
+impl<S, T: StyledPixels<S> + ?Sized> StyledPixels<S> for &T {
+    type Iter = T::Iter;
+
+    fn pixels(&self, style: &S) -> Self::Iter {
+        (**self).pixels(style)
+    }
+}
+
+impl<S, T: StyledPixels<S> + ?Sized> StyledPixels<S> for &mut T {
+    type Iter = T::Iter;
+
+    fn pixels(&self, style: &S) -> Self::Iter {
+        (**self).pixels(style)
+    }
 }


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR implements many of the core traits of e-g for both immutable and mutable refs. This change is done primarily to aid ergonomics. 

These changes were split off from https://github.com/embedded-graphics/embedded-graphics/pull/735
