### PR TITLE
Add Rectangle::new_at_origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 ### Added
 
-- [#733](https://github.com/embedded-graphics/embedded-graphics/pull/733) Add envelope() method to `Rectangle`
+- [#733](https://github.com/embedded-graphics/embedded-graphics/pull/733) Added `envelope` method to `Rectangle`.
+- [#738](https://github.com/embedded-graphics/embedded-graphics/pull/738) Added `new_at_origin` method to `Rectangle`.
 
 ## [0.8.1] - 2023-08-10
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -11,7 +11,9 @@
 - (technically breaking) [#731](https://github.com/embedded-graphics/embedded-graphics/pull/731) Bump MSRV to 1.71.1
 
 ### Added
-- [#733](https://github.com/embedded-graphics/embedded-graphics/pull/733) Add envelope() method to `Rectangle`
+
+- [#733](https://github.com/embedded-graphics/embedded-graphics/pull/733) Added `envelope` method to `Rectangle`.
+- [#738](https://github.com/embedded-graphics/embedded-graphics/pull/738) Added `new_at_origin` method to `Rectangle`.
 
 ## [0.4.0] - 2023-05-14
 

--- a/core/src/primitives/rectangle/mod.rs
+++ b/core/src/primitives/rectangle/mod.rs
@@ -83,6 +83,14 @@ impl Rectangle {
         Rectangle { top_left, size }
     }
 
+    /// Creates a new rectangle with the given size and the top left corner at the origin.
+    pub const fn new_at_origin(size: Size) -> Self {
+        Rectangle {
+            top_left: Point::zero(),
+            size,
+        }
+    }
+
     /// Creates a new rectangle from two corners.
     pub fn with_corners(corner_1: Point, corner_2: Point) -> Self {
         let left = min(corner_1.x, corner_2.x);


### PR DESCRIPTION
This PR adds a new constructor for rectangles at `(0, 0)` to `Rectangle`. I've added the `new_` prefix to the suggestion by @BroderickCarlin in #737 to make the function easier to discover as a constructor in the docs or via code completion.
