### PR TITLE
Add 8bit RGB332 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#756](https://github.com/embedded-graphics/embedded-graphics/pull/756) Added `Clone, Copy` derives to `SubImage` and `Default` impls to `Framebuffer`, `MonoTextStyleBuilder` and `TextStyleBuilder`.
 - [#763](https://github.com/embedded-graphics/embedded-graphics/pull/763) Added `swap_xy` method to `Point` and `Size`.
 - [#764](https://github.com/embedded-graphics/embedded-graphics/pull/764) Added `ImageRaw::new_const` as a panicking alternative to the new `ImageRaw::new` for ease of use in const contexts.
+- [#768](https://github.com/embedded-graphics/embedded-graphics/pull/768) Added 8bit `Rgb332` support.
 
 ## [0.8.1] - 2023-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 - **(breaking)** [#764](https://github.com/embedded-graphics/embedded-graphics/pull/764) Changed `ImageRaw::new` to return an error instead of truncating the image height.
 - **(breaking)** [#765](https://github.com/embedded-graphics/embedded-graphics/pull/765) Made conversion to and from `RawUx` types mandatory for all `PixelColor` implementations.
-- [#732](https://github.com/embedded-graphics/embedded-graphics/pull/732) Added `Rgb444` to support 12bit RGB displays. Note that this type is currently stored as a 16 bit value in `ImageRaw`s and `Framebuffer`s.
 
 ### Added
 
+- [#732](https://github.com/embedded-graphics/embedded-graphics/pull/732) Added `Rgb444` to support 12bit RGB displays. Note that this type is currently stored as a 16 bit value in `ImageRaw`s and `Framebuffer`s.
 - [#733](https://github.com/embedded-graphics/embedded-graphics/pull/733) Added `envelope` method to `Rectangle`.
 - [#738](https://github.com/embedded-graphics/embedded-graphics/pull/738) Added `new_at_origin` method to `Rectangle`.
 - [#756](https://github.com/embedded-graphics/embedded-graphics/pull/756) Added `PartialEq, Eq` derives to `Image` and `SubImage`.

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -13,9 +13,11 @@
 
 ### Added
 
+- [#732](https://github.com/embedded-graphics/embedded-graphics/pull/732) Added `Rgb444` to support 12bit RGB displays. Note that this type is currently stored as a 16 bit value in `ImageRaw`s and `Framebuffer`s.
 - [#733](https://github.com/embedded-graphics/embedded-graphics/pull/733) Added `envelope` method to `Rectangle`.
 - [#738](https://github.com/embedded-graphics/embedded-graphics/pull/738) Added `new_at_origin` method to `Rectangle`.
 - [#763](https://github.com/embedded-graphics/embedded-graphics/pull/763) Added `swap_xy` method to `Point` and `Size`.
+- [#768](https://github.com/embedded-graphics/embedded-graphics/pull/768) Added 8bit `Rgb332` support.
 
 ## [0.4.0] - 2023-05-14
 

--- a/core/src/pixelcolor/conversion.rs
+++ b/core/src/pixelcolor/conversion.rs
@@ -54,15 +54,16 @@ macro_rules! impl_rgb_conversion {
     };
 }
 
-impl_rgb_conversion!(Rgb444 => Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
-impl_rgb_conversion!(Rgb555 => Rgb444, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
-impl_rgb_conversion!(Bgr555 => Rgb444, Rgb555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
-impl_rgb_conversion!(Rgb565 => Rgb444, Rgb555, Bgr555, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
-impl_rgb_conversion!(Bgr565 => Rgb444, Rgb555, Bgr555, Rgb565, Rgb666, Bgr666, Rgb888, Bgr888);
-impl_rgb_conversion!(Rgb666 => Rgb444, Rgb555, Bgr555, Rgb565, Bgr666, Bgr565, Bgr888, Rgb888);
-impl_rgb_conversion!(Bgr666 => Rgb444, Rgb555, Bgr555, Rgb565, Rgb666, Bgr565, Bgr888, Rgb888);
-impl_rgb_conversion!(Rgb888 => Rgb444, Rgb555, Bgr555, Rgb565, Rgb666, Bgr666, Bgr565, Bgr888);
-impl_rgb_conversion!(Bgr888 => Rgb444, Rgb555, Bgr555, Rgb565, Rgb666, Bgr666, Bgr565, Rgb888);
+impl_rgb_conversion!(Rgb332 => Rgb444, Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
+impl_rgb_conversion!(Rgb444 => Rgb332, Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
+impl_rgb_conversion!(Rgb555 => Rgb332, Rgb444, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
+impl_rgb_conversion!(Bgr555 => Rgb332, Rgb444, Rgb555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
+impl_rgb_conversion!(Rgb565 => Rgb332, Rgb444, Rgb555, Bgr555, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
+impl_rgb_conversion!(Bgr565 => Rgb332, Rgb444, Rgb555, Bgr555, Rgb565, Rgb666, Bgr666, Rgb888, Bgr888);
+impl_rgb_conversion!(Rgb666 => Rgb332, Rgb444, Rgb555, Bgr555, Rgb565, Bgr666, Bgr565, Bgr888, Rgb888);
+impl_rgb_conversion!(Bgr666 => Rgb332, Rgb444, Rgb555, Bgr555, Rgb565, Rgb666, Bgr565, Bgr888, Rgb888);
+impl_rgb_conversion!(Rgb888 => Rgb332, Rgb444, Rgb555, Bgr555, Rgb565, Rgb666, Bgr666, Bgr565, Bgr888);
+impl_rgb_conversion!(Bgr888 => Rgb332, Rgb444, Rgb555, Bgr555, Rgb565, Rgb666, Bgr666, Bgr565, Rgb888);
 
 /// Macro to implement conversion between grayscale color types.
 macro_rules! impl_gray_conversion {
@@ -106,7 +107,7 @@ macro_rules! impl_rgb_to_and_from_gray {
     }
 }
 
-impl_rgb_to_and_from_gray!(Gray2, Gray4, Gray8 => Rgb444, Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
+impl_rgb_to_and_from_gray!(Gray2, Gray4, Gray8 => Rgb332, Rgb444, Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
 
 /// Macro to implement conversion from `BinaryColor` to RGB and grayscale types.
 macro_rules! impl_from_binary {
@@ -120,7 +121,8 @@ macro_rules! impl_from_binary {
 }
 
 impl_from_binary!(
-    Rgb444, Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888, Gray2, Gray4, Gray8
+    Rgb332, Rgb444, Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888, Gray2, Gray4,
+    Gray8
 );
 
 /// Macro to implement conversion from grayscale types to `BinaryColor`.
@@ -147,13 +149,40 @@ macro_rules! impl_rgb_to_binary {
     };
 }
 
-impl_rgb_to_binary!(Rgb444, Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
+impl_rgb_to_binary!(Rgb332, Rgb444, Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
 
 #[cfg(test)]
 mod tests {
     use core::fmt::Debug;
 
     use super::*;
+
+    #[test]
+    fn convert_rgb332_to_rgb888_and_back() {
+        for r in 0..=Rgb332::MAX_R {
+            let c = Rgb332::new(r, 0, 0);
+            let c2 = Rgb888::from(c);
+            let c3 = Rgb332::from(c2);
+
+            assert_eq!(c, c3);
+        }
+
+        for g in 0..=Rgb332::MAX_G {
+            let c = Rgb332::new(0, g, 0);
+            let c2 = Rgb888::from(c);
+            let c3 = Rgb332::from(c2);
+
+            assert_eq!(c, c3);
+        }
+
+        for b in 0..=Rgb332::MAX_B {
+            let c = Rgb332::new(0, 0, b);
+            let c2 = Rgb888::from(c);
+            let c3 = Rgb332::from(c2);
+
+            assert_eq!(c, c3);
+        }
+    }
 
     #[test]
     fn convert_rgb444_to_rgb888_and_back() {
@@ -245,7 +274,7 @@ mod tests {
             assert_eq!(ToC::from(FromC::WHITE), ToC::WHITE);
         }
 
-        type_matrix!(test_rgb_to_rgb; Rgb444, Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
+        type_matrix!(test_rgb_to_rgb; Rgb332, Rgb444, Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
     }
 
     #[test]
@@ -255,7 +284,7 @@ mod tests {
             assert_eq!(ToC::from(FromC::WHITE), ToC::WHITE);
         }
 
-        type_matrix!(test_rgb_to_gray; Rgb444, Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888 => Gray2, Gray4, Gray8);
+        type_matrix!(test_rgb_to_gray; Rgb332, Rgb444, Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888 => Gray2, Gray4, Gray8);
     }
 
     #[test]
@@ -268,7 +297,7 @@ mod tests {
             assert_eq!(BinaryColor::from(FromC::WHITE), BinaryColor::On);
         }
 
-        type_matrix!(test_rgb_to_binary; Rgb444, Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888 => BinaryColor);
+        type_matrix!(test_rgb_to_binary; Rgb332, Rgb444, Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888 => BinaryColor);
     }
 
     #[test]
@@ -288,7 +317,7 @@ mod tests {
             assert_eq!(ToC::from(FromC::WHITE), ToC::WHITE);
         }
 
-        type_matrix!(test_gray_to_rgb; Gray2, Gray4, Gray8 => Rgb444, Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
+        type_matrix!(test_gray_to_rgb; Gray2, Gray4, Gray8 => Rgb332, Rgb444, Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
     }
 
     #[test]
@@ -311,7 +340,7 @@ mod tests {
             assert_eq!(ToC::from(BinaryColor::On), ToC::WHITE);
         }
 
-        type_matrix!(test_binary_to_rgb; BinaryColor => Rgb444, Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
+        type_matrix!(test_binary_to_rgb; BinaryColor => Rgb332, Rgb444, Rgb555, Bgr555, Rgb565, Bgr565, Rgb666, Bgr666, Rgb888, Bgr888);
     }
 
     #[test]

--- a/src/mock_display/color_mapping.rs
+++ b/src/mock_display/color_mapping.rs
@@ -1,6 +1,6 @@
 use embedded_graphics_core::pixelcolor::{
-    Bgr555, Bgr565, Bgr888, BinaryColor, Gray2, Gray4, Gray8, GrayColor, Rgb444, Rgb555, Rgb565,
-    Rgb888, RgbColor, WebColors,
+    Bgr555, Bgr565, Bgr888, BinaryColor, Gray2, Gray4, Gray8, GrayColor, Rgb332, Rgb444, Rgb555,
+    Rgb565, Rgb888, RgbColor, WebColors,
 };
 
 /// Mapping between `char`s and colors.
@@ -122,6 +122,7 @@ macro_rules! impl_rgb_color_mapping {
     };
 }
 
+impl_rgb_color_mapping!(Rgb332);
 impl_rgb_color_mapping!(Rgb444);
 impl_rgb_color_mapping!(Rgb555);
 impl_rgb_color_mapping!(Bgr555);


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Adds `Rgb332` support which I need for a project. Mostly follows the changes from the RGB444 PR.
I needed to allow `trivial_numeric_casts` in two locations in the macro due to the storage type `u8` being the same as the `PixelColour::MAX_[RGB]` associated constant type. That seemed the simplest approach but I'm open to alternatives.
