### PR TITLE
Add oled-async to list of supported drivers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Note that some drivers may not support the latest version of embedded-graphics.
 * [hub75](https://crates.io/crates/hub75): A rust driver for hub75 rgb matrix displays
 * [ili9341](https://crates.io/crates/ili9341): A platform agnostic driver to interface with the ILI9341 (and ILI9340C) TFT LCD display
 * [ls010b7dh01](https://crates.io/crates/ls010b7dh01): A platform agnostic driver for the LS010B7DH01 memory LCD display
+* [oled-async](https://crates.io/crates/oled_async): Extensible I2C/SPI async driver for OLED displays(SH1107, SH1108 & SSD1309...)
 * [push2_display](https://crates.io/crates/push2_display): Ableton Push2 embedded-graphics display driver
 * [retro-display](https://crates.io/crates/retro-display): Display drivers for retro-computers incl. Commodore 64
 * [sh1106](https://crates.io/crates/sh1106): I2C driver for the SH1106 OLED display


### PR DESCRIPTION
Oled-async is designed to support many different displays with similar command structures.

Thank you for helping out with embedded-graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Oled-async is designed to support many different displays with similar command structures.
This change just adds it to the list of supported drivers. Documentation only change.

