### PR TITLE
Add load and store methods to RawData trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 - **(breaking)** [#764](https://github.com/embedded-graphics/embedded-graphics/pull/764) Changed `ImageRaw::new` to return an error instead of truncating the image height.
 - **(breaking)** [#765](https://github.com/embedded-graphics/embedded-graphics/pull/765) Made conversion to and from `RawUx` types mandatory for all `PixelColor` implementations.
+- **(breaking)** [#767](https://github.com/embedded-graphics/embedded-graphics/pull/767) Renamed `ByteOrder`, `LittleEndian`, and `BigEndian` to `DataOrder`, `LittleEndianMsb0`, and `BigEndianLsb0`.
+- **(breaking)** [#767](https://github.com/embedded-graphics/embedded-graphics/pull/767) Changed default data order for `ImageRaw` from `BigEndian` to `LittleEndianMsb0`.
 
 ### Added
 
@@ -20,6 +22,8 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#756](https://github.com/embedded-graphics/embedded-graphics/pull/756) Added `Clone, Copy` derives to `SubImage` and `Default` impls to `Framebuffer`, `MonoTextStyleBuilder` and `TextStyleBuilder`.
 - [#763](https://github.com/embedded-graphics/embedded-graphics/pull/763) Added `swap_xy` method to `Point` and `Size`.
 - [#764](https://github.com/embedded-graphics/embedded-graphics/pull/764) Added `ImageRaw::new_const` as a panicking alternative to the new `ImageRaw::new` for ease of use in const contexts.
+- [#767](https://github.com/embedded-graphics/embedded-graphics/pull/767) Added `load` and `store` methods to `RawData` trait.
+- [#767](https://github.com/embedded-graphics/embedded-graphics/pull/767) Added `MASK` constant to `RawData` trait.
 - [#768](https://github.com/embedded-graphics/embedded-graphics/pull/768) Added 8bit `Rgb332` support.
 
 ## [0.8.1] - 2023-08-10

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ fixed = { version = "1.14.0", optional = true, default-features = false }
 float-cmp = "0.9.0"
 micromath = { version = "2.0.0", default-features = false }
 embedded-graphics-core = { path = "core", version = "^0.4.0"}
-byteorder = { version = "1.4.3", default-features = false }
 defmt = { version = "0.3.2", optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ debugging, development or if hardware is not available.
 use embedded_graphics::{
     framebuffer::{buffer_size, Framebuffer},
     mono_font::{ascii::FONT_6X10, MonoTextStyle},
-    pixelcolor::{raw::LittleEndian, BinaryColor},
+    pixelcolor::{raw::LittleEndianMsb0, BinaryColor},
     prelude::*,
     primitives::{
         Circle, PrimitiveStyle, PrimitiveStyleBuilder, Rectangle, StrokeAlignment, Triangle,
@@ -181,7 +181,7 @@ fn main() -> Result<(), std::convert::Infallible> {
     let mut display = Framebuffer::<
        BinaryColor,
        _,
-       LittleEndian,
+       LittleEndianMsb0,
        320,
        240,
        { buffer_size::<BinaryColor>(320, 240) },

--- a/benches/framebuffer.rs
+++ b/benches/framebuffer.rs
@@ -3,7 +3,7 @@ use embedded_graphics::{
     framebuffer::{buffer_size, Framebuffer},
     geometry::Point,
     image::GetPixel,
-    pixelcolor::{raw::LittleEndian, BinaryColor, Rgb565},
+    pixelcolor::{raw::LittleEndianMsb0, BinaryColor, Rgb565},
     prelude::{DrawTarget, Size, WebColors},
     primitives::{Primitive, PrimitiveStyle, Rectangle},
 };
@@ -13,7 +13,7 @@ fn framebuffer_set_1bpp(c: &mut Criterion) {
         let mut fb = Framebuffer::<
             BinaryColor,
             _,
-            LittleEndian,
+            LittleEndianMsb0,
             320,
             240,
             { buffer_size::<BinaryColor>(320, 240) },
@@ -31,7 +31,7 @@ fn framebuffer_get_1bpp(c: &mut Criterion) {
         let fb = Framebuffer::<
             BinaryColor,
             _,
-            LittleEndian,
+            LittleEndianMsb0,
             320,
             240,
             { buffer_size::<BinaryColor>(320, 240) },
@@ -49,7 +49,7 @@ fn framebuffer_1bpp_draw_iter(c: &mut Criterion) {
         let mut fb = Framebuffer::<
             BinaryColor,
             _,
-            LittleEndian,
+            LittleEndianMsb0,
             320,
             240,
             { buffer_size::<BinaryColor>(320, 240) },
@@ -70,7 +70,7 @@ fn framebuffer_set_rgb565(c: &mut Criterion) {
         let mut fb = Framebuffer::<
             Rgb565,
             _,
-            LittleEndian,
+            LittleEndianMsb0,
             320,
             240,
             { buffer_size::<Rgb565>(320, 240) },
@@ -88,7 +88,7 @@ fn framebuffer_get_rgb565(c: &mut Criterion) {
         let fb = Framebuffer::<
             Rgb565,
             _,
-            LittleEndian,
+            LittleEndianMsb0,
             320,
             240,
             { buffer_size::<Rgb565>(320, 240) },

--- a/benches/raw_data_iter.rs
+++ b/benches/raw_data_iter.rs
@@ -7,13 +7,13 @@ macro_rules! impl_bench {
     ($fn:ident, $type:ident) => {
         fn $fn(c: &mut Criterion) {
             c.bench_function(stringify!($type), |b| {
-                let slice = RawDataSlice::<$type, LittleEndian>::new(TEST_DATA);
+                let slice = RawDataSlice::<$type, LittleEndianMsb0>::new(TEST_DATA);
 
                 b.iter(|| slice.into_iter().collect::<Vec<_>>())
             });
 
             c.bench_function(concat!(stringify!($type), " step by 20"), |b| {
-                let slice = RawDataSlice::<$type, LittleEndian>::new(TEST_DATA);
+                let slice = RawDataSlice::<$type, LittleEndianMsb0>::new(TEST_DATA);
 
                 b.iter(|| slice.into_iter().step_by(20).collect::<Vec<_>>())
             });

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - (technically breaking) [#731](https://github.com/embedded-graphics/embedded-graphics/pull/731) Bump MSRV to 1.71.1
 - **(breaking)** [#765](https://github.com/embedded-graphics/embedded-graphics/pull/765) Made conversion to and from `RawUx` types mandatory for all `PixelColor` implementations.
+- **(breaking)** [#767](https://github.com/embedded-graphics/embedded-graphics/pull/767) Renamed `ByteOrder`, `LittleEndian`, and `BigEndian` to `DataOrder`, `LittleEndianMsb0`, and `BigEndianLsb0`.
 
 ### Added
 
@@ -17,6 +18,8 @@
 - [#733](https://github.com/embedded-graphics/embedded-graphics/pull/733) Added `envelope` method to `Rectangle`.
 - [#738](https://github.com/embedded-graphics/embedded-graphics/pull/738) Added `new_at_origin` method to `Rectangle`.
 - [#763](https://github.com/embedded-graphics/embedded-graphics/pull/763) Added `swap_xy` method to `Point` and `Size`.
+- [#767](https://github.com/embedded-graphics/embedded-graphics/pull/767) Added `load` and `store` methods to `RawData` trait.
+- [#767](https://github.com/embedded-graphics/embedded-graphics/pull/767) Added `MASK` constant to `RawData` trait.
 - [#768](https://github.com/embedded-graphics/embedded-graphics/pull/768) Added 8bit `Rgb332` support.
 
 ## [0.4.0] - 2023-05-14

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,7 +20,6 @@ circle-ci = { repository = "embedded-graphics/embedded-graphics", branch = "mast
 [dependencies]
 az = "1.1"
 nalgebra = { version = "0.30.1", optional = true, default-features = false }
-byteorder = { version = "1.3.4", default-features = false }
 defmt = { version = "0.3.2", optional = true}
 
 [dev-dependencies]

--- a/core/src/pixelcolor/raw/load_store.rs
+++ b/core/src/pixelcolor/raw/load_store.rs
@@ -1,0 +1,159 @@
+use super::{
+    DataOrder, OutOfBoundsError, RawData, RawU1, RawU16, RawU2, RawU24, RawU32, RawU4, RawU8,
+};
+
+pub(crate) trait LoadStore<O: DataOrder>: Sized {
+    fn load(buffer: &[u8], index: usize) -> Option<Self>;
+    fn store(self, buffer: &mut [u8], index: usize) -> Result<(), OutOfBoundsError>;
+}
+
+#[inline]
+fn bit_position<R: RawData, O: DataOrder>(index: usize) -> (usize, usize) {
+    let pixels_per_byte = 8 / R::BITS_PER_PIXEL;
+
+    let byte_index = index / pixels_per_byte;
+    let bit_index = if O::IS_ALTERNATE_ORDER {
+        index % pixels_per_byte
+    } else {
+        (pixels_per_byte - 1) - (index % pixels_per_byte)
+    } * R::BITS_PER_PIXEL;
+
+    (byte_index, bit_index)
+}
+
+macro_rules! impl_load_store_bits {
+    ($raw_type:ty) => {
+        impl<O: DataOrder> LoadStore<O> for $raw_type {
+            #[inline]
+            fn load(buffer: &[u8], index: usize) -> Option<Self> {
+                let (byte_index, bit_index) = bit_position::<Self, O>(index);
+
+                buffer
+                    .get(byte_index)
+                    .map(|byte| byte >> bit_index)
+                    .map(Into::into)
+            }
+
+            #[inline]
+            fn store(self, buffer: &mut [u8], index: usize) -> Result<(), OutOfBoundsError> {
+                let (byte_index, bit_index) = bit_position::<Self, O>(index);
+
+                buffer
+                    .get_mut(byte_index)
+                    .ok_or(OutOfBoundsError)
+                    .map(|byte| {
+                        *byte =
+                            (*byte & !(Self::MASK << bit_index)) | (self.into_inner() << bit_index);
+                    })
+            }
+        }
+    };
+}
+
+impl_load_store_bits!(RawU1);
+impl_load_store_bits!(RawU2);
+impl_load_store_bits!(RawU4);
+
+impl<O: DataOrder> LoadStore<O> for RawU8 {
+    fn load(buffer: &[u8], index: usize) -> Option<Self> {
+        buffer.get(index).copied().map(Self::new)
+    }
+
+    fn store(self, buffer: &mut [u8], index: usize) -> Result<(), OutOfBoundsError> {
+        buffer
+            .get_mut(index)
+            .ok_or(OutOfBoundsError)
+            .map(|byte| *byte = self.0)
+    }
+}
+
+impl<O: DataOrder> LoadStore<O> for RawU16 {
+    fn load(buffer: &[u8], index: usize) -> Option<Self> {
+        buffer
+            .get(index * 2..)
+            .and_then(|buffer| buffer.get(0..2))
+            .map(|slice| {
+                let bytes = slice.try_into().unwrap();
+
+                let value = if O::IS_ALTERNATE_ORDER {
+                    u16::from_be_bytes(bytes)
+                } else {
+                    u16::from_le_bytes(bytes)
+                };
+
+                Self::new(value)
+            })
+    }
+
+    fn store(self, buffer: &mut [u8], index: usize) -> Result<(), OutOfBoundsError> {
+        let bytes = self.into_inner().to_le_bytes();
+
+        buffer
+            .get_mut(index * 2..)
+            .and_then(|buffer| buffer.get_mut(0..2))
+            .ok_or(OutOfBoundsError)
+            .map(|buffer| buffer.copy_from_slice(&bytes))
+    }
+}
+
+impl<O: DataOrder> LoadStore<O> for RawU24 {
+    fn load(buffer: &[u8], index: usize) -> Option<Self> {
+        buffer
+            .get(index * 3..)
+            .and_then(|buffer| buffer.get(0..3))
+            .map(|slice| {
+                let bytes: [_; 3] = slice.try_into().unwrap();
+                let mut bytes_extended = [0u8; 4];
+
+                let value = if O::IS_ALTERNATE_ORDER {
+                    bytes_extended[1..4].copy_from_slice(&bytes);
+                    u32::from_be_bytes(bytes_extended)
+                } else {
+                    bytes_extended[0..3].copy_from_slice(&bytes);
+                    u32::from_le_bytes(bytes_extended)
+                };
+
+                // The value is already masked by only copying 3 bytes.
+                Self::new_unmasked(value)
+            })
+    }
+
+    fn store(self, buffer: &mut [u8], index: usize) -> Result<(), OutOfBoundsError> {
+        let bytes = self.into_inner().to_le_bytes();
+
+        buffer
+            .get_mut(index * 3..)
+            .and_then(|buffer| buffer.get_mut(0..3))
+            .ok_or(OutOfBoundsError)
+            .map(|buffer| buffer.copy_from_slice(&bytes[0..3]))
+    }
+}
+
+impl<O: DataOrder> LoadStore<O> for RawU32 {
+    fn load(buffer: &[u8], index: usize) -> Option<Self> {
+        buffer
+            .get(index * 4..)
+            .and_then(|buffer| buffer.get(0..4))
+            .map(|slice| {
+                let bytes = slice.try_into().unwrap();
+
+                let value = if O::IS_ALTERNATE_ORDER {
+                    u32::from_be_bytes(bytes)
+                } else {
+                    u32::from_le_bytes(bytes)
+                };
+
+                Self::new(value)
+            })
+    }
+
+    fn store(self, buffer: &mut [u8], index: usize) -> Result<(), OutOfBoundsError> {
+        let bytes = self.into_inner().to_le_bytes();
+
+        buffer
+            .get_mut(index * 4..)
+            .and_then(|buffer| buffer.get_mut(0..4))
+            .ok_or(OutOfBoundsError)
+            .map(|buffer| buffer.copy_from_slice(&bytes))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@
 //! use embedded_graphics::{
 //!     framebuffer::{buffer_size, Framebuffer},
 //!     mono_font::{ascii::FONT_6X10, MonoTextStyle},
-//!     pixelcolor::{raw::LittleEndian, BinaryColor},
+//!     pixelcolor::{raw::LittleEndianMsb0, BinaryColor},
 //!     prelude::*,
 //!     primitives::{
 //!         Circle, PrimitiveStyle, PrimitiveStyleBuilder, Rectangle, StrokeAlignment, Triangle,
@@ -169,7 +169,7 @@
 //!     let mut display = Framebuffer::<
 //!        BinaryColor,
 //!        _,
-//!        LittleEndian,
+//!        LittleEndianMsb0,
 //!        320,
 //!        240,
 //!        { buffer_size::<BinaryColor>(320, 240) },

--- a/src/mono_font/mod.rs
+++ b/src/mono_font/mod.rs
@@ -236,7 +236,7 @@ pub(crate) mod tests {
         mock_display::MockDisplay,
         mono_font::{mapping::Mapping, MonoTextStyleBuilder},
         pixelcolor::{
-            raw::{LittleEndian, RawU1},
+            raw::{LittleEndianMsb0, RawU1},
             BinaryColor,
         },
         text::{Baseline, Text},
@@ -315,7 +315,7 @@ pub(crate) mod tests {
     fn new_framebuffer() -> Framebuffer<
         BinaryColor,
         RawU1,
-        LittleEndian,
+        LittleEndianMsb0,
         96,
         200,
         { buffer_size::<BinaryColor>(96, 200) },

--- a/src/primitives/rounded_rectangle/mod.rs
+++ b/src/primitives/rounded_rectangle/mod.rs
@@ -25,7 +25,7 @@ pub use styled::StyledPixelsIterator;
 /// radius for each corner, use the [`with_equal_corners`](RoundedRectangle::with_equal_corners()) method.
 ///
 /// Rounded rectangles with different radii for each corner can be created by passing a
-/// [`CornerRadii`](super::CornerRadii) configuration struct to the [`new`](RoundedRectangle::new())
+/// [`CornerRadii`] configuration struct to the [`new`](RoundedRectangle::new())
 /// method.
 ///
 /// # Overlapping corners
@@ -73,7 +73,7 @@ pub use styled::StyledPixelsIterator;
 /// ## Different corner radii
 ///
 /// This example creates a rounded rectangle 50px wide by 60px tall. Each corner is given a distinct
-/// radius in the x and y direction by creating a [`CornerRadii`](super::CornerRadii)
+/// radius in the x and y direction by creating a [`CornerRadii`]
 /// object and passing that to [`RoundedRectangle::new`](RoundedRectangle::new()).
 ///
 /// ```rust
@@ -107,7 +107,7 @@ pub use styled::StyledPixelsIterator;
 /// ## Using `CornerRadiiBuilder`
 ///
 /// This example creates a rounded rectangle 50px wide by 60px tall. Corner radii are set using the
-/// [`CornerRadiiBuilder`](super::CornerRadiiBuilder) builder.
+/// [`CornerRadiiBuilder`] builder.
 ///
 /// ```rust
 /// use embedded_graphics::{

--- a/tools/generate-drawing-examples/Cargo.toml
+++ b/tools/generate-drawing-examples/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 [dependencies]
 embedded-graphics = { path = "../../" }
 png-target = { path = "../png-target/" }
-tinytga = "0.5.0"
+tinytga = { git = "https://github.com/rfuest/tinytga.git", branch = "eg-0.9" }
 regex = "1.4.3"
 unindent = "0.1.7"


### PR DESCRIPTION
This PR adds the `load` and `store` methods from #711 to the `RawData` trait. These methods allow random access to individual pixels in a byte slice and are easier to use than the previous iterator based approach of reading pixels. In a later PR the new methods will be used in more places and will, for example, make it possible to remove all bit depth dependent code from `Framebuffer`, but I didn't want to let this PR get too large.