### PR TITLE
Add additional optional fonts to MonoTextStyle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ default = []
 nalgebra_support = [ "embedded-graphics-core/nalgebra_support" ]
 fixed_point = [ "fixed" ]
 defmt = [ "dep:defmt", "embedded-graphics-core/defmt" ]
+aux_font = []
 
 [[bench]]
 harness = false

--- a/core/src/primitives/rectangle/mod.rs
+++ b/core/src/primitives/rectangle/mod.rs
@@ -65,7 +65,7 @@ impl PointsIter for Rectangle {
     type Iter = Points;
 
     fn points(&self) -> Self::Iter {
-        self::Points::new(self)
+        Points::new(self)
     }
 }
 

--- a/src/mono_font/mapping.rs
+++ b/src/mono_font/mapping.rs
@@ -51,6 +51,11 @@ pub trait GlyphMapping: Sync {
     ///
     /// If `c` isn't included in the font the index of a suitable replacement glyph is returned.
     fn index(&self, c: char) -> usize;
+
+    /// Check the mapping contains the given char.
+    fn mappable(&self, _c: char) -> bool {
+        true
+    }
 }
 
 impl<F> GlyphMapping for F
@@ -144,6 +149,9 @@ impl GlyphMapping for StrGlyphMapping<'_> {
             .find(|(_, v)| c == *v)
             .map(|(index, _)| index)
             .unwrap_or(self.replacement_index)
+    }
+    fn mappable(&self, c: char) -> bool {
+        self.contains(c)
     }
 }
 

--- a/src/mono_font/mono_text_style.rs
+++ b/src/mono_font/mono_text_style.rs
@@ -48,8 +48,8 @@ pub struct MonoTextStyle<'a, C> {
     pub font: &'a MonoFont<'a>,
 
     /// Aux font
-	#[cfg(feature = "aux_font")]
-    pub aux_font: Option<&'a MonoFont<'a>>
+    #[cfg(feature = "aux_font")]
+    pub aux_font: Option<&'a MonoFont<'a>>,
 }
 
 impl<'a, C> MonoTextStyle<'a, C>
@@ -76,10 +76,7 @@ where
             && self.strikethrough_color.is_none()
     }
 
-    fn line_elements<'t>(
-        &self,
-        text: &'t str,
-    ) -> impl Iterator<Item = (u32, LineElement)> + 't {
+    fn line_elements<'t>(&self, text: &'t str) -> impl Iterator<Item = (u32, LineElement)> + 't {
         let char_width = self.font.character_size.width;
         let spacing_width = self.font.character_spacing;
 
@@ -129,13 +126,14 @@ where
 
     #[inline]
     fn get_font_info(&self, _c: char) -> (i32, &MonoFont<'a>) {
-	    #[cfg(feature = "aux_font")]
+        #[cfg(feature = "aux_font")]
         {
             let mut width_delta = 0_i32;
-            let mut font= self.font;
+            let mut font = self.font;
             if let Some(aux_font) = self.aux_font {
                 if aux_font.glyph_mapping.mappable(_c) {
-                    width_delta = aux_font.character_size.width as i32 - font.character_size.width as i32;
+                    width_delta =
+                        aux_font.character_size.width as i32 - font.character_size.width as i32;
                     font = aux_font;
                 }
             }
@@ -429,7 +427,7 @@ where
                 text_color: None,
                 underline_color: DecorationColor::None,
                 strikethrough_color: DecorationColor::None,
-				#[cfg(feature = "aux_font")]
+                #[cfg(feature = "aux_font")]
                 aux_font: None,
             },
         }
@@ -443,7 +441,7 @@ where
             text_color: self.style.text_color,
             underline_color: self.style.underline_color,
             strikethrough_color: self.style.strikethrough_color,
-			#[cfg(feature = "aux_font")]
+            #[cfg(feature = "aux_font")]
             aux_font: None,
         };
 
@@ -451,10 +449,10 @@ where
     }
 
     /// Sets the aux font.
-	#[cfg(feature = "aux_font")]
-    pub const fn aux_font<'c>(self, aux_font: &'c MonoFont<'c>) -> MonoTextStyleBuilder<'c, C> 
+    #[cfg(feature = "aux_font")]
+    pub const fn aux_font<'c>(self, aux_font: &'c MonoFont<'c>) -> MonoTextStyleBuilder<'c, C>
     where
-        'a: 'c
+        'a: 'c,
     {
         let style = MonoTextStyle {
             font: self.style.font,
@@ -601,7 +599,7 @@ mod tests {
                 background_color: None,
                 underline_color: DecorationColor::None,
                 strikethrough_color: DecorationColor::None,
-				#[cfg(feature = "aux_font")]
+                #[cfg(feature = "aux_font")]
                 aux_font: None,
             }
         );
@@ -1040,7 +1038,7 @@ mod tests {
                 underline_color: DecorationColor::TextColor,
                 strikethrough_color: DecorationColor::Custom(BinaryColor::On),
                 font: &FONT_6X9,
-				#[cfg(feature = "aux_font")]
+                #[cfg(feature = "aux_font")]
                 aux_font: None,
             }
         );

--- a/src/mono_font/mono_text_style.rs
+++ b/src/mono_font/mono_text_style.rs
@@ -1228,7 +1228,7 @@ mod tests {
         );
         assert_eq!(
             iter.next(),
-            Some((SPACED_FONT.character_size.width, LineElement::Spacing))
+            Some((SPACED_FONT.character_spacing, LineElement::Spacing))
         );
         assert_eq!(
             iter.next(),


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Add additional optional fonts to MonoTextStyle, supporting the display of characters in different styles within the same line (such as CJK full/half width).

This function can be controlled through the "aux_font" feature.

---
![helloworld](https://github.com/embedded-graphics/embedded-graphics/assets/209863/1c5bbe45-f6cf-4735-95c0-c1995cdd475c)

```
let pos = Text::with_text_style("#你好Hello!\n@世界World!\n세상아, 안녕!\nこんにちは世界", Point::new(2, 14), AUX_STYLE_ON, TEXT_STYLE_LEFT)
	.draw(self.target).ok().unwrap();

Text::with_text_style("Next!", pos, AUX_STYLE_ON, TEXT_STYLE_LEFT)
	.draw(self.target).ok();
```
```
const AUX_FONT: MonoFont = MonoFont { //12X12
	image: ImageRaw::new(&AUX_IMGRAW, 96),
	glyph_mapping: &StrGlyphMapping::new("你好世界세상아안녕こんにちは", 0),
	character_size: Size::new(12, 12),
	character_spacing: 0,
	baseline: 9,
	underline: DecorationDimensions::default_underline(12),
	strikethrough: DecorationDimensions::default_strikethrough(12),
};

const AUX_STYLE_ON: MonoTextStyle<'_, BinaryColor> = MonoTextStyleBuilder::new()
	.font(&FONT_6X12).aux_font(&AUX_FONT).text_color(BinaryColor::On).build();

const AUX_IMGRAW: [u8; 0x120] = [
	0x14,0x02,0x00,0x04,0x87,0xFC,0x11,0xE1,0x8C,0x3C,0xC3,0xCC,0x14,0x02,0x7C,0x24,
	0x84,0x44,0x11,0xE1,0x8C,0x26,0xC6,0x6C,0x27,0xE2,0x04,0x24,0x87,0xFC,0x11,0xE1,
	0x8C,0x62,0xC4,0x2C,0x24,0x2F,0x88,0x24,0x84,0x44,0x1F,0xE1,0xCF,0x42,0xC4,0x2F,
	0x69,0x44,0x90,0xFF,0xE7,0xFC,0x19,0xE2,0x6C,0x42,0xF6,0x6C,0xA1,0x04,0x90,0x24,
	0x80,0x40,0x39,0xE4,0x2C,0x62,0xC3,0xCC,0x25,0x44,0xFE,0x24,0x81,0xB0,0x6D,0xE0,
	0x0C,0x26,0xC0,0x0C,0x25,0x29,0x10,0x24,0x8E,0x0E,0x47,0xE1,0xF8,0x3C,0xC3,0x0C,
	0x25,0x25,0x10,0x27,0x81,0x10,0x01,0xE3,0x0C,0x00,0xC3,0x00,0x29,0x22,0x10,0x20,
	0x01,0x10,0x01,0xE3,0x0C,0x00,0xC3,0x00,0x21,0x05,0x10,0x20,0x02,0x10,0x01,0xE1,
	0xF8,0x00,0xC3,0xFC,0x23,0x08,0xB0,0x3F,0xE4,0x10,0x00,0x00,0x00,0x00,0x00,0x00,
	0x20,0x40,0x00,0x02,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x23,0xC3,0xE0,0x02,
	0x00,0x00,0x08,0x00,0x20,0x00,0x00,0x00,0x20,0x40,0x40,0x04,0x00,0x7C,0x08,0x02,
	0x20,0x00,0x00,0x00,0x23,0xC0,0x00,0x04,0x02,0x88,0x7F,0x02,0x20,0x00,0x00,0x00,
	0x20,0x40,0x00,0x08,0x02,0x10,0x10,0x04,0xF8,0x00,0x00,0x00,0x3F,0x42,0x00,0x0E,
	0x04,0x00,0x1F,0x04,0x20,0x00,0x00,0x00,0x00,0x44,0x00,0x11,0x04,0x00,0x10,0x84,
	0x20,0x00,0x00,0x00,0x0F,0x84,0x08,0x11,0x04,0x00,0x00,0x85,0x20,0x00,0x00,0x00,
	0x10,0x43,0xF0,0x21,0x25,0x40,0x00,0x86,0x70,0x00,0x00,0x00,0x10,0x40,0x00,0x20,
	0xC6,0x48,0x01,0x02,0xA8,0x00,0x00,0x00,0x0F,0x80,0x00,0x00,0x02,0x3C,0x0E,0x00,
	0xC0,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
];
```
