### PR TITLE
Add MogeeFont to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ this are adding support for different image formats or implementing custom fonts
 * [Large collection of fonts - `u8g2-fonts`](https://crates.io/crates/u8g2-fonts)
 * [ProFont monospace font - `profont`](https://crates.io/crates/profont)
 * [Picofont Pico8 font - `embedded-picofont`](https://crates.io/crates/embedded_picofont)
+* [MogeeFont proportional font with kerning and ligatures - `embedded-mogeefont`](https://crates.io/crates/embedded_mogeefont)
 * [IBM437 font - `ibm437`](https://crates.io/crates/ibm437)
 * [The fonts shipped with `embedded-graphics` 0.6 - `embedded-vintage-fonts`](https://crates.io/crates/embedded-vintage-fonts)
 * [Simple layout/alignment functions - `embedded-layout`](https://crates.io/crates/embedded-layout)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@
 //! * [Large collection of fonts - `u8g2-fonts`](https://crates.io/crates/u8g2-fonts)
 //! * [ProFont monospace font - `profont`](https://crates.io/crates/profont)
 //! * [Picofont Pico8 font - `embedded-picofont`](https://crates.io/crates/embedded_picofont)
+//! * [MogeeFont proportional font with kerning and ligatures - `embedded-mogeefont`](https://crates.io/crates/embedded_mogeefont)
 //! * [IBM437 font - `ibm437`](https://crates.io/crates/ibm437)
 //! * [The fonts shipped with `embedded-graphics` 0.6 - `embedded-vintage-fonts`](https://crates.io/crates/embedded-vintage-fonts)
 //! * [Simple layout/alignment functions - `embedded-layout`](https://crates.io/crates/embedded-layout)


### PR DESCRIPTION
## PR description

Adds a link to the [MogeeFont crate](https://crates.io/crates/embedded_mogeefont). I think it's the first font in the ecosystem that supports kerning and ligatures. It had broken a few assumptions in the embedded-text crate [that I've fixed](https://github.com/embedded-graphics/embedded-text/pull/167)! 

![mogeefont](https://github.com/embedded-graphics/embedded-graphics/assets/43472/afcb8ca6-0e9d-49ad-a5ab-6b325977e0a2)


P.S. This is my first rust crate, so I'd appreciate any feedback!