### PR TITLE
Add swap_xy for Point and Size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#738](https://github.com/embedded-graphics/embedded-graphics/pull/738) Added `new_at_origin` method to `Rectangle`.
 - [#756](https://github.com/embedded-graphics/embedded-graphics/pull/756) Added `PartialEq, Eq` derives to `Image` and `SubImage`.
 - [#756](https://github.com/embedded-graphics/embedded-graphics/pull/756) Added `Clone, Copy` derives to `SubImage` and `Default` impls to `Framebuffer`, `MonoTextStyleBuilder` and `TextStyleBuilder`.
+- [#763](https://github.com/embedded-graphics/embedded-graphics/pull/763) Added `swap_xy` method to `Point` and `Size`.
 
 ## [0.8.1] - 2023-08-10
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - [#733](https://github.com/embedded-graphics/embedded-graphics/pull/733) Added `envelope` method to `Rectangle`.
 - [#738](https://github.com/embedded-graphics/embedded-graphics/pull/738) Added `new_at_origin` method to `Rectangle`.
+- [#763](https://github.com/embedded-graphics/embedded-graphics/pull/763) Added `swap_xy` method to `Point` and `Size`.
 
 ## [0.4.0] - 2023-05-14
 

--- a/core/src/geometry/point.rs
+++ b/core/src/geometry/point.rs
@@ -21,7 +21,7 @@ use crate::geometry::Size;
 ///
 /// ## Create a `Point` from two integers
 ///
-/// ```rust
+/// ```
 /// use embedded_graphics::geometry::Point;
 ///
 /// // Create a coord using the `new` constructor method
@@ -32,7 +32,7 @@ use crate::geometry::Size;
 ///
 /// _Be sure to enable the `nalgebra_support` feature to get [Nalgebra] integration._
 ///
-/// ```rust
+/// ```
 /// # #[cfg(feature = "nalgebra_support")] {
 /// use embedded_graphics::geometry::Point;
 /// use nalgebra::Vector2;
@@ -49,7 +49,7 @@ use crate::geometry::Size;
 ///
 /// Smaller unsigned types that can be converted to `i32` are also supported in conversions.
 ///
-/// ```rust
+/// ```
 /// # #[cfg(feature = "nalgebra_support")] {
 /// use embedded_graphics::geometry::Point;
 /// use nalgebra::Vector2;
@@ -84,7 +84,7 @@ impl Point {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use embedded_graphics::geometry::Point;
     ///
     /// let point = Point::new_equal(11);
@@ -104,9 +104,9 @@ impl Point {
     ///
     /// # Examples
     ///
-    /// ## Move a `Point` along the X axis.
+    /// Move a `Point` along the X axis:
     ///
-    /// ```rust
+    /// ```
     /// use embedded_graphics::geometry::Point;
     ///
     /// let translate = Point::new(20, 30);
@@ -125,9 +125,9 @@ impl Point {
     ///
     /// # Examples
     ///
-    /// ## Move a `Point` along the Y axis.
+    /// Move a `Point` along the Y axis:
     ///
-    /// ```rust
+    /// ```
     /// use embedded_graphics::geometry::Point;
     ///
     /// let translate = Point::new(20, 30);
@@ -142,13 +142,13 @@ impl Point {
         Self { x: 0, y: self.y }
     }
 
-    /// Remove the sign from a coordinate
+    /// Returns a point with the componentwise absolute value of the coordinates.
     ///
     /// # Examples
     ///
     /// ```
-    /// # use embedded_graphics::geometry::Point;
-    /// #
+    /// use embedded_graphics::geometry::Point;
+    ///
     /// let point = Point::new(-5, -10);
     ///
     /// assert_eq!(point.abs(), Point::new(5, 10));
@@ -179,7 +179,7 @@ impl Point {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use embedded_graphics::geometry::Point;
     ///
     /// let min = Point::new(20, 30).component_min(Point::new(15, 50));
@@ -194,7 +194,7 @@ impl Point {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use embedded_graphics::geometry::Point;
     ///
     /// let min = Point::new(20, 30).component_max(Point::new(15, 50));
@@ -207,7 +207,9 @@ impl Point {
 
     /// Returns the componentwise multiplication of two `Point`s.
     ///
-    /// ```rust
+    /// # Examples
+    ///
+    /// ```
     /// use embedded_graphics::geometry::Point;
     ///
     /// let result = Point::new(20, 30).component_mul(Point::new(-2, 3));
@@ -218,13 +220,15 @@ impl Point {
         Self::new(self.x * other.x, self.y * other.y)
     }
 
-    /// Returns the componentwise division of two `Points`s.
+    /// Returns the componentwise division of two `Point`s.
     ///
     /// # Panics
     ///
     /// Panics if one of the components of `other` equals zero.
     ///
-    /// ```rust
+    /// # Examples
+    ///
+    /// ```
     /// use embedded_graphics::geometry::Point;
     ///
     /// let result = Point::new(20, 30).component_div(Point::new(10, -3));

--- a/core/src/geometry/point.rs
+++ b/core/src/geometry/point.rs
@@ -239,7 +239,7 @@ impl Point {
         Self::new(self.x / other.x, self.y / other.y)
     }
 
-    /// Returns a point with swapped x and y coordinates.
+    /// Returns a point with swapped X and Y coordinates.
     ///
     /// # Examples
     ///

--- a/core/src/geometry/point.rs
+++ b/core/src/geometry/point.rs
@@ -238,6 +238,21 @@ impl Point {
     pub const fn component_div(self, other: Self) -> Self {
         Self::new(self.x / other.x, self.y / other.y)
     }
+
+    /// Returns a point with swapped x and y coordinates.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use embedded_graphics::geometry::Point;
+    ///
+    /// let result = Point::new(1, 2).swap_xy();
+    ///
+    /// assert_eq!(result, Point::new(2, 1));
+    /// ```
+    pub const fn swap_xy(self) -> Self {
+        Self::new(self.y, self.x)
+    }
 }
 
 impl Add for Point {

--- a/core/src/geometry/size.rs
+++ b/core/src/geometry/size.rs
@@ -19,7 +19,7 @@ use crate::geometry::Point;
 /// ## Create a `Size` from two integers
 ///
 ///
-/// ```rust
+/// ```
 /// use embedded_graphics::geometry::Size;
 ///
 /// // Create a size using the `new` constructor method
@@ -32,7 +32,7 @@ use crate::geometry::Point;
 ///
 /// Any `Vector2<N>` can be used where `N: Into<u32> + nalgebra::Scalar`. This includes the primitive types `u32`, `u16` and `u8`.
 ///
-/// ```rust
+/// ```
 /// # #[cfg(feature = "nalgebra_support")] {
 /// use embedded_graphics::geometry::Size;
 /// use nalgebra::Vector2;
@@ -45,7 +45,7 @@ use crate::geometry::Point;
 ///
 /// `.into()` can also be used, but may require more type annotations:
 ///
-/// ```rust
+/// ```
 /// # #[cfg(feature = "nalgebra_support")] {
 /// use embedded_graphics::geometry::Size;
 /// use nalgebra::Vector2;
@@ -78,7 +78,7 @@ impl Size {
 
     /// Creates a size with width and height set to an equal value.
     ///
-    /// ```rust
+    /// ```
     /// use embedded_graphics::geometry::Size;
     ///
     /// let size = Size::new_equal(11);
@@ -110,9 +110,9 @@ impl Size {
     ///
     /// # Examples
     ///
-    /// ## Move a `Point` along the X axis.
+    /// Move a `Point` along the X axis:
     ///
-    /// ```rust
+    /// ```
     /// use embedded_graphics::geometry::{Point, Size};
     ///
     /// let size = Size::new(20, 30);
@@ -134,9 +134,9 @@ impl Size {
     ///
     /// # Examples
     ///
-    /// ## Move a `Point` along the Y axis.
+    /// Move a `Point` along the Y axis:
     ///
-    /// ```rust
+    /// ```
     /// use embedded_graphics::geometry::{Point, Size};
     ///
     /// let size = Size::new(20, 30);
@@ -167,7 +167,7 @@ impl Size {
     /// Saturating subtraction.
     ///
     /// Returns `0` for `width` and/or `height` instead of overflowing, if the
-    /// value in `other` is larger then in `self`.
+    /// value in `other` is larger than in `self`.
     pub const fn saturating_sub(self, other: Self) -> Self {
         Self {
             width: self.width.saturating_sub(other.width),
@@ -192,7 +192,7 @@ impl Size {
 
     /// Returns the componentwise minimum of two `Size`s.
     ///
-    /// ```rust
+    /// ```
     /// use embedded_graphics::geometry::Size;
     ///
     /// let min = Size::new(20, 30).component_min(Size::new(15, 50));
@@ -205,7 +205,7 @@ impl Size {
 
     /// Returns the componentwise maximum of two `Size`s.
     ///
-    /// ```rust
+    /// ```
     /// use embedded_graphics::geometry::Size;
     ///
     /// let min = Size::new(20, 30).component_max(Size::new(15, 50));
@@ -218,7 +218,7 @@ impl Size {
 
     /// Returns the componentwise multiplication of two `Size`s.
     ///
-    /// ```rust
+    /// ```
     /// use embedded_graphics::geometry::Size;
     ///
     /// let result = Size::new(20, 30).component_mul(Size::new(2, 3));
@@ -235,7 +235,7 @@ impl Size {
     ///
     /// Panics if one of the components of `other` equals zero.
     ///
-    /// ```rust
+    /// ```
     /// use embedded_graphics::geometry::Size;
     ///
     /// let result = Size::new(20, 30).component_div(Size::new(5, 10));

--- a/core/src/geometry/size.rs
+++ b/core/src/geometry/size.rs
@@ -245,6 +245,21 @@ impl Size {
     pub const fn component_div(self, other: Self) -> Self {
         Self::new(self.width / other.width, self.height / other.height)
     }
+
+    /// Returns a size with swapped width and height.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use embedded_graphics::geometry::Size;
+    ///
+    /// let result = Size::new(1, 2).swap_xy();
+    ///
+    /// assert_eq!(result, Size::new(2, 1));
+    /// ```
+    pub const fn swap_xy(self) -> Self {
+        Self::new(self.height, self.width)
+    }
 }
 
 impl Add for Size {


### PR DESCRIPTION
This PR adds `Point::swap_xy` and `Size::swap_xy` to swap the coordinates. The main advantage of having these functions instead of using `Point::new(p.y, p.x)` is that they can be used as part of a longer expression without having to us a temporary variable.

@jamwaffles: Would you like to review this PR or should I just merge it? This was a part of #711, which I want to slowly merge in smaller PRs.