### PR TITLE
Make conversion from and to RawUx mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 ### Changed
 
 - **(breaking)** [#764](https://github.com/embedded-graphics/embedded-graphics/pull/764) Changed `ImageRaw::new` to return an error instead of truncating the image height.
+- **(breaking)** [#765](https://github.com/embedded-graphics/embedded-graphics/pull/765) Made conversion to and from `RawUx` types mandatory for all `PixelColor` implementations.
 - [#732](https://github.com/embedded-graphics/embedded-graphics/pull/732) Added `Rgb444` to support 12bit RGB displays. Note that this type is currently stored as a 16 bit value in `ImageRaw`s and `Framebuffer`s.
 
 ### Added

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - (technically breaking) [#731](https://github.com/embedded-graphics/embedded-graphics/pull/731) Bump MSRV to 1.71.1
+- **(breaking)** [#765](https://github.com/embedded-graphics/embedded-graphics/pull/765) Made conversion to and from `RawUx` types mandatory for all `PixelColor` implementations.
 
 ### Added
 

--- a/core/src/pixelcolor/mod.rs
+++ b/core/src/pixelcolor/mod.rs
@@ -24,8 +24,8 @@
 //!     Red,
 //! }
 //!
-//! /// Implement the `PixelColor` trait to mark this type as a embedded-graphics
-//! /// color and to specify the binary storage format.
+//! /// Implement the `PixelColor` trait to mark this type as an embedded-graphics
+//! /// color and associated binary storage format.
 //! impl PixelColor for EpdColor {
 //!     // 2 bits per pixel are required to store the 3 colors.
 //!     type Raw = RawU2;

--- a/core/src/pixelcolor/mod.rs
+++ b/core/src/pixelcolor/mod.rs
@@ -13,6 +13,7 @@
 //! ```
 //! use embedded_graphics::{
 //!     geometry::Size, prelude::*, primitives::{Rectangle, PrimitiveStyle},
+//!     pixelcolor::raw::RawU2,
 //! };
 //!
 //! /// Color with 3 states.
@@ -23,10 +24,33 @@
 //!     Red,
 //! }
 //!
-//! /// The `Raw` can be is set to `()` because `EpdColor` doesn't need to be
-//! /// converted to raw data for the display and isn't stored in images.
+//! /// Implement the `PixelColor` trait to mark this type as a embedded-graphics
+//! /// color and to specify the binary storage format.
 //! impl PixelColor for EpdColor {
-//!     type Raw = ();
+//!     // 2 bits per pixel are required to store the 3 colors.
+//!     type Raw = RawU2;
+//! }
+//!
+//! /// Implement conversion from `RawU2` to `EpdColor` to make the type usable
+//! /// for raw images.
+//! impl From<RawU2> for EpdColor {
+//!     fn from(data: RawU2) -> Self {
+//!         match data.into_inner() {
+//!             0 => Self::White,
+//!             1 => Self::Black,
+//!             2 => Self::Red,
+//!             // Interpret the invalid encoding 0b11 as white:
+//!             _ => Self::White,
+//!         }
+//!     }
+//! }
+//!
+//! /// Implement conversion from `EpdColor` to `RawU2` to make the type usable
+//! /// in framebuffers.
+//! impl From<EpdColor> for RawU2 {
+//!     fn from(color: EpdColor) -> RawU2 {
+//!         RawU2::new(color as u8)
+//!     }
 //! }
 //!
 //! /// Mock EPD display.
@@ -102,7 +126,7 @@ pub use web_colors::WebColors;
 /// See the [module-level documentation] for more details.
 ///
 /// [module-level documentation]: self
-pub trait PixelColor: Copy + PartialEq {
+pub trait PixelColor: Copy + PartialEq + From<Self::Raw> + Into<Self::Raw> {
     /// Raw data type.
     ///
     /// Specifies the raw storage type that can be used to represent this color.
@@ -142,14 +166,10 @@ pub trait IntoStorage {
     fn into_storage(self) -> Self::Storage;
 }
 
-impl<C> IntoStorage for C
-where
-    C: PixelColor,
-    C::Raw: From<C>,
-{
+impl<C: PixelColor> IntoStorage for C {
     type Storage = <<C as PixelColor>::Raw as RawData>::Storage;
 
     fn into_storage(self) -> Self::Storage {
-        C::Raw::from(self).into_inner()
+        self.into().into_inner()
     }
 }

--- a/core/src/pixelcolor/raw/mod.rs
+++ b/core/src/pixelcolor/raw/mod.rs
@@ -73,6 +73,13 @@
 //!     }
 //! }
 //!
+//! /// Implement conversion into `RawU4` to make `RGBI` usable in framebuffers.
+//! impl From<RGBI> for RawU4 {
+//!     fn from(color: RGBI) -> Self {
+//!         color.0
+//!     }
+//! }
+//!
 //! /// Raw image data with 2 pixels per byte.
 //! #[rustfmt::skip]
 //! const IMAGE_DATA: &[u8] = &[
@@ -137,21 +144,6 @@ pub trait RawData: Sized + private::Sealed + From<<Self as RawData>::Storage> + 
     /// the same integer type. If the width of the `RawData` type is less than
     /// 32 bits only the least significant bits are used.
     fn from_u32(value: u32) -> Self;
-}
-
-/// Dummy implementation for `()`.
-///
-/// `()` can be used as [`PixelColor::Raw`] if raw data conversion isn't required.
-///
-/// [`PixelColor::Raw`]: super::PixelColor::Raw
-impl RawData for () {
-    type Storage = ();
-
-    const BITS_PER_PIXEL: usize = 0;
-
-    fn into_inner(self) {}
-
-    fn from_u32(_value: u32) {}
 }
 
 impl private::Sealed for () {}

--- a/core/src/pixelcolor/raw/to_bytes.rs
+++ b/core/src/pixelcolor/raw/to_bytes.rs
@@ -93,10 +93,7 @@ impl ToBytes for () {
     }
 }
 
-impl<C> ToBytes for C
-where
-    C: PixelColor + Into<<C as PixelColor>::Raw>,
-{
+impl<C: PixelColor> ToBytes for C {
     type Bytes = <<C as PixelColor>::Raw as ToBytes>::Bytes;
 
     fn to_le_bytes(self) -> Self::Bytes {

--- a/core/src/pixelcolor/rgb_color.rs
+++ b/core/src/pixelcolor/rgb_color.rs
@@ -247,7 +247,7 @@ mod tests {
     /// Convert color to integer and back again to test bit positions
     fn test_bpp16<C>(color: C, value: u16)
     where
-        C: RgbColor + From<RawU16> + Into<RawU16> + fmt::Debug,
+        C: PixelColor<Raw = RawU16> + fmt::Debug,
     {
         let value = RawU16::new(value);
 
@@ -258,7 +258,7 @@ mod tests {
     /// Convert color to integer and back again to test bit positions
     fn test_bpp24<C>(color: C, value: u32)
     where
-        C: RgbColor + From<RawU24> + Into<RawU24> + fmt::Debug,
+        C: PixelColor<Raw = RawU24> + fmt::Debug,
     {
         let value = RawU24::new(value);
 

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -111,7 +111,7 @@ where
 impl<C, BO, const WIDTH: usize, const HEIGHT: usize, const N: usize>
     Framebuffer<C, C::Raw, BO, WIDTH, HEIGHT, N>
 where
-    C: PixelColor + From<C::Raw>,
+    C: PixelColor,
     BO: ByteOrder,
     for<'a> RawDataSlice<'a, C::Raw, BO>: IntoIterator<Item = C::Raw>,
 {
@@ -128,7 +128,7 @@ where
 impl<C, BO, const WIDTH: usize, const HEIGHT: usize, const N: usize> GetPixel
     for Framebuffer<C, C::Raw, BO, WIDTH, HEIGHT, N>
 where
-    C: PixelColor + From<C::Raw>,
+    C: PixelColor,
     BO: ByteOrder,
     for<'a> RawDataSlice<'a, C::Raw, BO>: IntoIterator<Item = C::Raw>,
 {
@@ -144,7 +144,7 @@ macro_rules! impl_bit {
         impl<C, BO, const WIDTH: usize, const HEIGHT: usize, const N: usize>
             Framebuffer<C, $raw_type, BO, WIDTH, HEIGHT, N>
         where
-            C: PixelColor + Into<$raw_type>,
+            C: PixelColor<Raw = $raw_type>,
         {
             /// Sets the color of a pixel.
             ///
@@ -196,7 +196,7 @@ impl_bit!(RawU4);
 impl<C, BO, const WIDTH: usize, const HEIGHT: usize, const N: usize>
     Framebuffer<C, RawU8, BO, WIDTH, HEIGHT, N>
 where
-    C: PixelColor + Into<RawU8>,
+    C: PixelColor<Raw = RawU8>,
 {
     /// Sets the color of a pixel.
     ///
@@ -238,7 +238,7 @@ macro_rules! impl_bytes {
         impl<C, const WIDTH: usize, const HEIGHT: usize, const N: usize>
             Framebuffer<C, $raw_type, $bo_type, WIDTH, HEIGHT, N>
         where
-            C: PixelColor + Into<$raw_type>,
+            C: PixelColor<Raw = $raw_type>,
         {
             /// Sets the color of a pixel.
             ///

--- a/src/image/image_raw.rs
+++ b/src/image/image_raw.rs
@@ -121,7 +121,7 @@ pub enum ImageRawError {
 #[cfg_attr(feature = "defmt", derive(::defmt::Format))]
 pub struct ImageRaw<'a, C, BO = BigEndian>
 where
-    C: PixelColor + From<<C as PixelColor>::Raw>,
+    C: PixelColor,
     BO: ByteOrder,
 {
     /// Image data, packed as dictated by raw data type `C::Raw`
@@ -136,7 +136,7 @@ where
 
 impl<'a, C, BO> ImageRaw<'a, C, BO>
 where
-    C: PixelColor + From<<C as PixelColor>::Raw>,
+    C: PixelColor,
     BO: ByteOrder,
 {
     /// Creates a new image.
@@ -201,7 +201,7 @@ const fn bytes_per_row(width: u32, bits_per_pixel: usize) -> usize {
 
 impl<'a, C, BO> ImageDrawable for ImageRaw<'a, C, BO>
 where
-    C: PixelColor + From<<C as PixelColor>::Raw>,
+    C: PixelColor,
     BO: ByteOrder,
     RawDataSlice<'a, C::Raw, BO>: IntoIterator<Item = C::Raw>,
 {
@@ -247,7 +247,7 @@ where
 
 impl<C, BO> OriginDimensions for ImageRaw<'_, C, BO>
 where
-    C: PixelColor + From<<C as PixelColor>::Raw>,
+    C: PixelColor,
     BO: ByteOrder,
 {
     fn size(&self) -> Size {
@@ -257,7 +257,7 @@ where
 
 impl<'a, C, BO> GetPixel for ImageRaw<'a, C, BO>
 where
-    C: PixelColor + From<<C as PixelColor>::Raw>,
+    C: PixelColor,
     BO: ByteOrder,
     RawDataSlice<'a, C::Raw, BO>: IntoIterator<Item = C::Raw>,
 {
@@ -277,7 +277,7 @@ where
 
 struct ContiguousPixels<'a, C, BO>
 where
-    C: PixelColor + From<<C as PixelColor>::Raw>,
+    C: PixelColor,
     BO: ByteOrder,
     RawDataSlice<'a, C::Raw, BO>: IntoIterator<Item = C::Raw>,
 {
@@ -292,7 +292,7 @@ where
 
 impl<'a, C, BO> ContiguousPixels<'a, C, BO>
 where
-    C: PixelColor + From<<C as PixelColor>::Raw>,
+    C: PixelColor,
     BO: ByteOrder,
     RawDataSlice<'a, C::Raw, BO>: IntoIterator<Item = C::Raw>,
 {
@@ -318,7 +318,7 @@ where
 
 impl<'a, C, BO> Iterator for ContiguousPixels<'a, C, BO>
 where
-    C: PixelColor + From<<C as PixelColor>::Raw>,
+    C: PixelColor,
     BO: ByteOrder,
     RawDataSlice<'a, C::Raw, BO>: IntoIterator<Item = C::Raw>,
 {
@@ -369,10 +369,16 @@ mod tests {
         }
     }
 
+    impl From<TestColorU32> for RawU32 {
+        fn from(color: TestColorU32) -> Self {
+            color.0
+        }
+    }
+
     /// Tests if the given image data matches an excepted `MockDisplay` pattern.
     fn assert_pattern<C, BO>(image_data: ImageRaw<C, BO>, expected_pattern: &[&str])
     where
-        C: PixelColor + From<<C as PixelColor>::Raw> + ColorMapping,
+        C: PixelColor + ColorMapping,
         BO: ByteOrder,
         for<'a> RawDataSlice<'a, C::Raw, BO>: IntoIterator<Item = C::Raw>,
     {

--- a/tests/chaining.rs
+++ b/tests/chaining.rs
@@ -1,6 +1,7 @@
 extern crate embedded_graphics;
 
 use embedded_graphics::{
+    pixelcolor::raw::RawU1,
     prelude::*,
     primitives::{Circle, Line, Primitive, PrimitiveStyle, Rectangle},
 };
@@ -11,12 +12,24 @@ struct FakeDisplay {}
 pub struct TestPixelColor(pub bool);
 
 impl PixelColor for TestPixelColor {
-    type Raw = ();
+    type Raw = RawU1;
 }
 
 impl From<u8> for TestPixelColor {
     fn from(other: u8) -> Self {
         TestPixelColor(other != 0)
+    }
+}
+
+impl From<RawU1> for TestPixelColor {
+    fn from(value: RawU1) -> Self {
+        TestPixelColor(value.into_inner() != 0)
+    }
+}
+
+impl From<TestPixelColor> for RawU1 {
+    fn from(color: TestPixelColor) -> Self {
+        RawU1::new(color.0 as u8)
     }
 }
 


### PR DESCRIPTION
This PR makes `From<RawUx>` and `Into<RawUx>` mandatory for all `PixelColor`s. This is different from #711, where an additional trait `StorablePixelColor` was used.

At the moment this change doesn't have many advantages, except for making some trait bounds a bit simpler. But I think that requiring all `PixelColor`s to have a binary representation will have advantages if we want to add DMA transfers.