### PR TITLE
Correct dot spacing for thin rectangle borders

### DIFF
--- a/src/primitives/rectangle/styled.rs
+++ b/src/primitives/rectangle/styled.rs
@@ -186,7 +186,7 @@ where
 
         for offset in unit_positions_in_clockwise_order(length, dot_size) {
             if unit_is_dot {
-                let translation = *side / length as i32 * offset;
+                let translation = Point::new(side.x.signum(), side.y.signum()) * offset;
                 corner_dot
                     .translate(translation)
                     .draw_styled(style, target)?;
@@ -233,7 +233,7 @@ impl<C: PixelColor> StyledDrawable<PrimitiveStyle<C>> for Rectangle {
                 return Ok(());
             }
 
-            let border_size = stroke_area.size - Size::new_equal(dot_size);
+            let border_size = stroke_area.size.saturating_sub(Size::new_equal(dot_size));
             let dot_style = PrimitiveStyle::with_fill(stroke_color);
 
             if dot_size < 4 {


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [X] Check that you've added passing tests and documentation
- [X] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [X] Run `rustfmt` on the project
- [X] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This fixes a dotted rectangle border issue introduced in #772.

The `dot_positions_in_clockwise_order` function was originally intended to compute both dot and gap positions. However, it actually computed only dot positions, using `length / (2 * dot_size)` instead of `length / dot_size`, causing excessive spacing between dots for thin rectangle borders.

This probably happened because I made a copy-paste of the similar function `dot_positions_with_dotted_corners` during the last stage of the PR. Unfortunately I didn't notice the functionality change before.

This commit:
- fixes the computation
- renames the problematic function to `unit_positions_in_clockwise_order`
- moves the 2 functions closer together for comparison
- adds a unit test using `MockDisplay`

## Other remarks

After this PR, `dot_positions_with_dotted_corners`  and `dot_positions_in_clockwise_order` become similar with respect to the division by 0 risk. It's not possible with the input arguments given by the current code (because `dot_size` is chosen to be smaller than `length` in `draw_styled`), but it could happen with different input arguments.

Thus I think both functions should handle the eventuality in the same way, which is not the case here.
The better option seems to be adding a check in `*dotted_corners` and returning an empty iterator in the problematic case.

Should I add a commit for this in this PR?