### PR TITLE
Add feature dotted border for Rectangle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#767](https://github.com/embedded-graphics/embedded-graphics/pull/767) Added `load` and `store` methods to `RawData` trait.
 - [#767](https://github.com/embedded-graphics/embedded-graphics/pull/767) Added `MASK` constant to `RawData` trait.
 - [#768](https://github.com/embedded-graphics/embedded-graphics/pull/768) Added 8bit `Rgb332` support.
+- [#772](https://github.com/embedded-graphics/embedded-graphics/pull/772) Added `PrimitiveStyle::stroke_style` property to draw dotted borders (currently only supported for `Rectangle`).
 
 ## [0.8.1] - 2023-08-10
 

--- a/src/geometry/real.rs
+++ b/src/geometry/real.rs
@@ -222,7 +222,6 @@ impl Real {
         }
     }
 
-    #[allow(unused)]
     pub(crate) fn round(self) -> Self {
         Self(self.0.round())
     }

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -21,7 +21,7 @@ pub use self::{
     ellipse::Ellipse,
     line::Line,
     polyline::Polyline,
-    primitive_style::{PrimitiveStyle, PrimitiveStyleBuilder, StrokeAlignment},
+    primitive_style::{PrimitiveStyle, PrimitiveStyleBuilder, StrokeAlignment, StrokeStyle},
     rounded_rectangle::{CornerRadii, CornerRadiiBuilder, RoundedRectangle},
     sector::Sector,
     triangle::Triangle,

--- a/src/primitives/primitive_style.rs
+++ b/src/primitives/primitive_style.rs
@@ -42,6 +42,14 @@ where
     /// This property only applies to closed shapes (rectangle, circle, ...) and is
     /// ignored for open shapes (line, ...).
     pub stroke_alignment: StrokeAlignment,
+
+    /// Stroke style.
+    ///
+    /// The stroke style sets the border style (default is [`StrokeStyle::Solid`]).
+    ///
+    /// [`StrokeStyle::Dotted`] is only implemented for the [`Rectangle`](crate::primitives::Rectangle)
+    /// primitive, the default will be used for all other primitives.
+    pub stroke_style: StrokeStyle,
 }
 
 impl<C> PrimitiveStyle<C>
@@ -131,6 +139,7 @@ where
             stroke_color: None,
             stroke_width: 0,
             stroke_alignment: StrokeAlignment::Center,
+            stroke_style: StrokeStyle::const_default(),
         }
     }
 }
@@ -254,6 +263,16 @@ where
         self
     }
 
+    /// Sets the stroke style.
+    ///
+    /// This feature is not supported for all primitives, see [PrimitiveStyle::stroke_style]
+    /// for the complete list.
+    pub const fn stroke_style(mut self, stroke_style: StrokeStyle) -> Self {
+        self.style.stroke_style = stroke_style;
+
+        self
+    }
+
     /// Builds the primitive style.
     pub const fn build(self) -> PrimitiveStyle<C> {
         self.style
@@ -287,6 +306,24 @@ impl Default for StrokeAlignment {
     }
 }
 
+/// Stroke style.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Default)]
+#[cfg_attr(feature = "defmt", derive(::defmt::Format))]
+#[non_exhaustive]
+pub enum StrokeStyle {
+    /// Solid.
+    #[default]
+    Solid,
+    /// Dotted.
+    Dotted,
+}
+
+impl StrokeStyle {
+    const fn const_default() -> Self {
+        Self::Solid
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -301,6 +338,7 @@ mod tests {
                 stroke_color: None,
                 stroke_width: 0,
                 stroke_alignment: StrokeAlignment::Center,
+                stroke_style: StrokeStyle::Solid,
             }
         );
 

--- a/src/primitives/primitive_style.rs
+++ b/src/primitives/primitive_style.rs
@@ -126,7 +126,13 @@ where
     /// Returns the fill area.
     pub(in crate::primitives) fn fill_area<P: OffsetOutline>(&self, primitive: &P) -> P {
         // saturate offset at i32::min_value() if stroke width is to large
-        let offset = -self.inside_stroke_width().saturating_as::<i32>();
+        let offset = if self.stroke_style == StrokeStyle::Solid {
+            -self.inside_stroke_width().saturating_as::<i32>()
+        } else {
+            // do not shrink the fill area for non solid borders, because the entire fill
+            // area is visible through the gaps in the border
+            0
+        };
 
         primitive.offset(offset)
     }

--- a/src/primitives/rectangle/styled.rs
+++ b/src/primitives/rectangle/styled.rs
@@ -1,11 +1,12 @@
 use crate::{
     draw_target::DrawTarget,
-    geometry::{Dimensions, Point, Size},
+    geometry::{Dimensions, Point, Real, Size},
     pixelcolor::PixelColor,
     primitives::{
+        primitive_style::StrokeStyle,
         rectangle::{Points, Rectangle},
         styled::{StyledDimensions, StyledDrawable, StyledPixels},
-        PointsIter, PrimitiveStyle,
+        Circle, PointsIter, PrimitiveStyle,
     },
     transform::Transform,
     Pixel,
@@ -69,6 +70,113 @@ impl<C: PixelColor> StyledPixels<PrimitiveStyle<C>> for Rectangle {
     }
 }
 
+fn dot_positions_with_dotted_corners(
+    length: u32,
+    dot_size: u32,
+    include_corners: bool,
+) -> impl Iterator<Item = i32> {
+    let nb_dots = (length + dot_size) / (2 * dot_size);
+    let dot_offset = Real::from(length) / Real::from(nb_dots);
+
+    let idx_iter = if include_corners {
+        0..=nb_dots
+    } else {
+        1..=nb_dots - 1
+    };
+
+    idx_iter.map(move |idx| (dot_offset * Real::from(idx)).round().into())
+}
+
+/// Draw a dotted rectangular border with dots in the 4 corners.
+///
+/// The gaps between dots ideally have the same size as the dots.
+/// The gaps can be smaller or larger than ideal.
+/// Opposite borders are identical (horizontal and vertical sides are independent).
+fn draw_dotted_rectangle_border_with_dotted_corners<D>(
+    top_left: &Point,
+    border_size: &Size,
+    dot_size: u32,
+    style: &PrimitiveStyle<D::Color>,
+    target: &mut D,
+) -> Result<(), D::Error>
+where
+    D: DrawTarget,
+{
+    let top_left_dot = Circle::new(*top_left, dot_size);
+
+    // Draw horizontal sides (including corner dots)
+    for x in dot_positions_with_dotted_corners(border_size.width, dot_size, true) {
+        top_left_dot
+            .translate(Point::new(x, 0))
+            .draw_styled(style, target)?;
+        top_left_dot
+            .translate(Point::new(x, 0) + border_size.y_axis())
+            .draw_styled(style, target)?;
+    }
+
+    // Draw vertical sides (without corner dots)
+    for y in dot_positions_with_dotted_corners(border_size.height, dot_size, false) {
+        top_left_dot
+            .translate(Point::new(0, y))
+            .draw_styled(style, target)?;
+        top_left_dot
+            .translate(Point::new(0, y) + border_size.x_axis())
+            .draw_styled(style, target)?;
+    }
+
+    Ok(())
+}
+
+fn dot_positions_in_clockwise_order(length: u32, dot_size: u32) -> impl Iterator<Item = i32> {
+    let nb_dots = length / (2 * dot_size);
+    let dot_offset = if nb_dots != 0 {
+        Real::from(length) / Real::from(nb_dots)
+    } else {
+        Real::from(0) // this value won't be used
+    };
+
+    let idx_iter = 0..nb_dots;
+
+    idx_iter.map(move |idx| (dot_offset * Real::from(idx)).round().into())
+}
+
+/// Draw a dotted rectangular border.
+///
+/// The dot type is [`Rectangle`] (this method is meant to be used with smaller values of `dot_size`).
+/// The gaps between dots ideally have the same size as the dots.
+/// The gaps can be larger than ideal, but not smaller.
+/// A corner can be filled either by a dot or a gap (sides are drawn in clockwise order).
+fn draw_dotted_rectangle_border_in_clockwise_order<D>(
+    top_left: &Point,
+    border_sides: &[Point],
+    dot_size: u32,
+    style: &PrimitiveStyle<D::Color>,
+    target: &mut D,
+) -> Result<(), D::Error>
+where
+    D: DrawTarget,
+{
+    let mut corner_dot = Rectangle::new(*top_left, Size::new_equal(dot_size));
+    let mut unit_is_dot = true;
+
+    for (side_idx, side) in border_sides.iter().enumerate() {
+        let length = side[side_idx % 2].unsigned_abs();
+
+        for offset in dot_positions_in_clockwise_order(length, dot_size) {
+            if unit_is_dot {
+                let translation = *side / length as i32 * offset;
+                corner_dot
+                    .translate(translation)
+                    .draw_styled(style, target)?;
+            };
+            unit_is_dot = !unit_is_dot; // alternating dots and gaps
+        }
+        corner_dot.translate_mut(*side);
+    }
+
+    Ok(())
+}
+
 impl<C: PixelColor> StyledDrawable<PrimitiveStyle<C>> for Rectangle {
     type Color = C;
     type Output = ();
@@ -89,11 +197,47 @@ impl<C: PixelColor> StyledDrawable<PrimitiveStyle<C>> for Rectangle {
         }
 
         // Draw stroke
-        if let Some(stroke_color) = style.effective_stroke_color() {
-            let stroke_width = style.stroke_width;
+        let Some(stroke_color) = style.effective_stroke_color() else {
+            return Ok(());
+        };
+        let stroke_width = style.stroke_width;
+        let stroke_area = style.stroke_area(self);
 
-            let stroke_area = style.stroke_area(self);
+        if style.stroke_style == StrokeStyle::Dotted {
+            let dot_size = stroke_width
+                .min(stroke_area.size.height / 2)
+                .min(stroke_area.size.width / 2);
+            if dot_size == 0 {
+                return Ok(());
+            }
 
+            let border_size = stroke_area.size - Size::new_equal(dot_size);
+            let dot_style = PrimitiveStyle::with_fill(stroke_color);
+
+            if dot_size < 4 {
+                let mut border_sides: [Point; 4] = [Point::zero(); 4];
+                border_sides[0] += border_size.x_axis();
+                border_sides[1] += border_size.y_axis();
+                border_sides[2] -= border_size.x_axis();
+                border_sides[3] -= border_size.y_axis();
+
+                draw_dotted_rectangle_border_in_clockwise_order(
+                    &stroke_area.top_left,
+                    &border_sides,
+                    dot_size,
+                    &dot_style,
+                    target,
+                )?
+            } else {
+                draw_dotted_rectangle_border_with_dotted_corners(
+                    &stroke_area.top_left,
+                    &border_size,
+                    dot_size,
+                    &dot_style,
+                    target,
+                )?
+            }
+        } else {
             let top_border = Rectangle::new(
                 stroke_area.top_left,
                 Size::new(


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [X] Check that you've added passing tests and documentation
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [X] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Support for dotted/dashed borders and fills was requested in #771. This pull request is only the beginning of the implementation, starting with dotted borders for the `Rectangle` primitive.

### Developer tests

I've tested the existing commits by comparing screenshots of the regular and dotted border (with all stroke alignment styles), see [screenshots](https://github.com/inesvar/test-embedded-graphics/blob/ec6cfb16cfd1ab0ef81f9b06369c83fe1ebb0baf/README.md) (the testing code is in the linked repo).

### Testing issue

I'm not sure what kind of tests should be added for this feature, any advice?
Checking that the dotted border fits the regular border seemed relevant, are there existing tests doing this kind of stuff using screenshots ?

### Scope of the PR

I plan on continuing the implementation of #771 with dotted borders for `Line` and `Polyline`. If you think it would be best to group this in one PR, just let me know.


