### PR TITLE
Adjust performance expectations in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A core goal of embedded-graphics is to draw graphics without using any buffers; 
 `no_std` compatible and works without a dynamic memory allocator, and without pre-allocating
 large chunks of memory. To achieve this, it takes an `Iterator` based approach, where pixel
 colors and positions are calculated on the fly, with the minimum of saved state. This allows the
-consuming application to use far less RAM at little to no performance penalty.
+consuming application to use far less RAM, albeit with a significant performance penalty.
 
 It contains built in items that make it easy to draw 2D graphics primitives:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! `no_std` compatible and works without a dynamic memory allocator, and without pre-allocating
 //! large chunks of memory. To achieve this, it takes an `Iterator` based approach, where pixel
 //! colors and positions are calculated on the fly, with the minimum of saved state. This allows the
-//! consuming application to use far less RAM at little to no performance penalty.
+//! consuming application to use far less RAM, albeit with a significant performance penalty.
 //!
 //! It contains built in items that make it easy to draw 2D graphics primitives:
 //!


### PR DESCRIPTION
In my testing, using esp32 and GC9A01A (240x240), writing to the display with the DrawTarget interface is ~1000% slower for a simple framebuffer, up to >5000% slower for elaborate geometry, this is compared to using a (tiled) framebuffer and copying it with DMA, following the conventional industry approach.

This does not change with -s or -O3 optimization, so the description of the project should be updated to better reflect the scope of the project.

Thank you