### PR TITLE
Return error from ImageRaw::new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 ### Changed
 
+- **(breaking)** [#764](https://github.com/embedded-graphics/embedded-graphics/pull/764) Changed `ImageRaw::new` to return an error instead of truncating the image height.
 - [#732](https://github.com/embedded-graphics/embedded-graphics/pull/732) Added `Rgb444` to support 12bit RGB displays. Note that this type is currently stored as a 16 bit value in `ImageRaw`s and `Framebuffer`s.
 
 ### Added
@@ -17,6 +18,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#756](https://github.com/embedded-graphics/embedded-graphics/pull/756) Added `PartialEq, Eq` derives to `Image` and `SubImage`.
 - [#756](https://github.com/embedded-graphics/embedded-graphics/pull/756) Added `Clone, Copy` derives to `SubImage` and `Default` impls to `Framebuffer`, `MonoTextStyleBuilder` and `TextStyleBuilder`.
 - [#763](https://github.com/embedded-graphics/embedded-graphics/pull/763) Added `swap_xy` method to `Point` and `Size`.
+- [#764](https://github.com/embedded-graphics/embedded-graphics/pull/764) Added `ImageRaw::new_const` as a panicing alternative to the new `ImageRaw::new` for ease of use in const contexts.
 
 ## [0.8.1] - 2023-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#756](https://github.com/embedded-graphics/embedded-graphics/pull/756) Added `PartialEq, Eq` derives to `Image` and `SubImage`.
 - [#756](https://github.com/embedded-graphics/embedded-graphics/pull/756) Added `Clone, Copy` derives to `SubImage` and `Default` impls to `Framebuffer`, `MonoTextStyleBuilder` and `TextStyleBuilder`.
 - [#763](https://github.com/embedded-graphics/embedded-graphics/pull/763) Added `swap_xy` method to `Point` and `Size`.
-- [#764](https://github.com/embedded-graphics/embedded-graphics/pull/764) Added `ImageRaw::new_const` as a panicing alternative to the new `ImageRaw::new` for ease of use in const contexts.
+- [#764](https://github.com/embedded-graphics/embedded-graphics/pull/764) Added `ImageRaw::new_const` as a panicking alternative to the new `ImageRaw::new` for ease of use in const contexts.
 
 ## [0.8.1] - 2023-08-10
 

--- a/benches/image.rs
+++ b/benches/image.rs
@@ -13,7 +13,7 @@ fn image_1bpp(c: &mut Criterion) {
     c.bench_function("image 4x4px", |b| {
         let bytes = include_bytes!("../assets/patch_1bpp.raw");
 
-        let image: ImageRaw<BinaryColor> = ImageRaw::new(bytes, 4);
+        let image: ImageRaw<BinaryColor> = ImageRaw::new(bytes, Size::new(4, 4)).unwrap();
         let object = Image::new(&image, Point::zero());
 
         let mut framebuffer = Framebuffer::new();

--- a/core/src/pixelcolor/raw/mod.rs
+++ b/core/src/pixelcolor/raw/mod.rs
@@ -81,7 +81,7 @@
 //! ];
 //!
 //! // Create new image with RGBI colors.
-//! let image_raw: ImageRaw<RGBI> = ImageRaw::new(IMAGE_DATA, 2);
+//! let image_raw: ImageRaw<RGBI> = ImageRaw::new(IMAGE_DATA, Size::new(2, 2)).unwrap();
 //!
 //! // In a real application the image could now be drawn to a display:
 //! // display.draw(&image);

--- a/src/draw_target/mod.rs
+++ b/src/draw_target/mod.rs
@@ -183,7 +183,7 @@ pub trait DrawTargetExt: DrawTarget + Sized {
     /// ];
     ///
     /// // Create a `BinaryColor` image from the image data.
-    /// let raw_image = ImageRaw::<BinaryColor>::new(DATA, 4);
+    /// let raw_image = ImageRaw::<BinaryColor>::new(DATA, Size::new(4, 4)).unwrap();
     /// let image = Image::new(&raw_image, Point::zero());
     ///
     /// // Create a `Rgb888` display.

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -117,7 +117,11 @@ where
 {
     /// Returns an image based on the framebuffer content.
     pub fn as_image(&self) -> ImageRaw<'_, C, BO> {
-        ImageRaw::new(&self.data[0..Self::BUFFER_SIZE], WIDTH as u32)
+        ImageRaw::new(
+            &self.data[0..Self::BUFFER_SIZE],
+            Size::new(WIDTH as u32, HEIGHT as u32),
+        )
+        .unwrap()
     }
 }
 

--- a/src/image/image_drawable_ext.rs
+++ b/src/image/image_drawable_ext.rs
@@ -27,7 +27,7 @@ pub trait ImageDrawableExt: Sized {
     /// // or: let data = include_bytes!("sprite_atlas.raw");
     ///
     /// # let data = [0u8; 32 * 16 * 2];
-    /// let sprite_atlas = ImageRawBE::<Rgb565>::new(&data, 32);
+    /// let sprite_atlas = ImageRawBE::<Rgb565>::new(&data, Size::new(32, 16)).unwrap();
     ///
     /// let sprite_1 = sprite_atlas.sub_image(&Rectangle::new(Point::new(0, 0), Size::new(16, 16)));
     /// let sprite_2 = sprite_atlas.sub_image(&Rectangle::new(Point::new(16, 0), Size::new(16, 16)));

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -35,7 +35,7 @@
 //!
 //! // Create a raw image instance. Other image formats will require different code to load them.
 //! // All code after loading is the same for any image format.
-//! let raw: ImageRawBE<Rgb565> = ImageRaw::new(&data, 4);
+//! let raw: ImageRawBE<Rgb565> = ImageRaw::new(&data, Size::new(4, 2)).unwrap();
 //!
 //! // Create an `Image` object to position the image at `Point::zero()`.
 //! let image = Image::new(&raw, Point::zero());
@@ -68,7 +68,7 @@
 //! // or: let data = include_bytes!("sprite_atlas.raw");
 //!
 //! # let data = [0u8; 32 * 16 * 2];
-//! let sprite_atlas: ImageRawBE<Rgb565> = ImageRaw::new(&data, 32);
+//! let sprite_atlas: ImageRawBE<Rgb565> = ImageRaw::new(&data, Size::new(32, 16)).unwrap();
 //!
 //! // Create individual sub images for each sprite in the sprite atlas.
 //! // The position and size of the sub images is defined by a `Rectangle`.
@@ -101,7 +101,7 @@ mod sub_image;
 
 pub use embedded_graphics_core::image::{GetPixel, ImageDrawable};
 pub use image_drawable_ext::ImageDrawableExt;
-pub use image_raw::{ImageRaw, ImageRawBE, ImageRawLE};
+pub use image_raw::{ImageRaw, ImageRawBE, ImageRawError, ImageRawLE};
 pub use sub_image::SubImage;
 
 use crate::{
@@ -174,7 +174,7 @@ impl<T> Transform for Image<'_, T> {
     ///     prelude::*,
     /// };
     ///
-    /// let image: ImageRaw<BinaryColor> = ImageRaw::new(&[0xff, 0x00, 0xff, 0x00], 4);
+    /// let image: ImageRaw<BinaryColor> = ImageRaw::new(&[0xff, 0x00, 0xff, 0x00], Size::new(4, 4)).unwrap();
     ///
     /// let image = Image::new(&image, Point::zero());
     ///
@@ -207,7 +207,7 @@ impl<T> Transform for Image<'_, T> {
     ///     prelude::*,
     /// };
     ///
-    /// let image: ImageRaw<BinaryColor> = ImageRaw::new(&[0xff, 0x00, 0xff, 0x00], 4);
+    /// let image: ImageRaw<BinaryColor> = ImageRaw::new(&[0xff, 0x00, 0xff, 0x00], Size::new(4, 4)).unwrap();
     ///
     /// let mut image = Image::new(&image, Point::zero());
     ///
@@ -254,7 +254,8 @@ mod tests {
 
     #[test]
     fn negative_top_left() {
-        let image: ImageRaw<BinaryColor> = ImageRaw::new(&[0xff, 0x00, 0xff, 0x00], 4);
+        let image: ImageRaw<BinaryColor> =
+            ImageRaw::new(&[0xff, 0x00, 0xff, 0x00], Size::new(4, 4)).unwrap();
 
         let image = Image::new(&image, Point::zero()).translate(Point::new(-1, -1));
 
@@ -266,7 +267,8 @@ mod tests {
 
     #[test]
     fn dimensions() {
-        let image: ImageRaw<BinaryColor> = ImageRaw::new(&[0xff, 0x00, 0xFF, 0x00], 4);
+        let image: ImageRaw<BinaryColor> =
+            ImageRaw::new(&[0xff, 0x00, 0xFF, 0x00], Size::new(4, 4)).unwrap();
 
         let image = Image::new(&image, Point::zero()).translate(Point::new(100, 200));
 
@@ -278,7 +280,8 @@ mod tests {
 
     #[test]
     fn position() {
-        let image_raw: ImageRaw<BinaryColor> = ImageRaw::new(&[0xAA, 0x55, 0xAA, 0x55], 4);
+        let image_raw: ImageRaw<BinaryColor> =
+            ImageRaw::new(&[0xAA, 0x55, 0xAA, 0x55], Size::new(4, 4)).unwrap();
 
         let mut display = MockDisplay::new();
         Image::new(&image_raw, Point::new(1, 2))
@@ -297,7 +300,8 @@ mod tests {
 
     #[test]
     fn with_center() {
-        let image_raw: ImageRaw<BinaryColor> = ImageRaw::new(&[0xAA, 0x55, 0xAA, 0x55], 4);
+        let image_raw: ImageRaw<BinaryColor> =
+            ImageRaw::new(&[0xAA, 0x55, 0xAA, 0x55], Size::new(4, 4)).unwrap();
 
         let mut display = MockDisplay::new();
         Image::with_center(&image_raw, Point::new(1, 2))

--- a/src/mock_display/mod.rs
+++ b/src/mock_display/mod.rs
@@ -152,7 +152,7 @@
 //!     0x00, 0x1F, 0x07, 0xFF, 0xF8, 0x1F, 0xFF, 0xFF, //
 //! ];
 //!
-//! let raw: ImageRawBE<Rgb565> = ImageRaw::new(&data, 4);
+//! let raw: ImageRawBE<Rgb565> = ImageRaw::new(&data, Size::new(4, 2)).unwrap();
 //!
 //! let image = Image::new(&raw, Point::zero());
 //!

--- a/src/mono_font/generated/ascii.rs
+++ b/src/mono_font/generated/ascii.rs
@@ -18,7 +18,10 @@
 
 /// 4x6 pixel monospace font.
 pub const FONT_4X6: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(include_bytes!("../../../fonts/raw/ascii/font_4x6.raw"), 64),
+    image: crate::image::ImageRaw::new_const(
+        include_bytes!("../../../fonts/raw/ascii/font_4x6.raw"),
+        crate::geometry::Size::new(64, 36),
+    ),
     glyph_mapping: &crate::mono_font::mapping::ASCII,
     character_size: crate::geometry::Size::new(4, 6),
     character_spacing: 0,
@@ -29,7 +32,10 @@ pub const FONT_4X6: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 5x7 pixel monospace font.
 pub const FONT_5X7: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(include_bytes!("../../../fonts/raw/ascii/font_5x7.raw"), 80),
+    image: crate::image::ImageRaw::new_const(
+        include_bytes!("../../../fonts/raw/ascii/font_5x7.raw"),
+        crate::geometry::Size::new(80, 42),
+    ),
     glyph_mapping: &crate::mono_font::mapping::ASCII,
     character_size: crate::geometry::Size::new(5, 7),
     character_spacing: 0,
@@ -40,7 +46,10 @@ pub const FONT_5X7: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 5x8 pixel monospace font.
 pub const FONT_5X8: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(include_bytes!("../../../fonts/raw/ascii/font_5x8.raw"), 80),
+    image: crate::image::ImageRaw::new_const(
+        include_bytes!("../../../fonts/raw/ascii/font_5x8.raw"),
+        crate::geometry::Size::new(80, 48),
+    ),
     glyph_mapping: &crate::mono_font::mapping::ASCII,
     character_size: crate::geometry::Size::new(5, 8),
     character_spacing: 0,
@@ -51,7 +60,10 @@ pub const FONT_5X8: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x9 pixel monospace font.
 pub const FONT_6X9: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(include_bytes!("../../../fonts/raw/ascii/font_6x9.raw"), 96),
+    image: crate::image::ImageRaw::new_const(
+        include_bytes!("../../../fonts/raw/ascii/font_6x9.raw"),
+        crate::geometry::Size::new(96, 54),
+    ),
     glyph_mapping: &crate::mono_font::mapping::ASCII,
     character_size: crate::geometry::Size::new(6, 9),
     character_spacing: 0,
@@ -62,9 +74,9 @@ pub const FONT_6X9: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x10 pixel monospace font.
 pub const FONT_6X10: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/ascii/font_6x10.raw"),
-        96,
+        crate::geometry::Size::new(96, 60),
     ),
     glyph_mapping: &crate::mono_font::mapping::ASCII,
     character_size: crate::geometry::Size::new(6, 10),
@@ -76,9 +88,9 @@ pub const FONT_6X10: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x12 pixel monospace font.
 pub const FONT_6X12: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/ascii/font_6x12.raw"),
-        96,
+        crate::geometry::Size::new(96, 72),
     ),
     glyph_mapping: &crate::mono_font::mapping::ASCII,
     character_size: crate::geometry::Size::new(6, 12),
@@ -90,9 +102,9 @@ pub const FONT_6X12: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/ascii/font_6x13.raw"),
-        96,
+        crate::geometry::Size::new(96, 78),
     ),
     glyph_mapping: &crate::mono_font::mapping::ASCII,
     character_size: crate::geometry::Size::new(6, 13),
@@ -104,9 +116,9 @@ pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/ascii/font_6x13_bold.raw"),
-        96,
+        crate::geometry::Size::new(96, 78),
     ),
     glyph_mapping: &crate::mono_font::mapping::ASCII,
     character_size: crate::geometry::Size::new(6, 13),
@@ -118,9 +130,9 @@ pub const FONT_6X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/ascii/font_6x13_italic.raw"),
-        96,
+        crate::geometry::Size::new(96, 78),
     ),
     glyph_mapping: &crate::mono_font::mapping::ASCII,
     character_size: crate::geometry::Size::new(6, 13),
@@ -132,9 +144,9 @@ pub const FONT_6X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/ascii/font_7x13.raw"),
-        112,
+        crate::geometry::Size::new(112, 78),
     ),
     glyph_mapping: &crate::mono_font::mapping::ASCII,
     character_size: crate::geometry::Size::new(7, 13),
@@ -146,9 +158,9 @@ pub const FONT_7X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/ascii/font_7x13_bold.raw"),
-        112,
+        crate::geometry::Size::new(112, 78),
     ),
     glyph_mapping: &crate::mono_font::mapping::ASCII,
     character_size: crate::geometry::Size::new(7, 13),
@@ -160,9 +172,9 @@ pub const FONT_7X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/ascii/font_7x13_italic.raw"),
-        112,
+        crate::geometry::Size::new(112, 78),
     ),
     glyph_mapping: &crate::mono_font::mapping::ASCII,
     character_size: crate::geometry::Size::new(7, 13),
@@ -174,9 +186,9 @@ pub const FONT_7X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/ascii/font_7x14.raw"),
-        112,
+        crate::geometry::Size::new(112, 84),
     ),
     glyph_mapping: &crate::mono_font::mapping::ASCII,
     character_size: crate::geometry::Size::new(7, 14),
@@ -188,9 +200,9 @@ pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/ascii/font_7x14_bold.raw"),
-        112,
+        crate::geometry::Size::new(112, 84),
     ),
     glyph_mapping: &crate::mono_font::mapping::ASCII,
     character_size: crate::geometry::Size::new(7, 14),
@@ -202,9 +214,9 @@ pub const FONT_7X14_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/ascii/font_8x13.raw"),
-        128,
+        crate::geometry::Size::new(128, 78),
     ),
     glyph_mapping: &crate::mono_font::mapping::ASCII,
     character_size: crate::geometry::Size::new(8, 13),
@@ -216,9 +228,9 @@ pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/ascii/font_8x13_bold.raw"),
-        128,
+        crate::geometry::Size::new(128, 78),
     ),
     glyph_mapping: &crate::mono_font::mapping::ASCII,
     character_size: crate::geometry::Size::new(8, 13),
@@ -230,9 +242,9 @@ pub const FONT_8X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/ascii/font_8x13_italic.raw"),
-        128,
+        crate::geometry::Size::new(128, 78),
     ),
     glyph_mapping: &crate::mono_font::mapping::ASCII,
     character_size: crate::geometry::Size::new(8, 13),
@@ -244,9 +256,9 @@ pub const FONT_8X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/ascii/font_9x15.raw"),
-        144,
+        crate::geometry::Size::new(144, 90),
     ),
     glyph_mapping: &crate::mono_font::mapping::ASCII,
     character_size: crate::geometry::Size::new(9, 15),
@@ -258,9 +270,9 @@ pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/ascii/font_9x15_bold.raw"),
-        144,
+        crate::geometry::Size::new(144, 90),
     ),
     glyph_mapping: &crate::mono_font::mapping::ASCII,
     character_size: crate::geometry::Size::new(9, 15),
@@ -272,9 +284,9 @@ pub const FONT_9X15_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/ascii/font_9x18.raw"),
-        144,
+        crate::geometry::Size::new(144, 108),
     ),
     glyph_mapping: &crate::mono_font::mapping::ASCII,
     character_size: crate::geometry::Size::new(9, 18),
@@ -286,9 +298,9 @@ pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/ascii/font_9x18_bold.raw"),
-        144,
+        crate::geometry::Size::new(144, 108),
     ),
     glyph_mapping: &crate::mono_font::mapping::ASCII,
     character_size: crate::geometry::Size::new(9, 18),
@@ -300,9 +312,9 @@ pub const FONT_9X18_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 10x20 pixel monospace font.
 pub const FONT_10X20: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/ascii/font_10x20.raw"),
-        160,
+        crate::geometry::Size::new(160, 120),
     ),
     glyph_mapping: &crate::mono_font::mapping::ASCII,
     character_size: crate::geometry::Size::new(10, 20),

--- a/src/mono_font/generated/iso_8859_1.rs
+++ b/src/mono_font/generated/iso_8859_1.rs
@@ -18,9 +18,9 @@
 
 /// 4x6 pixel monospace font.
 pub const FONT_4X6: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_1/font_4x6.raw"),
-        64,
+        crate::geometry::Size::new(64, 72),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_1,
     character_size: crate::geometry::Size::new(4, 6),
@@ -32,9 +32,9 @@ pub const FONT_4X6: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 5x7 pixel monospace font.
 pub const FONT_5X7: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_1/font_5x7.raw"),
-        80,
+        crate::geometry::Size::new(80, 84),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_1,
     character_size: crate::geometry::Size::new(5, 7),
@@ -46,9 +46,9 @@ pub const FONT_5X7: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 5x8 pixel monospace font.
 pub const FONT_5X8: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_1/font_5x8.raw"),
-        80,
+        crate::geometry::Size::new(80, 96),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_1,
     character_size: crate::geometry::Size::new(5, 8),
@@ -60,9 +60,9 @@ pub const FONT_5X8: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x9 pixel monospace font.
 pub const FONT_6X9: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_1/font_6x9.raw"),
-        96,
+        crate::geometry::Size::new(96, 108),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_1,
     character_size: crate::geometry::Size::new(6, 9),
@@ -74,9 +74,9 @@ pub const FONT_6X9: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x10 pixel monospace font.
 pub const FONT_6X10: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_1/font_6x10.raw"),
-        96,
+        crate::geometry::Size::new(96, 120),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_1,
     character_size: crate::geometry::Size::new(6, 10),
@@ -88,9 +88,9 @@ pub const FONT_6X10: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x12 pixel monospace font.
 pub const FONT_6X12: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_1/font_6x12.raw"),
-        96,
+        crate::geometry::Size::new(96, 144),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_1,
     character_size: crate::geometry::Size::new(6, 12),
@@ -102,9 +102,9 @@ pub const FONT_6X12: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_1/font_6x13.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_1,
     character_size: crate::geometry::Size::new(6, 13),
@@ -116,9 +116,9 @@ pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_1/font_6x13_bold.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_1,
     character_size: crate::geometry::Size::new(6, 13),
@@ -130,9 +130,9 @@ pub const FONT_6X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_1/font_6x13_italic.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_1,
     character_size: crate::geometry::Size::new(6, 13),
@@ -144,9 +144,9 @@ pub const FONT_6X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_1/font_7x13.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_1,
     character_size: crate::geometry::Size::new(7, 13),
@@ -158,9 +158,9 @@ pub const FONT_7X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_1/font_7x13_bold.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_1,
     character_size: crate::geometry::Size::new(7, 13),
@@ -172,9 +172,9 @@ pub const FONT_7X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_1/font_7x13_italic.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_1,
     character_size: crate::geometry::Size::new(7, 13),
@@ -186,9 +186,9 @@ pub const FONT_7X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_1/font_7x14.raw"),
-        112,
+        crate::geometry::Size::new(112, 168),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_1,
     character_size: crate::geometry::Size::new(7, 14),
@@ -200,9 +200,9 @@ pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_1/font_7x14_bold.raw"),
-        112,
+        crate::geometry::Size::new(112, 168),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_1,
     character_size: crate::geometry::Size::new(7, 14),
@@ -214,9 +214,9 @@ pub const FONT_7X14_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_1/font_8x13.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_1,
     character_size: crate::geometry::Size::new(8, 13),
@@ -228,9 +228,9 @@ pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_1/font_8x13_bold.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_1,
     character_size: crate::geometry::Size::new(8, 13),
@@ -242,9 +242,9 @@ pub const FONT_8X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_1/font_8x13_italic.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_1,
     character_size: crate::geometry::Size::new(8, 13),
@@ -256,9 +256,9 @@ pub const FONT_8X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_1/font_9x15.raw"),
-        144,
+        crate::geometry::Size::new(144, 180),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_1,
     character_size: crate::geometry::Size::new(9, 15),
@@ -270,9 +270,9 @@ pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_1/font_9x15_bold.raw"),
-        144,
+        crate::geometry::Size::new(144, 180),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_1,
     character_size: crate::geometry::Size::new(9, 15),
@@ -284,9 +284,9 @@ pub const FONT_9X15_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_1/font_9x18.raw"),
-        144,
+        crate::geometry::Size::new(144, 216),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_1,
     character_size: crate::geometry::Size::new(9, 18),
@@ -298,9 +298,9 @@ pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_1/font_9x18_bold.raw"),
-        144,
+        crate::geometry::Size::new(144, 216),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_1,
     character_size: crate::geometry::Size::new(9, 18),
@@ -312,9 +312,9 @@ pub const FONT_9X18_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 10x20 pixel monospace font.
 pub const FONT_10X20: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_1/font_10x20.raw"),
-        160,
+        crate::geometry::Size::new(160, 240),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_1,
     character_size: crate::geometry::Size::new(10, 20),

--- a/src/mono_font/generated/iso_8859_10.rs
+++ b/src/mono_font/generated/iso_8859_10.rs
@@ -18,9 +18,9 @@
 
 /// 4x6 pixel monospace font.
 pub const FONT_4X6: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_10/font_4x6.raw"),
-        64,
+        crate::geometry::Size::new(64, 72),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_10,
     character_size: crate::geometry::Size::new(4, 6),
@@ -32,9 +32,9 @@ pub const FONT_4X6: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 5x7 pixel monospace font.
 pub const FONT_5X7: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_10/font_5x7.raw"),
-        80,
+        crate::geometry::Size::new(80, 84),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_10,
     character_size: crate::geometry::Size::new(5, 7),
@@ -46,9 +46,9 @@ pub const FONT_5X7: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 5x8 pixel monospace font.
 pub const FONT_5X8: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_10/font_5x8.raw"),
-        80,
+        crate::geometry::Size::new(80, 96),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_10,
     character_size: crate::geometry::Size::new(5, 8),
@@ -60,9 +60,9 @@ pub const FONT_5X8: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x9 pixel monospace font.
 pub const FONT_6X9: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_10/font_6x9.raw"),
-        96,
+        crate::geometry::Size::new(96, 108),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_10,
     character_size: crate::geometry::Size::new(6, 9),
@@ -74,9 +74,9 @@ pub const FONT_6X9: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x10 pixel monospace font.
 pub const FONT_6X10: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_10/font_6x10.raw"),
-        96,
+        crate::geometry::Size::new(96, 120),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_10,
     character_size: crate::geometry::Size::new(6, 10),
@@ -88,9 +88,9 @@ pub const FONT_6X10: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x12 pixel monospace font.
 pub const FONT_6X12: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_10/font_6x12.raw"),
-        96,
+        crate::geometry::Size::new(96, 144),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_10,
     character_size: crate::geometry::Size::new(6, 12),
@@ -102,9 +102,9 @@ pub const FONT_6X12: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_10/font_6x13.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_10,
     character_size: crate::geometry::Size::new(6, 13),
@@ -116,9 +116,9 @@ pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_10/font_6x13_bold.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_10,
     character_size: crate::geometry::Size::new(6, 13),
@@ -130,9 +130,9 @@ pub const FONT_6X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_10/font_6x13_italic.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_10,
     character_size: crate::geometry::Size::new(6, 13),
@@ -144,9 +144,9 @@ pub const FONT_6X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_10/font_7x13.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_10,
     character_size: crate::geometry::Size::new(7, 13),
@@ -158,9 +158,9 @@ pub const FONT_7X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_10/font_7x13_bold.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_10,
     character_size: crate::geometry::Size::new(7, 13),
@@ -172,9 +172,9 @@ pub const FONT_7X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_10/font_7x13_italic.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_10,
     character_size: crate::geometry::Size::new(7, 13),
@@ -186,9 +186,9 @@ pub const FONT_7X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_10/font_7x14.raw"),
-        112,
+        crate::geometry::Size::new(112, 168),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_10,
     character_size: crate::geometry::Size::new(7, 14),
@@ -200,9 +200,9 @@ pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_10/font_7x14_bold.raw"),
-        112,
+        crate::geometry::Size::new(112, 168),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_10,
     character_size: crate::geometry::Size::new(7, 14),
@@ -214,9 +214,9 @@ pub const FONT_7X14_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_10/font_8x13.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_10,
     character_size: crate::geometry::Size::new(8, 13),
@@ -228,9 +228,9 @@ pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_10/font_8x13_bold.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_10,
     character_size: crate::geometry::Size::new(8, 13),
@@ -242,9 +242,9 @@ pub const FONT_8X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_10/font_8x13_italic.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_10,
     character_size: crate::geometry::Size::new(8, 13),
@@ -256,9 +256,9 @@ pub const FONT_8X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_10/font_9x15.raw"),
-        144,
+        crate::geometry::Size::new(144, 180),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_10,
     character_size: crate::geometry::Size::new(9, 15),
@@ -270,9 +270,9 @@ pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_10/font_9x15_bold.raw"),
-        144,
+        crate::geometry::Size::new(144, 180),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_10,
     character_size: crate::geometry::Size::new(9, 15),
@@ -284,9 +284,9 @@ pub const FONT_9X15_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_10/font_9x18.raw"),
-        144,
+        crate::geometry::Size::new(144, 216),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_10,
     character_size: crate::geometry::Size::new(9, 18),
@@ -298,9 +298,9 @@ pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_10/font_9x18_bold.raw"),
-        144,
+        crate::geometry::Size::new(144, 216),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_10,
     character_size: crate::geometry::Size::new(9, 18),
@@ -312,9 +312,9 @@ pub const FONT_9X18_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 10x20 pixel monospace font.
 pub const FONT_10X20: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_10/font_10x20.raw"),
-        160,
+        crate::geometry::Size::new(160, 240),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_10,
     character_size: crate::geometry::Size::new(10, 20),

--- a/src/mono_font/generated/iso_8859_13.rs
+++ b/src/mono_font/generated/iso_8859_13.rs
@@ -18,9 +18,9 @@
 
 /// 4x6 pixel monospace font.
 pub const FONT_4X6: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_13/font_4x6.raw"),
-        64,
+        crate::geometry::Size::new(64, 72),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_13,
     character_size: crate::geometry::Size::new(4, 6),
@@ -32,9 +32,9 @@ pub const FONT_4X6: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 5x7 pixel monospace font.
 pub const FONT_5X7: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_13/font_5x7.raw"),
-        80,
+        crate::geometry::Size::new(80, 84),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_13,
     character_size: crate::geometry::Size::new(5, 7),
@@ -46,9 +46,9 @@ pub const FONT_5X7: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 5x8 pixel monospace font.
 pub const FONT_5X8: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_13/font_5x8.raw"),
-        80,
+        crate::geometry::Size::new(80, 96),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_13,
     character_size: crate::geometry::Size::new(5, 8),
@@ -60,9 +60,9 @@ pub const FONT_5X8: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x9 pixel monospace font.
 pub const FONT_6X9: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_13/font_6x9.raw"),
-        96,
+        crate::geometry::Size::new(96, 108),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_13,
     character_size: crate::geometry::Size::new(6, 9),
@@ -74,9 +74,9 @@ pub const FONT_6X9: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x10 pixel monospace font.
 pub const FONT_6X10: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_13/font_6x10.raw"),
-        96,
+        crate::geometry::Size::new(96, 120),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_13,
     character_size: crate::geometry::Size::new(6, 10),
@@ -88,9 +88,9 @@ pub const FONT_6X10: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x12 pixel monospace font.
 pub const FONT_6X12: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_13/font_6x12.raw"),
-        96,
+        crate::geometry::Size::new(96, 144),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_13,
     character_size: crate::geometry::Size::new(6, 12),
@@ -102,9 +102,9 @@ pub const FONT_6X12: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_13/font_6x13.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_13,
     character_size: crate::geometry::Size::new(6, 13),
@@ -116,9 +116,9 @@ pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_13/font_6x13_bold.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_13,
     character_size: crate::geometry::Size::new(6, 13),
@@ -130,9 +130,9 @@ pub const FONT_6X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_13/font_6x13_italic.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_13,
     character_size: crate::geometry::Size::new(6, 13),
@@ -144,9 +144,9 @@ pub const FONT_6X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_13/font_7x13.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_13,
     character_size: crate::geometry::Size::new(7, 13),
@@ -158,9 +158,9 @@ pub const FONT_7X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_13/font_7x13_bold.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_13,
     character_size: crate::geometry::Size::new(7, 13),
@@ -172,9 +172,9 @@ pub const FONT_7X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_13/font_7x13_italic.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_13,
     character_size: crate::geometry::Size::new(7, 13),
@@ -186,9 +186,9 @@ pub const FONT_7X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_13/font_7x14.raw"),
-        112,
+        crate::geometry::Size::new(112, 168),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_13,
     character_size: crate::geometry::Size::new(7, 14),
@@ -200,9 +200,9 @@ pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_13/font_7x14_bold.raw"),
-        112,
+        crate::geometry::Size::new(112, 168),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_13,
     character_size: crate::geometry::Size::new(7, 14),
@@ -214,9 +214,9 @@ pub const FONT_7X14_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_13/font_8x13.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_13,
     character_size: crate::geometry::Size::new(8, 13),
@@ -228,9 +228,9 @@ pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_13/font_8x13_bold.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_13,
     character_size: crate::geometry::Size::new(8, 13),
@@ -242,9 +242,9 @@ pub const FONT_8X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_13/font_8x13_italic.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_13,
     character_size: crate::geometry::Size::new(8, 13),
@@ -256,9 +256,9 @@ pub const FONT_8X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_13/font_9x15.raw"),
-        144,
+        crate::geometry::Size::new(144, 180),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_13,
     character_size: crate::geometry::Size::new(9, 15),
@@ -270,9 +270,9 @@ pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_13/font_9x15_bold.raw"),
-        144,
+        crate::geometry::Size::new(144, 180),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_13,
     character_size: crate::geometry::Size::new(9, 15),
@@ -284,9 +284,9 @@ pub const FONT_9X15_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_13/font_9x18.raw"),
-        144,
+        crate::geometry::Size::new(144, 216),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_13,
     character_size: crate::geometry::Size::new(9, 18),
@@ -298,9 +298,9 @@ pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_13/font_9x18_bold.raw"),
-        144,
+        crate::geometry::Size::new(144, 216),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_13,
     character_size: crate::geometry::Size::new(9, 18),
@@ -312,9 +312,9 @@ pub const FONT_9X18_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 10x20 pixel monospace font.
 pub const FONT_10X20: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_13/font_10x20.raw"),
-        160,
+        crate::geometry::Size::new(160, 240),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_13,
     character_size: crate::geometry::Size::new(10, 20),

--- a/src/mono_font/generated/iso_8859_14.rs
+++ b/src/mono_font/generated/iso_8859_14.rs
@@ -18,9 +18,9 @@
 
 /// 4x6 pixel monospace font.
 pub const FONT_4X6: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_14/font_4x6.raw"),
-        64,
+        crate::geometry::Size::new(64, 72),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_14,
     character_size: crate::geometry::Size::new(4, 6),
@@ -32,9 +32,9 @@ pub const FONT_4X6: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 5x7 pixel monospace font.
 pub const FONT_5X7: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_14/font_5x7.raw"),
-        80,
+        crate::geometry::Size::new(80, 84),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_14,
     character_size: crate::geometry::Size::new(5, 7),
@@ -46,9 +46,9 @@ pub const FONT_5X7: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 5x8 pixel monospace font.
 pub const FONT_5X8: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_14/font_5x8.raw"),
-        80,
+        crate::geometry::Size::new(80, 96),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_14,
     character_size: crate::geometry::Size::new(5, 8),
@@ -60,9 +60,9 @@ pub const FONT_5X8: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x9 pixel monospace font.
 pub const FONT_6X9: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_14/font_6x9.raw"),
-        96,
+        crate::geometry::Size::new(96, 108),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_14,
     character_size: crate::geometry::Size::new(6, 9),
@@ -74,9 +74,9 @@ pub const FONT_6X9: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x10 pixel monospace font.
 pub const FONT_6X10: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_14/font_6x10.raw"),
-        96,
+        crate::geometry::Size::new(96, 120),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_14,
     character_size: crate::geometry::Size::new(6, 10),
@@ -88,9 +88,9 @@ pub const FONT_6X10: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x12 pixel monospace font.
 pub const FONT_6X12: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_14/font_6x12.raw"),
-        96,
+        crate::geometry::Size::new(96, 144),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_14,
     character_size: crate::geometry::Size::new(6, 12),
@@ -102,9 +102,9 @@ pub const FONT_6X12: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_14/font_6x13.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_14,
     character_size: crate::geometry::Size::new(6, 13),
@@ -116,9 +116,9 @@ pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_14/font_6x13_bold.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_14,
     character_size: crate::geometry::Size::new(6, 13),
@@ -130,9 +130,9 @@ pub const FONT_6X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_14/font_6x13_italic.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_14,
     character_size: crate::geometry::Size::new(6, 13),
@@ -144,9 +144,9 @@ pub const FONT_6X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_14/font_7x13.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_14,
     character_size: crate::geometry::Size::new(7, 13),
@@ -158,9 +158,9 @@ pub const FONT_7X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_14/font_7x13_bold.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_14,
     character_size: crate::geometry::Size::new(7, 13),
@@ -172,9 +172,9 @@ pub const FONT_7X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_14/font_7x13_italic.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_14,
     character_size: crate::geometry::Size::new(7, 13),
@@ -186,9 +186,9 @@ pub const FONT_7X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_14/font_7x14.raw"),
-        112,
+        crate::geometry::Size::new(112, 168),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_14,
     character_size: crate::geometry::Size::new(7, 14),
@@ -200,9 +200,9 @@ pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_14/font_7x14_bold.raw"),
-        112,
+        crate::geometry::Size::new(112, 168),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_14,
     character_size: crate::geometry::Size::new(7, 14),
@@ -214,9 +214,9 @@ pub const FONT_7X14_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_14/font_8x13.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_14,
     character_size: crate::geometry::Size::new(8, 13),
@@ -228,9 +228,9 @@ pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_14/font_8x13_bold.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_14,
     character_size: crate::geometry::Size::new(8, 13),
@@ -242,9 +242,9 @@ pub const FONT_8X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_14/font_8x13_italic.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_14,
     character_size: crate::geometry::Size::new(8, 13),
@@ -256,9 +256,9 @@ pub const FONT_8X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_14/font_9x15.raw"),
-        144,
+        crate::geometry::Size::new(144, 180),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_14,
     character_size: crate::geometry::Size::new(9, 15),
@@ -270,9 +270,9 @@ pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_14/font_9x15_bold.raw"),
-        144,
+        crate::geometry::Size::new(144, 180),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_14,
     character_size: crate::geometry::Size::new(9, 15),
@@ -284,9 +284,9 @@ pub const FONT_9X15_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_14/font_9x18.raw"),
-        144,
+        crate::geometry::Size::new(144, 216),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_14,
     character_size: crate::geometry::Size::new(9, 18),
@@ -298,9 +298,9 @@ pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_14/font_9x18_bold.raw"),
-        144,
+        crate::geometry::Size::new(144, 216),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_14,
     character_size: crate::geometry::Size::new(9, 18),
@@ -312,9 +312,9 @@ pub const FONT_9X18_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 10x20 pixel monospace font.
 pub const FONT_10X20: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_14/font_10x20.raw"),
-        160,
+        crate::geometry::Size::new(160, 240),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_14,
     character_size: crate::geometry::Size::new(10, 20),

--- a/src/mono_font/generated/iso_8859_15.rs
+++ b/src/mono_font/generated/iso_8859_15.rs
@@ -18,9 +18,9 @@
 
 /// 4x6 pixel monospace font.
 pub const FONT_4X6: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_15/font_4x6.raw"),
-        64,
+        crate::geometry::Size::new(64, 72),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_15,
     character_size: crate::geometry::Size::new(4, 6),
@@ -32,9 +32,9 @@ pub const FONT_4X6: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 5x7 pixel monospace font.
 pub const FONT_5X7: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_15/font_5x7.raw"),
-        80,
+        crate::geometry::Size::new(80, 84),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_15,
     character_size: crate::geometry::Size::new(5, 7),
@@ -46,9 +46,9 @@ pub const FONT_5X7: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 5x8 pixel monospace font.
 pub const FONT_5X8: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_15/font_5x8.raw"),
-        80,
+        crate::geometry::Size::new(80, 96),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_15,
     character_size: crate::geometry::Size::new(5, 8),
@@ -60,9 +60,9 @@ pub const FONT_5X8: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x9 pixel monospace font.
 pub const FONT_6X9: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_15/font_6x9.raw"),
-        96,
+        crate::geometry::Size::new(96, 108),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_15,
     character_size: crate::geometry::Size::new(6, 9),
@@ -74,9 +74,9 @@ pub const FONT_6X9: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x10 pixel monospace font.
 pub const FONT_6X10: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_15/font_6x10.raw"),
-        96,
+        crate::geometry::Size::new(96, 120),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_15,
     character_size: crate::geometry::Size::new(6, 10),
@@ -88,9 +88,9 @@ pub const FONT_6X10: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x12 pixel monospace font.
 pub const FONT_6X12: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_15/font_6x12.raw"),
-        96,
+        crate::geometry::Size::new(96, 144),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_15,
     character_size: crate::geometry::Size::new(6, 12),
@@ -102,9 +102,9 @@ pub const FONT_6X12: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_15/font_6x13.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_15,
     character_size: crate::geometry::Size::new(6, 13),
@@ -116,9 +116,9 @@ pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_15/font_6x13_bold.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_15,
     character_size: crate::geometry::Size::new(6, 13),
@@ -130,9 +130,9 @@ pub const FONT_6X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_15/font_6x13_italic.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_15,
     character_size: crate::geometry::Size::new(6, 13),
@@ -144,9 +144,9 @@ pub const FONT_6X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_15/font_7x13.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_15,
     character_size: crate::geometry::Size::new(7, 13),
@@ -158,9 +158,9 @@ pub const FONT_7X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_15/font_7x13_bold.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_15,
     character_size: crate::geometry::Size::new(7, 13),
@@ -172,9 +172,9 @@ pub const FONT_7X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_15/font_7x13_italic.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_15,
     character_size: crate::geometry::Size::new(7, 13),
@@ -186,9 +186,9 @@ pub const FONT_7X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_15/font_7x14.raw"),
-        112,
+        crate::geometry::Size::new(112, 168),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_15,
     character_size: crate::geometry::Size::new(7, 14),
@@ -200,9 +200,9 @@ pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_15/font_7x14_bold.raw"),
-        112,
+        crate::geometry::Size::new(112, 168),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_15,
     character_size: crate::geometry::Size::new(7, 14),
@@ -214,9 +214,9 @@ pub const FONT_7X14_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_15/font_8x13.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_15,
     character_size: crate::geometry::Size::new(8, 13),
@@ -228,9 +228,9 @@ pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_15/font_8x13_bold.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_15,
     character_size: crate::geometry::Size::new(8, 13),
@@ -242,9 +242,9 @@ pub const FONT_8X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_15/font_8x13_italic.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_15,
     character_size: crate::geometry::Size::new(8, 13),
@@ -256,9 +256,9 @@ pub const FONT_8X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_15/font_9x15.raw"),
-        144,
+        crate::geometry::Size::new(144, 180),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_15,
     character_size: crate::geometry::Size::new(9, 15),
@@ -270,9 +270,9 @@ pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_15/font_9x15_bold.raw"),
-        144,
+        crate::geometry::Size::new(144, 180),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_15,
     character_size: crate::geometry::Size::new(9, 15),
@@ -284,9 +284,9 @@ pub const FONT_9X15_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_15/font_9x18.raw"),
-        144,
+        crate::geometry::Size::new(144, 216),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_15,
     character_size: crate::geometry::Size::new(9, 18),
@@ -298,9 +298,9 @@ pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_15/font_9x18_bold.raw"),
-        144,
+        crate::geometry::Size::new(144, 216),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_15,
     character_size: crate::geometry::Size::new(9, 18),
@@ -312,9 +312,9 @@ pub const FONT_9X18_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 10x20 pixel monospace font.
 pub const FONT_10X20: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_15/font_10x20.raw"),
-        160,
+        crate::geometry::Size::new(160, 240),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_15,
     character_size: crate::geometry::Size::new(10, 20),

--- a/src/mono_font/generated/iso_8859_16.rs
+++ b/src/mono_font/generated/iso_8859_16.rs
@@ -18,9 +18,9 @@
 
 /// 4x6 pixel monospace font.
 pub const FONT_4X6: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_16/font_4x6.raw"),
-        64,
+        crate::geometry::Size::new(64, 72),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_16,
     character_size: crate::geometry::Size::new(4, 6),
@@ -32,9 +32,9 @@ pub const FONT_4X6: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 5x7 pixel monospace font.
 pub const FONT_5X7: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_16/font_5x7.raw"),
-        80,
+        crate::geometry::Size::new(80, 84),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_16,
     character_size: crate::geometry::Size::new(5, 7),
@@ -46,9 +46,9 @@ pub const FONT_5X7: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 5x8 pixel monospace font.
 pub const FONT_5X8: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_16/font_5x8.raw"),
-        80,
+        crate::geometry::Size::new(80, 96),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_16,
     character_size: crate::geometry::Size::new(5, 8),
@@ -60,9 +60,9 @@ pub const FONT_5X8: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x9 pixel monospace font.
 pub const FONT_6X9: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_16/font_6x9.raw"),
-        96,
+        crate::geometry::Size::new(96, 108),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_16,
     character_size: crate::geometry::Size::new(6, 9),
@@ -74,9 +74,9 @@ pub const FONT_6X9: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x10 pixel monospace font.
 pub const FONT_6X10: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_16/font_6x10.raw"),
-        96,
+        crate::geometry::Size::new(96, 120),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_16,
     character_size: crate::geometry::Size::new(6, 10),
@@ -88,9 +88,9 @@ pub const FONT_6X10: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x12 pixel monospace font.
 pub const FONT_6X12: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_16/font_6x12.raw"),
-        96,
+        crate::geometry::Size::new(96, 144),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_16,
     character_size: crate::geometry::Size::new(6, 12),
@@ -102,9 +102,9 @@ pub const FONT_6X12: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_16/font_6x13.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_16,
     character_size: crate::geometry::Size::new(6, 13),
@@ -116,9 +116,9 @@ pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_16/font_6x13_bold.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_16,
     character_size: crate::geometry::Size::new(6, 13),
@@ -130,9 +130,9 @@ pub const FONT_6X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_16/font_6x13_italic.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_16,
     character_size: crate::geometry::Size::new(6, 13),
@@ -144,9 +144,9 @@ pub const FONT_6X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_16/font_7x13.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_16,
     character_size: crate::geometry::Size::new(7, 13),
@@ -158,9 +158,9 @@ pub const FONT_7X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_16/font_7x13_bold.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_16,
     character_size: crate::geometry::Size::new(7, 13),
@@ -172,9 +172,9 @@ pub const FONT_7X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_16/font_7x13_italic.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_16,
     character_size: crate::geometry::Size::new(7, 13),
@@ -186,9 +186,9 @@ pub const FONT_7X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_16/font_7x14.raw"),
-        112,
+        crate::geometry::Size::new(112, 168),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_16,
     character_size: crate::geometry::Size::new(7, 14),
@@ -200,9 +200,9 @@ pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_16/font_7x14_bold.raw"),
-        112,
+        crate::geometry::Size::new(112, 168),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_16,
     character_size: crate::geometry::Size::new(7, 14),
@@ -214,9 +214,9 @@ pub const FONT_7X14_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_16/font_8x13.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_16,
     character_size: crate::geometry::Size::new(8, 13),
@@ -228,9 +228,9 @@ pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_16/font_8x13_bold.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_16,
     character_size: crate::geometry::Size::new(8, 13),
@@ -242,9 +242,9 @@ pub const FONT_8X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_16/font_8x13_italic.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_16,
     character_size: crate::geometry::Size::new(8, 13),
@@ -256,9 +256,9 @@ pub const FONT_8X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_16/font_9x15.raw"),
-        144,
+        crate::geometry::Size::new(144, 180),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_16,
     character_size: crate::geometry::Size::new(9, 15),
@@ -270,9 +270,9 @@ pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_16/font_9x15_bold.raw"),
-        144,
+        crate::geometry::Size::new(144, 180),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_16,
     character_size: crate::geometry::Size::new(9, 15),
@@ -284,9 +284,9 @@ pub const FONT_9X15_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_16/font_9x18.raw"),
-        144,
+        crate::geometry::Size::new(144, 216),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_16,
     character_size: crate::geometry::Size::new(9, 18),
@@ -298,9 +298,9 @@ pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_16/font_9x18_bold.raw"),
-        144,
+        crate::geometry::Size::new(144, 216),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_16,
     character_size: crate::geometry::Size::new(9, 18),
@@ -312,9 +312,9 @@ pub const FONT_9X18_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 10x20 pixel monospace font.
 pub const FONT_10X20: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_16/font_10x20.raw"),
-        160,
+        crate::geometry::Size::new(160, 240),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_16,
     character_size: crate::geometry::Size::new(10, 20),

--- a/src/mono_font/generated/iso_8859_2.rs
+++ b/src/mono_font/generated/iso_8859_2.rs
@@ -18,9 +18,9 @@
 
 /// 4x6 pixel monospace font.
 pub const FONT_4X6: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_2/font_4x6.raw"),
-        64,
+        crate::geometry::Size::new(64, 72),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_2,
     character_size: crate::geometry::Size::new(4, 6),
@@ -32,9 +32,9 @@ pub const FONT_4X6: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 5x7 pixel monospace font.
 pub const FONT_5X7: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_2/font_5x7.raw"),
-        80,
+        crate::geometry::Size::new(80, 84),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_2,
     character_size: crate::geometry::Size::new(5, 7),
@@ -46,9 +46,9 @@ pub const FONT_5X7: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 5x8 pixel monospace font.
 pub const FONT_5X8: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_2/font_5x8.raw"),
-        80,
+        crate::geometry::Size::new(80, 96),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_2,
     character_size: crate::geometry::Size::new(5, 8),
@@ -60,9 +60,9 @@ pub const FONT_5X8: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x9 pixel monospace font.
 pub const FONT_6X9: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_2/font_6x9.raw"),
-        96,
+        crate::geometry::Size::new(96, 108),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_2,
     character_size: crate::geometry::Size::new(6, 9),
@@ -74,9 +74,9 @@ pub const FONT_6X9: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x10 pixel monospace font.
 pub const FONT_6X10: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_2/font_6x10.raw"),
-        96,
+        crate::geometry::Size::new(96, 120),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_2,
     character_size: crate::geometry::Size::new(6, 10),
@@ -88,9 +88,9 @@ pub const FONT_6X10: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x12 pixel monospace font.
 pub const FONT_6X12: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_2/font_6x12.raw"),
-        96,
+        crate::geometry::Size::new(96, 144),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_2,
     character_size: crate::geometry::Size::new(6, 12),
@@ -102,9 +102,9 @@ pub const FONT_6X12: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_2/font_6x13.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_2,
     character_size: crate::geometry::Size::new(6, 13),
@@ -116,9 +116,9 @@ pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_2/font_6x13_bold.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_2,
     character_size: crate::geometry::Size::new(6, 13),
@@ -130,9 +130,9 @@ pub const FONT_6X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_2/font_6x13_italic.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_2,
     character_size: crate::geometry::Size::new(6, 13),
@@ -144,9 +144,9 @@ pub const FONT_6X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_2/font_7x13.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_2,
     character_size: crate::geometry::Size::new(7, 13),
@@ -158,9 +158,9 @@ pub const FONT_7X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_2/font_7x13_bold.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_2,
     character_size: crate::geometry::Size::new(7, 13),
@@ -172,9 +172,9 @@ pub const FONT_7X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_2/font_7x13_italic.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_2,
     character_size: crate::geometry::Size::new(7, 13),
@@ -186,9 +186,9 @@ pub const FONT_7X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_2/font_7x14.raw"),
-        112,
+        crate::geometry::Size::new(112, 168),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_2,
     character_size: crate::geometry::Size::new(7, 14),
@@ -200,9 +200,9 @@ pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_2/font_7x14_bold.raw"),
-        112,
+        crate::geometry::Size::new(112, 168),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_2,
     character_size: crate::geometry::Size::new(7, 14),
@@ -214,9 +214,9 @@ pub const FONT_7X14_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_2/font_8x13.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_2,
     character_size: crate::geometry::Size::new(8, 13),
@@ -228,9 +228,9 @@ pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_2/font_8x13_bold.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_2,
     character_size: crate::geometry::Size::new(8, 13),
@@ -242,9 +242,9 @@ pub const FONT_8X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_2/font_8x13_italic.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_2,
     character_size: crate::geometry::Size::new(8, 13),
@@ -256,9 +256,9 @@ pub const FONT_8X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_2/font_9x15.raw"),
-        144,
+        crate::geometry::Size::new(144, 180),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_2,
     character_size: crate::geometry::Size::new(9, 15),
@@ -270,9 +270,9 @@ pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_2/font_9x15_bold.raw"),
-        144,
+        crate::geometry::Size::new(144, 180),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_2,
     character_size: crate::geometry::Size::new(9, 15),
@@ -284,9 +284,9 @@ pub const FONT_9X15_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_2/font_9x18.raw"),
-        144,
+        crate::geometry::Size::new(144, 216),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_2,
     character_size: crate::geometry::Size::new(9, 18),
@@ -298,9 +298,9 @@ pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_2/font_9x18_bold.raw"),
-        144,
+        crate::geometry::Size::new(144, 216),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_2,
     character_size: crate::geometry::Size::new(9, 18),
@@ -312,9 +312,9 @@ pub const FONT_9X18_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 10x20 pixel monospace font.
 pub const FONT_10X20: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_2/font_10x20.raw"),
-        160,
+        crate::geometry::Size::new(160, 240),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_2,
     character_size: crate::geometry::Size::new(10, 20),

--- a/src/mono_font/generated/iso_8859_3.rs
+++ b/src/mono_font/generated/iso_8859_3.rs
@@ -18,9 +18,9 @@
 
 /// 4x6 pixel monospace font.
 pub const FONT_4X6: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_3/font_4x6.raw"),
-        64,
+        crate::geometry::Size::new(64, 72),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_3,
     character_size: crate::geometry::Size::new(4, 6),
@@ -32,9 +32,9 @@ pub const FONT_4X6: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 5x7 pixel monospace font.
 pub const FONT_5X7: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_3/font_5x7.raw"),
-        80,
+        crate::geometry::Size::new(80, 84),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_3,
     character_size: crate::geometry::Size::new(5, 7),
@@ -46,9 +46,9 @@ pub const FONT_5X7: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 5x8 pixel monospace font.
 pub const FONT_5X8: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_3/font_5x8.raw"),
-        80,
+        crate::geometry::Size::new(80, 96),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_3,
     character_size: crate::geometry::Size::new(5, 8),
@@ -60,9 +60,9 @@ pub const FONT_5X8: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x9 pixel monospace font.
 pub const FONT_6X9: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_3/font_6x9.raw"),
-        96,
+        crate::geometry::Size::new(96, 108),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_3,
     character_size: crate::geometry::Size::new(6, 9),
@@ -74,9 +74,9 @@ pub const FONT_6X9: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x10 pixel monospace font.
 pub const FONT_6X10: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_3/font_6x10.raw"),
-        96,
+        crate::geometry::Size::new(96, 120),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_3,
     character_size: crate::geometry::Size::new(6, 10),
@@ -88,9 +88,9 @@ pub const FONT_6X10: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x12 pixel monospace font.
 pub const FONT_6X12: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_3/font_6x12.raw"),
-        96,
+        crate::geometry::Size::new(96, 144),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_3,
     character_size: crate::geometry::Size::new(6, 12),
@@ -102,9 +102,9 @@ pub const FONT_6X12: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_3/font_6x13.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_3,
     character_size: crate::geometry::Size::new(6, 13),
@@ -116,9 +116,9 @@ pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_3/font_6x13_bold.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_3,
     character_size: crate::geometry::Size::new(6, 13),
@@ -130,9 +130,9 @@ pub const FONT_6X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_3/font_6x13_italic.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_3,
     character_size: crate::geometry::Size::new(6, 13),
@@ -144,9 +144,9 @@ pub const FONT_6X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_3/font_7x13.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_3,
     character_size: crate::geometry::Size::new(7, 13),
@@ -158,9 +158,9 @@ pub const FONT_7X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_3/font_7x13_bold.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_3,
     character_size: crate::geometry::Size::new(7, 13),
@@ -172,9 +172,9 @@ pub const FONT_7X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_3/font_7x13_italic.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_3,
     character_size: crate::geometry::Size::new(7, 13),
@@ -186,9 +186,9 @@ pub const FONT_7X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_3/font_7x14.raw"),
-        112,
+        crate::geometry::Size::new(112, 168),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_3,
     character_size: crate::geometry::Size::new(7, 14),
@@ -200,9 +200,9 @@ pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_3/font_7x14_bold.raw"),
-        112,
+        crate::geometry::Size::new(112, 168),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_3,
     character_size: crate::geometry::Size::new(7, 14),
@@ -214,9 +214,9 @@ pub const FONT_7X14_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_3/font_8x13.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_3,
     character_size: crate::geometry::Size::new(8, 13),
@@ -228,9 +228,9 @@ pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_3/font_8x13_bold.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_3,
     character_size: crate::geometry::Size::new(8, 13),
@@ -242,9 +242,9 @@ pub const FONT_8X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_3/font_8x13_italic.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_3,
     character_size: crate::geometry::Size::new(8, 13),
@@ -256,9 +256,9 @@ pub const FONT_8X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_3/font_9x15.raw"),
-        144,
+        crate::geometry::Size::new(144, 180),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_3,
     character_size: crate::geometry::Size::new(9, 15),
@@ -270,9 +270,9 @@ pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_3/font_9x15_bold.raw"),
-        144,
+        crate::geometry::Size::new(144, 180),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_3,
     character_size: crate::geometry::Size::new(9, 15),
@@ -284,9 +284,9 @@ pub const FONT_9X15_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_3/font_9x18.raw"),
-        144,
+        crate::geometry::Size::new(144, 216),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_3,
     character_size: crate::geometry::Size::new(9, 18),
@@ -298,9 +298,9 @@ pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_3/font_9x18_bold.raw"),
-        144,
+        crate::geometry::Size::new(144, 216),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_3,
     character_size: crate::geometry::Size::new(9, 18),
@@ -312,9 +312,9 @@ pub const FONT_9X18_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 10x20 pixel monospace font.
 pub const FONT_10X20: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_3/font_10x20.raw"),
-        160,
+        crate::geometry::Size::new(160, 240),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_3,
     character_size: crate::geometry::Size::new(10, 20),

--- a/src/mono_font/generated/iso_8859_4.rs
+++ b/src/mono_font/generated/iso_8859_4.rs
@@ -18,9 +18,9 @@
 
 /// 4x6 pixel monospace font.
 pub const FONT_4X6: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_4/font_4x6.raw"),
-        64,
+        crate::geometry::Size::new(64, 72),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_4,
     character_size: crate::geometry::Size::new(4, 6),
@@ -32,9 +32,9 @@ pub const FONT_4X6: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 5x7 pixel monospace font.
 pub const FONT_5X7: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_4/font_5x7.raw"),
-        80,
+        crate::geometry::Size::new(80, 84),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_4,
     character_size: crate::geometry::Size::new(5, 7),
@@ -46,9 +46,9 @@ pub const FONT_5X7: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 5x8 pixel monospace font.
 pub const FONT_5X8: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_4/font_5x8.raw"),
-        80,
+        crate::geometry::Size::new(80, 96),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_4,
     character_size: crate::geometry::Size::new(5, 8),
@@ -60,9 +60,9 @@ pub const FONT_5X8: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x9 pixel monospace font.
 pub const FONT_6X9: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_4/font_6x9.raw"),
-        96,
+        crate::geometry::Size::new(96, 108),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_4,
     character_size: crate::geometry::Size::new(6, 9),
@@ -74,9 +74,9 @@ pub const FONT_6X9: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x10 pixel monospace font.
 pub const FONT_6X10: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_4/font_6x10.raw"),
-        96,
+        crate::geometry::Size::new(96, 120),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_4,
     character_size: crate::geometry::Size::new(6, 10),
@@ -88,9 +88,9 @@ pub const FONT_6X10: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x12 pixel monospace font.
 pub const FONT_6X12: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_4/font_6x12.raw"),
-        96,
+        crate::geometry::Size::new(96, 144),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_4,
     character_size: crate::geometry::Size::new(6, 12),
@@ -102,9 +102,9 @@ pub const FONT_6X12: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_4/font_6x13.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_4,
     character_size: crate::geometry::Size::new(6, 13),
@@ -116,9 +116,9 @@ pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_4/font_6x13_bold.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_4,
     character_size: crate::geometry::Size::new(6, 13),
@@ -130,9 +130,9 @@ pub const FONT_6X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_4/font_6x13_italic.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_4,
     character_size: crate::geometry::Size::new(6, 13),
@@ -144,9 +144,9 @@ pub const FONT_6X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_4/font_7x13.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_4,
     character_size: crate::geometry::Size::new(7, 13),
@@ -158,9 +158,9 @@ pub const FONT_7X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_4/font_7x13_bold.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_4,
     character_size: crate::geometry::Size::new(7, 13),
@@ -172,9 +172,9 @@ pub const FONT_7X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_4/font_7x13_italic.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_4,
     character_size: crate::geometry::Size::new(7, 13),
@@ -186,9 +186,9 @@ pub const FONT_7X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_4/font_7x14.raw"),
-        112,
+        crate::geometry::Size::new(112, 168),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_4,
     character_size: crate::geometry::Size::new(7, 14),
@@ -200,9 +200,9 @@ pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_4/font_7x14_bold.raw"),
-        112,
+        crate::geometry::Size::new(112, 168),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_4,
     character_size: crate::geometry::Size::new(7, 14),
@@ -214,9 +214,9 @@ pub const FONT_7X14_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_4/font_8x13.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_4,
     character_size: crate::geometry::Size::new(8, 13),
@@ -228,9 +228,9 @@ pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_4/font_8x13_bold.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_4,
     character_size: crate::geometry::Size::new(8, 13),
@@ -242,9 +242,9 @@ pub const FONT_8X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_4/font_8x13_italic.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_4,
     character_size: crate::geometry::Size::new(8, 13),
@@ -256,9 +256,9 @@ pub const FONT_8X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_4/font_9x15.raw"),
-        144,
+        crate::geometry::Size::new(144, 180),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_4,
     character_size: crate::geometry::Size::new(9, 15),
@@ -270,9 +270,9 @@ pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_4/font_9x15_bold.raw"),
-        144,
+        crate::geometry::Size::new(144, 180),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_4,
     character_size: crate::geometry::Size::new(9, 15),
@@ -284,9 +284,9 @@ pub const FONT_9X15_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_4/font_9x18.raw"),
-        144,
+        crate::geometry::Size::new(144, 216),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_4,
     character_size: crate::geometry::Size::new(9, 18),
@@ -298,9 +298,9 @@ pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_4/font_9x18_bold.raw"),
-        144,
+        crate::geometry::Size::new(144, 216),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_4,
     character_size: crate::geometry::Size::new(9, 18),
@@ -312,9 +312,9 @@ pub const FONT_9X18_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 10x20 pixel monospace font.
 pub const FONT_10X20: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_4/font_10x20.raw"),
-        160,
+        crate::geometry::Size::new(160, 240),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_4,
     character_size: crate::geometry::Size::new(10, 20),

--- a/src/mono_font/generated/iso_8859_5.rs
+++ b/src/mono_font/generated/iso_8859_5.rs
@@ -18,9 +18,9 @@
 
 /// 4x6 pixel monospace font.
 pub const FONT_4X6: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_5/font_4x6.raw"),
-        64,
+        crate::geometry::Size::new(64, 72),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_5,
     character_size: crate::geometry::Size::new(4, 6),
@@ -32,9 +32,9 @@ pub const FONT_4X6: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 5x7 pixel monospace font.
 pub const FONT_5X7: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_5/font_5x7.raw"),
-        80,
+        crate::geometry::Size::new(80, 84),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_5,
     character_size: crate::geometry::Size::new(5, 7),
@@ -46,9 +46,9 @@ pub const FONT_5X7: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 5x8 pixel monospace font.
 pub const FONT_5X8: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_5/font_5x8.raw"),
-        80,
+        crate::geometry::Size::new(80, 96),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_5,
     character_size: crate::geometry::Size::new(5, 8),
@@ -60,9 +60,9 @@ pub const FONT_5X8: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x9 pixel monospace font.
 pub const FONT_6X9: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_5/font_6x9.raw"),
-        96,
+        crate::geometry::Size::new(96, 108),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_5,
     character_size: crate::geometry::Size::new(6, 9),
@@ -74,9 +74,9 @@ pub const FONT_6X9: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x10 pixel monospace font.
 pub const FONT_6X10: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_5/font_6x10.raw"),
-        96,
+        crate::geometry::Size::new(96, 120),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_5,
     character_size: crate::geometry::Size::new(6, 10),
@@ -88,9 +88,9 @@ pub const FONT_6X10: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x12 pixel monospace font.
 pub const FONT_6X12: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_5/font_6x12.raw"),
-        96,
+        crate::geometry::Size::new(96, 144),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_5,
     character_size: crate::geometry::Size::new(6, 12),
@@ -102,9 +102,9 @@ pub const FONT_6X12: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_5/font_6x13.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_5,
     character_size: crate::geometry::Size::new(6, 13),
@@ -116,9 +116,9 @@ pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_5/font_6x13_bold.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_5,
     character_size: crate::geometry::Size::new(6, 13),
@@ -130,9 +130,9 @@ pub const FONT_6X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_5/font_6x13_italic.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_5,
     character_size: crate::geometry::Size::new(6, 13),
@@ -144,9 +144,9 @@ pub const FONT_6X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_5/font_7x13.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_5,
     character_size: crate::geometry::Size::new(7, 13),
@@ -158,9 +158,9 @@ pub const FONT_7X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_5/font_7x13_bold.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_5,
     character_size: crate::geometry::Size::new(7, 13),
@@ -172,9 +172,9 @@ pub const FONT_7X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_5/font_7x13_italic.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_5,
     character_size: crate::geometry::Size::new(7, 13),
@@ -186,9 +186,9 @@ pub const FONT_7X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_5/font_7x14.raw"),
-        112,
+        crate::geometry::Size::new(112, 168),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_5,
     character_size: crate::geometry::Size::new(7, 14),
@@ -200,9 +200,9 @@ pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_5/font_7x14_bold.raw"),
-        112,
+        crate::geometry::Size::new(112, 168),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_5,
     character_size: crate::geometry::Size::new(7, 14),
@@ -214,9 +214,9 @@ pub const FONT_7X14_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_5/font_8x13.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_5,
     character_size: crate::geometry::Size::new(8, 13),
@@ -228,9 +228,9 @@ pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_5/font_8x13_bold.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_5,
     character_size: crate::geometry::Size::new(8, 13),
@@ -242,9 +242,9 @@ pub const FONT_8X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_5/font_8x13_italic.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_5,
     character_size: crate::geometry::Size::new(8, 13),
@@ -256,9 +256,9 @@ pub const FONT_8X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_5/font_9x15.raw"),
-        144,
+        crate::geometry::Size::new(144, 180),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_5,
     character_size: crate::geometry::Size::new(9, 15),
@@ -270,9 +270,9 @@ pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_5/font_9x15_bold.raw"),
-        144,
+        crate::geometry::Size::new(144, 180),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_5,
     character_size: crate::geometry::Size::new(9, 15),
@@ -284,9 +284,9 @@ pub const FONT_9X15_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_5/font_9x18.raw"),
-        144,
+        crate::geometry::Size::new(144, 216),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_5,
     character_size: crate::geometry::Size::new(9, 18),
@@ -298,9 +298,9 @@ pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_5/font_9x18_bold.raw"),
-        144,
+        crate::geometry::Size::new(144, 216),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_5,
     character_size: crate::geometry::Size::new(9, 18),
@@ -312,9 +312,9 @@ pub const FONT_9X18_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 10x20 pixel monospace font.
 pub const FONT_10X20: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_5/font_10x20.raw"),
-        160,
+        crate::geometry::Size::new(160, 240),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_5,
     character_size: crate::geometry::Size::new(10, 20),

--- a/src/mono_font/generated/iso_8859_7.rs
+++ b/src/mono_font/generated/iso_8859_7.rs
@@ -18,9 +18,9 @@
 
 /// 4x6 pixel monospace font.
 pub const FONT_4X6: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_7/font_4x6.raw"),
-        64,
+        crate::geometry::Size::new(64, 72),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_7,
     character_size: crate::geometry::Size::new(4, 6),
@@ -32,9 +32,9 @@ pub const FONT_4X6: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 5x7 pixel monospace font.
 pub const FONT_5X7: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_7/font_5x7.raw"),
-        80,
+        crate::geometry::Size::new(80, 84),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_7,
     character_size: crate::geometry::Size::new(5, 7),
@@ -46,9 +46,9 @@ pub const FONT_5X7: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 5x8 pixel monospace font.
 pub const FONT_5X8: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_7/font_5x8.raw"),
-        80,
+        crate::geometry::Size::new(80, 96),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_7,
     character_size: crate::geometry::Size::new(5, 8),
@@ -60,9 +60,9 @@ pub const FONT_5X8: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x9 pixel monospace font.
 pub const FONT_6X9: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_7/font_6x9.raw"),
-        96,
+        crate::geometry::Size::new(96, 108),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_7,
     character_size: crate::geometry::Size::new(6, 9),
@@ -74,9 +74,9 @@ pub const FONT_6X9: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x10 pixel monospace font.
 pub const FONT_6X10: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_7/font_6x10.raw"),
-        96,
+        crate::geometry::Size::new(96, 120),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_7,
     character_size: crate::geometry::Size::new(6, 10),
@@ -88,9 +88,9 @@ pub const FONT_6X10: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x12 pixel monospace font.
 pub const FONT_6X12: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_7/font_6x12.raw"),
-        96,
+        crate::geometry::Size::new(96, 144),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_7,
     character_size: crate::geometry::Size::new(6, 12),
@@ -102,9 +102,9 @@ pub const FONT_6X12: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_7/font_6x13.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_7,
     character_size: crate::geometry::Size::new(6, 13),
@@ -116,9 +116,9 @@ pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_7/font_6x13_bold.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_7,
     character_size: crate::geometry::Size::new(6, 13),
@@ -130,9 +130,9 @@ pub const FONT_6X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_7/font_6x13_italic.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_7,
     character_size: crate::geometry::Size::new(6, 13),
@@ -144,9 +144,9 @@ pub const FONT_6X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_7/font_7x13.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_7,
     character_size: crate::geometry::Size::new(7, 13),
@@ -158,9 +158,9 @@ pub const FONT_7X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_7/font_7x13_bold.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_7,
     character_size: crate::geometry::Size::new(7, 13),
@@ -172,9 +172,9 @@ pub const FONT_7X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_7/font_7x13_italic.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_7,
     character_size: crate::geometry::Size::new(7, 13),
@@ -186,9 +186,9 @@ pub const FONT_7X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_7/font_7x14.raw"),
-        112,
+        crate::geometry::Size::new(112, 168),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_7,
     character_size: crate::geometry::Size::new(7, 14),
@@ -200,9 +200,9 @@ pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_7/font_7x14_bold.raw"),
-        112,
+        crate::geometry::Size::new(112, 168),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_7,
     character_size: crate::geometry::Size::new(7, 14),
@@ -214,9 +214,9 @@ pub const FONT_7X14_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_7/font_8x13.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_7,
     character_size: crate::geometry::Size::new(8, 13),
@@ -228,9 +228,9 @@ pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_7/font_8x13_bold.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_7,
     character_size: crate::geometry::Size::new(8, 13),
@@ -242,9 +242,9 @@ pub const FONT_8X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_7/font_8x13_italic.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_7,
     character_size: crate::geometry::Size::new(8, 13),
@@ -256,9 +256,9 @@ pub const FONT_8X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_7/font_9x15.raw"),
-        144,
+        crate::geometry::Size::new(144, 180),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_7,
     character_size: crate::geometry::Size::new(9, 15),
@@ -270,9 +270,9 @@ pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_7/font_9x15_bold.raw"),
-        144,
+        crate::geometry::Size::new(144, 180),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_7,
     character_size: crate::geometry::Size::new(9, 15),
@@ -284,9 +284,9 @@ pub const FONT_9X15_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_7/font_9x18.raw"),
-        144,
+        crate::geometry::Size::new(144, 216),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_7,
     character_size: crate::geometry::Size::new(9, 18),
@@ -298,9 +298,9 @@ pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_7/font_9x18_bold.raw"),
-        144,
+        crate::geometry::Size::new(144, 216),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_7,
     character_size: crate::geometry::Size::new(9, 18),
@@ -312,9 +312,9 @@ pub const FONT_9X18_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 10x20 pixel monospace font.
 pub const FONT_10X20: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_7/font_10x20.raw"),
-        160,
+        crate::geometry::Size::new(160, 240),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_7,
     character_size: crate::geometry::Size::new(10, 20),

--- a/src/mono_font/generated/iso_8859_9.rs
+++ b/src/mono_font/generated/iso_8859_9.rs
@@ -18,9 +18,9 @@
 
 /// 4x6 pixel monospace font.
 pub const FONT_4X6: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_9/font_4x6.raw"),
-        64,
+        crate::geometry::Size::new(64, 72),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_9,
     character_size: crate::geometry::Size::new(4, 6),
@@ -32,9 +32,9 @@ pub const FONT_4X6: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 5x7 pixel monospace font.
 pub const FONT_5X7: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_9/font_5x7.raw"),
-        80,
+        crate::geometry::Size::new(80, 84),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_9,
     character_size: crate::geometry::Size::new(5, 7),
@@ -46,9 +46,9 @@ pub const FONT_5X7: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 5x8 pixel monospace font.
 pub const FONT_5X8: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_9/font_5x8.raw"),
-        80,
+        crate::geometry::Size::new(80, 96),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_9,
     character_size: crate::geometry::Size::new(5, 8),
@@ -60,9 +60,9 @@ pub const FONT_5X8: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x9 pixel monospace font.
 pub const FONT_6X9: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_9/font_6x9.raw"),
-        96,
+        crate::geometry::Size::new(96, 108),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_9,
     character_size: crate::geometry::Size::new(6, 9),
@@ -74,9 +74,9 @@ pub const FONT_6X9: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x10 pixel monospace font.
 pub const FONT_6X10: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_9/font_6x10.raw"),
-        96,
+        crate::geometry::Size::new(96, 120),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_9,
     character_size: crate::geometry::Size::new(6, 10),
@@ -88,9 +88,9 @@ pub const FONT_6X10: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x12 pixel monospace font.
 pub const FONT_6X12: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_9/font_6x12.raw"),
-        96,
+        crate::geometry::Size::new(96, 144),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_9,
     character_size: crate::geometry::Size::new(6, 12),
@@ -102,9 +102,9 @@ pub const FONT_6X12: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_9/font_6x13.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_9,
     character_size: crate::geometry::Size::new(6, 13),
@@ -116,9 +116,9 @@ pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_9/font_6x13_bold.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_9,
     character_size: crate::geometry::Size::new(6, 13),
@@ -130,9 +130,9 @@ pub const FONT_6X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_9/font_6x13_italic.raw"),
-        96,
+        crate::geometry::Size::new(96, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_9,
     character_size: crate::geometry::Size::new(6, 13),
@@ -144,9 +144,9 @@ pub const FONT_6X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_9/font_7x13.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_9,
     character_size: crate::geometry::Size::new(7, 13),
@@ -158,9 +158,9 @@ pub const FONT_7X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_9/font_7x13_bold.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_9,
     character_size: crate::geometry::Size::new(7, 13),
@@ -172,9 +172,9 @@ pub const FONT_7X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 7x13 pixel monospace font.
 pub const FONT_7X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_9/font_7x13_italic.raw"),
-        112,
+        crate::geometry::Size::new(112, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_9,
     character_size: crate::geometry::Size::new(7, 13),
@@ -186,9 +186,9 @@ pub const FONT_7X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_9/font_7x14.raw"),
-        112,
+        crate::geometry::Size::new(112, 168),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_9,
     character_size: crate::geometry::Size::new(7, 14),
@@ -200,9 +200,9 @@ pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_9/font_7x14_bold.raw"),
-        112,
+        crate::geometry::Size::new(112, 168),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_9,
     character_size: crate::geometry::Size::new(7, 14),
@@ -214,9 +214,9 @@ pub const FONT_7X14_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_9/font_8x13.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_9,
     character_size: crate::geometry::Size::new(8, 13),
@@ -228,9 +228,9 @@ pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_9/font_8x13_bold.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_9,
     character_size: crate::geometry::Size::new(8, 13),
@@ -242,9 +242,9 @@ pub const FONT_8X13_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_9/font_8x13_italic.raw"),
-        128,
+        crate::geometry::Size::new(128, 156),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_9,
     character_size: crate::geometry::Size::new(8, 13),
@@ -256,9 +256,9 @@ pub const FONT_8X13_ITALIC: crate::mono_font::MonoFont = crate::mono_font::MonoF
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_9/font_9x15.raw"),
-        144,
+        crate::geometry::Size::new(144, 180),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_9,
     character_size: crate::geometry::Size::new(9, 15),
@@ -270,9 +270,9 @@ pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_9/font_9x15_bold.raw"),
-        144,
+        crate::geometry::Size::new(144, 180),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_9,
     character_size: crate::geometry::Size::new(9, 15),
@@ -284,9 +284,9 @@ pub const FONT_9X15_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_9/font_9x18.raw"),
-        144,
+        crate::geometry::Size::new(144, 216),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_9,
     character_size: crate::geometry::Size::new(9, 18),
@@ -298,9 +298,9 @@ pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_9/font_9x18_bold.raw"),
-        144,
+        crate::geometry::Size::new(144, 216),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_9,
     character_size: crate::geometry::Size::new(9, 18),
@@ -312,9 +312,9 @@ pub const FONT_9X18_BOLD: crate::mono_font::MonoFont = crate::mono_font::MonoFon
 
 /// 10x20 pixel monospace font.
 pub const FONT_10X20: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/iso_8859_9/font_10x20.raw"),
-        160,
+        crate::geometry::Size::new(160, 240),
     ),
     glyph_mapping: &crate::mono_font::mapping::ISO_8859_9,
     character_size: crate::geometry::Size::new(10, 20),

--- a/src/mono_font/generated/jis_x0201.rs
+++ b/src/mono_font/generated/jis_x0201.rs
@@ -13,9 +13,9 @@
 
 /// 6x13 pixel monospace font.
 pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/jis_x0201/font_6x13.raw"),
-        96,
+        crate::geometry::Size::new(96, 130),
     ),
     glyph_mapping: &crate::mono_font::mapping::JIS_X0201,
     character_size: crate::geometry::Size::new(6, 13),
@@ -27,9 +27,9 @@ pub const FONT_6X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 7x14 pixel monospace font.
 pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/jis_x0201/font_7x14.raw"),
-        112,
+        crate::geometry::Size::new(112, 140),
     ),
     glyph_mapping: &crate::mono_font::mapping::JIS_X0201,
     character_size: crate::geometry::Size::new(7, 14),
@@ -41,9 +41,9 @@ pub const FONT_7X14: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 8x13 pixel monospace font.
 pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/jis_x0201/font_8x13.raw"),
-        128,
+        crate::geometry::Size::new(128, 130),
     ),
     glyph_mapping: &crate::mono_font::mapping::JIS_X0201,
     character_size: crate::geometry::Size::new(8, 13),
@@ -55,9 +55,9 @@ pub const FONT_8X13: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x15 pixel monospace font.
 pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/jis_x0201/font_9x15.raw"),
-        144,
+        crate::geometry::Size::new(144, 150),
     ),
     glyph_mapping: &crate::mono_font::mapping::JIS_X0201,
     character_size: crate::geometry::Size::new(9, 15),
@@ -69,9 +69,9 @@ pub const FONT_9X15: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 9x18 pixel monospace font.
 pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/jis_x0201/font_9x18.raw"),
-        144,
+        crate::geometry::Size::new(144, 180),
     ),
     glyph_mapping: &crate::mono_font::mapping::JIS_X0201,
     character_size: crate::geometry::Size::new(9, 18),
@@ -83,9 +83,9 @@ pub const FONT_9X18: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
 
 /// 10x20 pixel monospace font.
 pub const FONT_10X20: crate::mono_font::MonoFont = crate::mono_font::MonoFont {
-    image: crate::image::ImageRaw::new(
+    image: crate::image::ImageRaw::new_const(
         include_bytes!("../../../fonts/raw/jis_x0201/font_10x20.raw"),
-        160,
+        crate::geometry::Size::new(160, 200),
     ),
     glyph_mapping: &crate::mono_font::mapping::JIS_X0201,
     character_size: crate::geometry::Size::new(10, 20),

--- a/src/mono_font/mod.rs
+++ b/src/mono_font/mod.rs
@@ -215,7 +215,7 @@ impl DecorationDimensions {
 }
 
 const NULL_FONT: MonoFont = MonoFont {
-    image: ImageRaw::new(&[], 1),
+    image: ImageRaw::new_const(&[], Size::zero()),
     character_size: Size::zero(),
     character_spacing: 0,
     baseline: 0,
@@ -401,7 +401,7 @@ pub(crate) mod tests {
     #[test]
     fn zero_width_image() {
         const ZERO_WIDTH: MonoFont = MonoFont {
-            image: ImageRaw::new(&[], 0),
+            image: ImageRaw::new_const(&[], Size::zero()),
             character_size: Size::zero(),
             character_spacing: 0,
             baseline: 0,
@@ -425,7 +425,7 @@ pub(crate) mod tests {
     #[test]
     fn image_width_less_than_character_width() {
         const NOT_WIDE_ENOUGH: MonoFont = MonoFont {
-            image: ImageRaw::new(&[0xAA, 0xAA], 4),
+            image: ImageRaw::new_const(&[0xAA, 0xAA], Size::new(4, 2)),
             character_size: Size::new(5, 2),
             character_spacing: 0,
             baseline: 0,
@@ -449,7 +449,7 @@ pub(crate) mod tests {
     #[test]
     fn image_height_less_than_character_height() {
         const NOT_HIGH_ENOUGH: MonoFont = MonoFont {
-            image: ImageRaw::new(&[0xAA, 0xAA], 4),
+            image: ImageRaw::new_const(&[0xAA, 0xAA], Size::new(4, 2)),
             character_size: Size::new(4, 1),
             character_spacing: 0,
             baseline: 0,

--- a/src/mono_font/mono_text_style.rs
+++ b/src/mono_font/mono_text_style.rs
@@ -1204,7 +1204,7 @@ mod tests {
     fn builder_change_font() {
         let _style = {
             let font = MonoFont {
-                image: ImageRaw::new(&[1, 2, 3], 1),
+                image: ImageRaw::new(&[1, 2, 3], Size::new(1, 3)).unwrap(),
                 character_size: Size::new(1, 2),
                 character_spacing: 0,
                 baseline: 0,

--- a/tests/font.rs
+++ b/tests/font.rs
@@ -14,7 +14,7 @@ fn custom_font() {
     let mapping = StrGlyphMapping::new("01", 0);
 
     let font = MonoFont {
-        image: ImageRaw::new(DATA, 8),
+        image: ImageRaw::new_const(DATA, Size::new(8, 2)),
         character_size: Size::new(2, 2),
         character_spacing: 0,
         baseline: 0,


### PR DESCRIPTION
This PR changes the signature of `ImageRaw` to take a `Size` argument and to return a `Result`. If I remember correctly the previous method of only specifying the `width` of the image was introduced to work around some const limitation at the time. Returning an error instead of silently truncating the height of the image is a much better approach in my opinion.

The changes in this PR affected the auto generated font code which makes it noisy and appear much more extensive than it is.