### PR TITLE
Add support for `StrokeStyle::Dotted` for `Line`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#767](https://github.com/embedded-graphics/embedded-graphics/pull/767) Added `load` and `store` methods to `RawData` trait.
 - [#767](https://github.com/embedded-graphics/embedded-graphics/pull/767) Added `MASK` constant to `RawData` trait.
 - [#768](https://github.com/embedded-graphics/embedded-graphics/pull/768) Added 8bit `Rgb332` support.
-- [#772](https://github.com/embedded-graphics/embedded-graphics/pull/772) Added `PrimitiveStyle::stroke_style` property to draw dotted borders (currently only supported for `Rectangle`).
+- [#772](https://github.com/embedded-graphics/embedded-graphics/pull/772), [#776](https://github.com/embedded-graphics/embedded-graphics/pull/776) Added `PrimitiveStyle::stroke_style` property to draw dotted borders (currently only supported for `Rectangle` and `Line`).
 
 ## [0.8.1] - 2023-08-10
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ float-cmp = "0.9.0"
 micromath = { version = "2.0.0", default-features = false }
 embedded-graphics-core = { path = "core", version = "^0.4.0"}
 defmt = { version = "0.3.2", optional = true }
+integer-sqrt = "0.1.5"
 
 [dev-dependencies]
 arrayvec = { version = "0.7.2", default-features = false }

--- a/src/primitives/line/dotted_bresenham.rs
+++ b/src/primitives/line/dotted_bresenham.rs
@@ -1,0 +1,148 @@
+//! A variant of the bresenham algorithm that is used to select
+//! points from a bresenham line in order to draw a dotted line.
+
+use super::{bresenham::MajorMinor, Line, Points};
+use crate::geometry::Point;
+
+/// Dotted bresenham parameters.
+///
+/// [`super::bresenham::BresenhamParameters`] describes a major and
+/// a minor step, classically vectors along opposing axes.
+///
+/// [`DottedBresenhamParameters`] describes a scalar major step and a
+/// scalar minor step. It is used to draw a dotted line with the
+/// desired number of dots by selecting the appropriate points in a
+/// bresenham line.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[cfg_attr(feature = "defmt", derive(::defmt::Format))]
+struct DottedBresenhamParameters {
+    /// Error threshold.
+    ///
+    /// If the accumulated error exceeds the threshold a minor move is made.
+    error_threshold: i32,
+
+    /// Change in error for major and minor steps.
+    error_step: MajorMinor<i32>,
+
+    /// Change in index for major and minor steps.
+    index_step: MajorMinor<usize>,
+}
+
+impl DottedBresenhamParameters {
+    /// Create a new bresenham parameters object.
+    fn new(line: &Line, nb_dots_desired: i32) -> Self {
+        let delta = line.delta().abs();
+        let line_max_index = delta.x.max(delta.y);
+        let nb_pixels_in_line = line_max_index + 1;
+
+        // Enforce the use of at least 2 dots to prevent division by 0 when the line is reduced to a point.
+        // `clamp` can't be used here (`nb_pixels_in_line` is less than 2 when the line is reduced to a point).
+        let nb_dots = nb_dots_desired.min(nb_pixels_in_line).max(2);
+
+        let integer_quotient = line_max_index / (nb_dots - 1);
+        let remainder = line_max_index - integer_quotient * (nb_dots - 1);
+
+        let index_step = MajorMinor::new(integer_quotient as usize, 1);
+        let error_threshold = nb_dots - 1;
+
+        Self {
+            error_threshold,
+            error_step: MajorMinor::new(remainder * 2, error_threshold * 2),
+            index_step,
+        }
+    }
+
+    /// Increases the error by a major step.
+    ///
+    /// If the error threshold is reached the error is reduced by a minor step and
+    /// `true` is returned.
+    fn increase_error(&self, error: &mut i32) -> bool {
+        *error += self.error_step.major;
+        if *error >= self.error_threshold {
+            *error -= self.error_step.minor;
+
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Bresenham algorithm for dotted lines.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[cfg_attr(feature = "defmt", derive(::defmt::Format))]
+struct DottedBresenham {
+    /// Current index increment.
+    ///
+    /// It is used to retrieve the next dot from a [`Points`] iterator.
+    index_nth: Option<usize>,
+
+    /// Error accumulator.
+    error: i32,
+}
+
+impl DottedBresenham {
+    /// Create a new bresenham object.
+    const fn new() -> Self {
+        Self {
+            index_nth: Some(0),
+            error: 0,
+        }
+    }
+
+    /// Return the increment to the next point on the line.
+    /// This iterator is infinite, except if `parameters.index_step.major = 0`.
+    fn next(&mut self, parameters: &DottedBresenhamParameters) -> Option<usize> {
+        let ret = self.index_nth;
+
+        if self.index_nth.is_some() {
+            let mut increment = parameters.index_step.major;
+
+            if parameters.increase_error(&mut self.error) {
+                increment += parameters.index_step.minor;
+            }
+
+            self.index_nth = if increment > 0 {
+                Some(increment - 1)
+            } else {
+                None
+            };
+        }
+
+        ret
+    }
+}
+
+/// Iterator over all points on a dotted line.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[cfg_attr(feature = "defmt", derive(::defmt::Format))]
+pub(super) struct DottedLinePoints {
+    points: Points,
+    index_parameters: DottedBresenhamParameters,
+    index_bresenham: DottedBresenham,
+}
+
+impl DottedLinePoints {
+    /// Creates an iterator over all points on the given line
+    /// taking into account the desired number of dots.
+    pub(super) fn new(line: &Line, nb_dots_desired: i32) -> Self {
+        let points = Points::new(line);
+        let index_parameters = DottedBresenhamParameters::new(line, nb_dots_desired);
+        let index_bresenham = DottedBresenham::new();
+
+        Self {
+            points,
+            index_parameters,
+            index_bresenham,
+        }
+    }
+}
+
+impl Iterator for DottedLinePoints {
+    type Item = Point;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.points
+            .nth(self.index_bresenham.next(&self.index_parameters)?)
+    }
+}

--- a/src/primitives/line/mod.rs
+++ b/src/primitives/line/mod.rs
@@ -12,6 +12,7 @@ use crate::{
 use az::SaturatingAs;
 
 mod bresenham;
+mod dotted_bresenham;
 pub(in crate::primitives) mod intersection_params;
 mod points;
 mod styled;

--- a/src/primitives/line/styled.rs
+++ b/src/primitives/line/styled.rs
@@ -15,7 +15,6 @@ use crate::{
     Pixel,
 };
 use az::SaturatingAs;
-use integer_sqrt::IntegerSquareRoot;
 
 /// Styled line iterator.
 #[derive(Clone, Debug)]
@@ -190,17 +189,8 @@ impl<C: PixelColor> StyledDrawable<PrimitiveStyle<C>> for Line {
             };
 
             // Draw dots along the line.
-            let mut length = line.delta().length_squared().integer_sqrt();
-            // The gaps between dots ideally have the same size as the dots
-            // If `dot_size <= 3`, only positive error is allowed,
-            // otherwise both positive and negative error are allowed.
-            if dot_size > 3 {
-                length += dot_size;
-            }
-            // The 2 endpoint dots take half the space of a regular dot.
-            let nb_dots_desired = length / (2 * dot_size) + 1;
             let dotted_line_points =
-                DottedLinePoints::new(&line.translate(-line.start), nb_dots_desired);
+                DottedLinePoints::with_dot_size(&line.translate(-line.start), dot_size);
             let dot_style = PrimitiveStyle::with_fill(stroke_color);
             // Improve the positioning of the dots.
             let start = start_dot_offset(self, dot_size);

--- a/src/primitives/line/styled.rs
+++ b/src/primitives/line/styled.rs
@@ -1,9 +1,13 @@
 use crate::{
     draw_target::DrawTarget,
-    geometry::{PointExt, Size},
+    geometry::{Point, PointExt, Size},
     pixelcolor::PixelColor,
     primitives::{
-        line::{dotted_bresenham::DottedLinePoints, thick_points::ThickPoints, Line, StrokeOffset},
+        line::{
+            dotted_bresenham::DottedLinePoints,
+            thick_points::{ThickPoints, HORIZONTAL_LINE},
+            Line, StrokeOffset,
+        },
         styled::{StyledDimensions, StyledDrawable, StyledPixels},
         Circle, PrimitiveStyle, Rectangle, StrokeStyle,
     },
@@ -71,6 +75,66 @@ where
     Ok(())
 }
 
+/// Compute the translation needed so that the dotted line fits the line as well as possible.
+/// The naive positioning of the dots might not be ideal for the following reasons :
+///
+/// 1. Considering that a dot is either a `Circle` or a squared `Rectangle`, the geometric
+///    center of a dot can either be on a pixel center (when the dot size is odd),
+///    or on a 4-pixel intersection (when the dot size is even).
+///    In the second case, the "center point" used in e-g is actually the neighboring top-left
+///    pixel, which causes the dot to be moved slightly to the bottom right.
+///
+/// 2. A line with an odd number of bresenham lines is symmetric. However when there is an
+///    even number of bresenham lines, the line is slightly thicker on the left.
+fn start_dot_offset(line: &Line, dot_size: i32) -> Point {
+    if dot_size % 2 == 1 {
+        // No translation is applied for dots of odd diameter
+        // (their geometric center coincides with their "center point" as computed in e-g).
+        return line.start;
+    }
+
+    // Dots of even diameter (with a geometric center on a 4-pixel intersection).
+    //
+    // A translation is applied to get the following result:
+    // - on horizontal, vertical and other lines using the minimal (odd) number of bresenham lines,
+    // the geometric center of the starting dot will lie on the left starting corner of the
+    // bresenham line;
+    // If possible, the translation as a function of the line orientation should change
+    // when the number of bresenham lines changes.
+    let mut start = line.start;
+    let delta = if start != line.end {
+        line.delta()
+    } else {
+        HORIZONTAL_LINE.delta()
+    };
+    if !ThickPoints::has_more_lines_than_expected(line, dot_size) {
+        // Horizontal, vertical, and other lines that use the minimal (odd) number of bresenham lines.
+        let to_bottom_right = delta.dot_product(Point::new(1, 1));
+        let to_top_right = delta.dot_product(Point::new(1, -1));
+
+        if to_bottom_right > 0 || to_bottom_right == 0 && to_top_right < 0 {
+            start.y -= 1;
+        };
+        if to_top_right > 0 || to_top_right == 0 && to_bottom_right > 0 {
+            start.x -= 1;
+        };
+        start
+    } else {
+        // Lines that have more bresenham lines than the minimum.
+        // The same offset is used as on the previous horizontal/vertical line in clockwise order.
+        let to_right = delta.dot_product(Point::new(1, 0));
+        let to_bottom = delta.dot_product(Point::new(0, 1));
+
+        if to_right > 0 || to_right == 0 && to_bottom < 0 {
+            start.x -= 1;
+        };
+        if to_bottom > 0 || to_bottom == 0 && to_right > 0 {
+            start.y -= 1;
+        };
+        start
+    }
+}
+
 impl<C: PixelColor> StyledDrawable<PrimitiveStyle<C>> for Line {
     type Color = C;
     type Output = ();
@@ -106,17 +170,19 @@ impl<C: PixelColor> StyledDrawable<PrimitiveStyle<C>> for Line {
             let dotted_line_points =
                 DottedLinePoints::new(&self.translate(-self.start), nb_dots_desired);
             let dot_style = PrimitiveStyle::with_fill(stroke_color);
+            // Improve the positioning of the dots.
+            let start = start_dot_offset(self, dot_size);
 
             if dot_size > 3 {
                 draw_dotted_line(
-                    &Circle::with_center(self.start, dot_size as u32),
+                    &Circle::with_center(start, dot_size as u32),
                     &dotted_line_points,
                     &dot_style,
                     target,
                 )
             } else {
                 draw_dotted_line(
-                    &Rectangle::with_center(self.start, Size::new_equal(dot_size as u32)),
+                    &Rectangle::with_center(start, Size::new_equal(dot_size as u32)),
                     &dotted_line_points,
                     &dot_style,
                     target,
@@ -155,7 +221,7 @@ mod tests {
     use crate::{
         geometry::{Dimensions, Point},
         mock_display::MockDisplay,
-        pixelcolor::{BinaryColor, Rgb888, RgbColor},
+        pixelcolor::{BinaryColor, Gray2, Rgb888, RgbColor},
         primitives::{Primitive, PrimitiveStyleBuilder},
         Drawable,
     };
@@ -319,6 +385,222 @@ mod tests {
             "             ###...### ",
             "                ...### ",
             "                   ### ",
+        ]);
+    }
+
+    #[test]
+    /// When the dotted line is reduced to a point (it has the same `start` and `end`), then only
+    /// one dot should be drawn, and it should fit the corresponding solid line (which is horizontal).
+    fn null_line_is_correct() {
+        let point = Point::new_equal(3);
+        let null_line = Line::new(point, point);
+
+        let expected_pattern_width_1 = [
+            "         ",
+            "         ",
+            "         ",
+            "   0     ",
+            "         ",
+            "         ",
+        ];
+
+        let expected_pattern_width_2 = [
+            "         ",
+            "         ",
+            "  21     ",
+            "  20     ",
+            "         ",
+            "         ",
+        ];
+
+        let expected_pattern_width_3 = [
+            "         ",
+            "         ",
+            "  212    ",
+            "  202    ",
+            "  212    ",
+            "         ",
+        ];
+
+        let expected_pattern_width_4 = [
+            "         ",
+            "  21     ",
+            " 2212    ",
+            " 2202    ",
+            "  21     ",
+            "         ",
+        ];
+
+        let width_and_result = [
+            expected_pattern_width_1,
+            expected_pattern_width_2,
+            expected_pattern_width_3,
+            expected_pattern_width_4,
+        ];
+
+        let solid_1px_style = PrimitiveStyle::with_stroke(Gray2::new(0x0), 1);
+
+        for (width, expected_pattern) in width_and_result.iter().enumerate() {
+            let solid_style = PrimitiveStyle::with_stroke(Gray2::new(0x1), (width + 1) as u32);
+            let dotted_style = PrimitiveStyleBuilder::from(&solid_style)
+                .stroke_color(Gray2::new(0x2))
+                .stroke_style(StrokeStyle::Dotted)
+                .build();
+
+            let mut display = MockDisplay::new();
+
+            null_line
+                .into_styled(dotted_style)
+                .draw(&mut display)
+                .unwrap();
+            // overdraw wasn't allowed up to this point, this proves only one dot was drawn
+            display.set_allow_overdraw(true);
+            null_line
+                .into_styled(solid_style)
+                .draw(&mut display)
+                .unwrap();
+            null_line
+                .into_styled(solid_1px_style)
+                .draw(&mut display)
+                .unwrap();
+
+            display.assert_pattern(expected_pattern);
+        }
+    }
+
+    #[test]
+    /// Lines with even width are thicker on the left, and dots with even diameter have
+    /// an offset to the bottom right. The output of `start_dot_offset` should match the
+    /// array `expected_corrections` on 8 major orientations.
+    fn start_dot_offset_matches_expectations() {
+        let origin = Point::zero();
+        // 8 orientations in clockwise order (the first one is to the right).
+        let orientations = [
+            Point::new(1, 0),
+            Point::new(1, 1),
+            Point::new(0, 1),
+            Point::new(-1, 1),
+            Point::new(-1, 0),
+            Point::new(-1, -1),
+            Point::new(0, -1),
+            Point::new(1, -1),
+        ];
+        let expected_corrections = [
+            Point::new(-1, -1),
+            Point::new(-1, -1),
+            Point::new(0, -1),
+            Point::new(0, -1),
+            Point::new(0, 0),
+            Point::new(0, 0),
+            Point::new(-1, 0),
+            Point::new(-1, 0),
+        ];
+
+        let lines = [
+            Line::new(origin, orientations[0]),
+            Line::new(origin, orientations[1]),
+            Line::new(origin, orientations[2]),
+            Line::new(origin, orientations[3]),
+            Line::new(origin, orientations[4]),
+            Line::new(origin, orientations[5]),
+            Line::new(origin, orientations[6]),
+            Line::new(origin, orientations[7]),
+        ];
+
+        for width in [2, 4] {
+            assert_eq!(start_dot_offset(&lines[0], width), expected_corrections[0]);
+            assert_eq!(start_dot_offset(&lines[1], width), expected_corrections[1]);
+            assert_eq!(start_dot_offset(&lines[2], width), expected_corrections[2]);
+            assert_eq!(start_dot_offset(&lines[3], width), expected_corrections[3]);
+            assert_eq!(start_dot_offset(&lines[4], width), expected_corrections[4]);
+            assert_eq!(start_dot_offset(&lines[5], width), expected_corrections[5]);
+            assert_eq!(start_dot_offset(&lines[6], width), expected_corrections[6]);
+            assert_eq!(start_dot_offset(&lines[7], width), expected_corrections[7]);
+        }
+
+        for width in [1, 3] {
+            assert_eq!(start_dot_offset(&lines[0], width), Point::zero());
+            assert_eq!(start_dot_offset(&lines[1], width), Point::zero());
+            assert_eq!(start_dot_offset(&lines[2], width), Point::zero());
+            assert_eq!(start_dot_offset(&lines[3], width), Point::zero());
+            assert_eq!(start_dot_offset(&lines[4], width), Point::zero());
+            assert_eq!(start_dot_offset(&lines[5], width), Point::zero());
+            assert_eq!(start_dot_offset(&lines[6], width), Point::zero());
+            assert_eq!(start_dot_offset(&lines[7], width), Point::zero());
+        }
+    }
+
+    #[test]
+    /// Lines with even width are thicker on the left, and dots with even diameter have
+    /// an offset to the bottom right. start_dot_offset` should translate the dotted line
+    /// so that it fits the solid line as well as possible.
+    fn start_dot_offset_matches_drawing() {
+        let origin = Point::new_equal(8);
+        // 8 orientations in clockwise order (the first direction is to the right).
+        let orientations = [
+            Point::new(1, 0),
+            Point::new(1, 1),
+            Point::new(0, 1),
+            Point::new(-1, 1),
+            Point::new(-1, 0),
+            Point::new(-1, -1),
+            Point::new(0, -1),
+            Point::new(1, -1),
+        ];
+
+        let lines = [
+            Line::new(origin + orientations[0] * 4, origin + orientations[0] * 8),
+            Line::new(origin + orientations[1] * 4, origin + orientations[1] * 8),
+            Line::new(origin + orientations[2] * 4, origin + orientations[2] * 8),
+            Line::new(origin + orientations[3] * 4, origin + orientations[3] * 8),
+            Line::new(origin + orientations[4] * 4, origin + orientations[4] * 8),
+            Line::new(origin + orientations[5] * 4, origin + orientations[5] * 8),
+            Line::new(origin + orientations[6] * 4, origin + orientations[6] * 8),
+            Line::new(origin + orientations[7] * 4, origin + orientations[7] * 8),
+        ];
+
+        let solid_fill_style = PrimitiveStyle::with_fill(Gray2::new(0x0));
+        let solid_style = PrimitiveStyle::with_stroke(Gray2::new(0x1), 2);
+        let dotted_style = PrimitiveStyleBuilder::from(&solid_style)
+            .stroke_color(Gray2::new(0x2))
+            .stroke_style(StrokeStyle::Dotted)
+            .build();
+
+        let mut display = MockDisplay::new();
+        display.set_allow_overdraw(true);
+
+        for line in lines {
+            line.into_styled(solid_style).draw(&mut display).unwrap();
+            line.into_styled(dotted_style).draw(&mut display).unwrap();
+            Rectangle::new(line.start, Size::new_equal(1))
+                .into_styled(solid_fill_style)
+                .draw(&mut display)
+                .unwrap();
+
+            Rectangle::new(line.end, Size::new_equal(1))
+                .into_styled(solid_fill_style)
+                .draw(&mut display)
+                .unwrap();
+        }
+
+        display.assert_pattern(&[
+            "02     20      20 ",
+            "22     22     122 ",
+            " 11    11    11   ",
+            "  11   11   11    ",
+            "   102 20  20     ",
+            "    22 22  22     ",
+            "                  ",
+            "           221122 ",
+            "021102     201120 ",
+            "221122            ",
+            "                  ",
+            "    22  22 22     ",
+            "    02  02 201    ",
+            "   11   11   11   ",
+            "  11    11    11  ",
+            "221     22     22 ",
+            "02      02     20 ",
         ]);
     }
 }

--- a/src/primitives/line/styled.rs
+++ b/src/primitives/line/styled.rs
@@ -86,7 +86,7 @@ where
 fn start_dot_offset(line: &Line, dot_size: i32) -> Point {
     if dot_size % 2 == 1 {
         // The dot size is odd so the positioning is already ideal.
-        return line.start;
+        return Point::zero();
     }
 
     // Depending on the line orientation, the number of bresenham lines might be odd or even.
@@ -98,8 +98,8 @@ fn start_dot_offset(line: &Line, dot_size: i32) -> Point {
     // on the edge of the rasterized line.
     //
     // There's a drawing of the resulting alignment in test `start_dot_offset_matches_drawing`.
-    let mut start = line.start;
-    let delta = if start != line.end {
+    let mut start = Point::zero();
+    let delta = if line.start != line.end {
         line.delta()
     } else {
         HORIZONTAL_LINE.delta()
@@ -183,28 +183,27 @@ impl<C: PixelColor> StyledDrawable<PrimitiveStyle<C>> for Line {
                 // is longer by one pixel when the dot size is even.
                 // So that the dotted rectangle border matches 4 lines drawn in clockwise order,
                 // the line is extended by one pixel when the dot size is even.
-                extend_line_by_one_unit(self)
+                let extended = extend_line_by_one_unit(self);
+                // Improve the positioning of the dots.
+                extended.translate(start_dot_offset(self, dot_size))
             } else {
                 *self
             };
 
             // Draw dots along the line.
-            let dotted_line_points =
-                DottedLinePoints::with_dot_size(&line.translate(-line.start), dot_size);
+            let dotted_line_points = DottedLinePoints::with_dot_size(&line, dot_size);
             let dot_style = PrimitiveStyle::with_fill(stroke_color);
-            // Improve the positioning of the dots.
-            let start = start_dot_offset(self, dot_size);
 
             if dot_size > 3 {
                 draw_dotted_line(
-                    &Circle::with_center(start, dot_size as u32),
+                    &Circle::with_center(Point::zero(), dot_size as u32),
                     &dotted_line_points,
                     &dot_style,
                     target,
                 )
             } else {
                 draw_dotted_line(
-                    &Rectangle::with_center(start, Size::new_equal(dot_size as u32)),
+                    &Rectangle::with_center(Point::zero(), Size::new_equal(dot_size as u32)),
                     &dotted_line_points,
                     &dot_style,
                     target,

--- a/src/primitives/line/thick_points.rs
+++ b/src/primitives/line/thick_points.rs
@@ -9,7 +9,7 @@ use crate::{
     },
 };
 
-const HORIZONTAL_LINE: Line = Line::new(Point::zero(), Point::new(1, 0));
+pub(super) const HORIZONTAL_LINE: Line = Line::new(Point::zero(), Point::new(1, 0));
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[cfg_attr(feature = "defmt", derive(::defmt::Format))]
@@ -220,6 +220,15 @@ impl ThickPoints {
             parallel_points_remaining: 0,
             iter: ParallelsIterator::new(line, thickness, StrokeOffset::None),
         }
+    }
+
+    /// Returns `true` when the line uses a number of bresenham lines greater than the stroke width.
+    ///
+    /// Horizontal and vertical lines use `x` bresenham lines where `x` is the stroke width.
+    /// Diagonal lines however, may require more bresenham lines to have the same visual width.
+    pub(super) fn has_more_lines_than_expected(line: &Line, thickness: i32) -> bool {
+        let iter = ParallelsIterator::new(line, thickness, StrokeOffset::None);
+        iter.count() as i32 > thickness
     }
 }
 

--- a/src/primitives/line/thick_points.rs
+++ b/src/primitives/line/thick_points.rs
@@ -221,15 +221,6 @@ impl ThickPoints {
             iter: ParallelsIterator::new(line, thickness, StrokeOffset::None),
         }
     }
-
-    /// Returns `true` when the line uses a number of bresenham lines greater than the stroke width.
-    ///
-    /// Horizontal and vertical lines use `x` bresenham lines where `x` is the stroke width.
-    /// Diagonal lines however, may require more bresenham lines to have the same visual width.
-    pub(super) fn has_more_lines_than_expected(line: &Line, thickness: i32) -> bool {
-        let iter = ParallelsIterator::new(line, thickness, StrokeOffset::None);
-        iter.count() as i32 > thickness
-    }
 }
 
 impl Iterator for ThickPoints {

--- a/src/primitives/primitive_style.rs
+++ b/src/primitives/primitive_style.rs
@@ -48,7 +48,7 @@ where
     /// The stroke style sets the border style (default is [`StrokeStyle::Solid`]).
     ///
     /// [`StrokeStyle::Dotted`] is only implemented for the [`Rectangle`](crate::primitives::Rectangle)
-    /// primitive, the default will be used for all other primitives.
+    /// and the [`Line`](crate::primitives::Line) primitive, the default will be used for all other primitives.
     pub stroke_style: StrokeStyle,
 }
 


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [X] Check that you've added passing tests and documentation
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [X] Run `rustfmt` on the project
- [X] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR implements support for dotted lines following the issue #771. It uses 2 different strategies based on the width of the line :
- for thin lines, the regular line iterator `ThickPoints` is used but part of the pixels are skipped
- for thicker lines, dots are drawn regularly along the line using primitive `Circle` and new iterator `DottedLinePoints`

Thin lines have width below 3, I tried to apply the thin line strategy for width 3 but I didn't manage (more details in the comment from the 2nd commit).

The new iterator `DottedLinePoints` computes relevant points (from a bresenham line) to draw a dotted line with the desired number of points. In the previous PR for the rectangle dotted border, I used floats (`Real` type) to determine the dot positions. I realized that I could use a variant of the bresenham algorithm to do this without using floats. The result should be exactly the same (it's tested in `dotted_line_dots_are_correct`). 

Eventually, the dotted rectangle border could also rely on `DottedLinePoints` instead of using floats.

## Testing the code

I used the debug-tools repo, attached is a patch that updates the Cargo.toml (the extension must be changed to .patch).

[debug-tools-dotted-line.patch.txt](https://github.com/user-attachments/files/19727098/debug-tools-dotted-line.patch.txt)

## Changelog ?

I didn't update it (only a public comment was changed in `PrimitiveStyle`).