### PR TITLE
Fix broken doc links

### DIFF
--- a/core/src/geometry/size.rs
+++ b/core/src/geometry/size.rs
@@ -56,7 +56,6 @@ use crate::geometry::Point;
 /// # }
 /// ```
 ///
-/// [`Drawable`]: super::drawable::Drawable
 /// [`Vector2<N>`]: https://docs.rs/nalgebra/0.18.0/nalgebra/base/type.Vector2.html
 /// [`Vector2`]: https://docs.rs/nalgebra/0.18.0/nalgebra/base/type.Vector2.html
 /// [Nalgebra]: https://docs.rs/nalgebra

--- a/src/image/image_raw.rs
+++ b/src/image/image_raw.rs
@@ -113,9 +113,7 @@ pub enum ImageRawError {
 ///
 /// [`raw` module documentation]: crate::pixelcolor::raw
 /// [`Image`]: crate::image::Image
-/// [`Drawable`]: crate::drawable::Drawable
 /// [`PixelColor`]: crate::pixelcolor::PixelColor
-/// [`ByteOrder`]: crate::pixelcolor::raw::ByteOrder
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[cfg_attr(feature = "defmt", derive(::defmt::Format))]
 pub struct ImageRaw<'a, C, O = LittleEndianMsb0>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,7 +272,6 @@
 //! [Rounded rectangles]: primitives::rounded_rectangle::RoundedRectangle
 //! [Text]: text
 //! [Monospaced fonts]: mono_font
-//! [`Drawable`]: drawable::Drawable
 //! [`DrawTarget`]: https://docs.rs/embedded-graphics-core/latest/embedded_graphics_core/draw_target/trait.DrawTarget.html
 //! [`embedded-graphics-core`]: https://docs.rs/embedded-graphics-core/
 //! [simulator]: https://github.com/embedded-graphics/simulator

--- a/src/mono_font/mono_text_style.rs
+++ b/src/mono_font/mono_text_style.rs
@@ -62,9 +62,9 @@ where
 
     /// Returns `true` if the style is transparent.
     ///
-    /// Drawing a `Text` with a transparent `MonoTextStyle` will not draw any pixels.
+    /// Drawing a [`Text`] with a transparent `MonoTextStyle` will not draw any pixels.
     ///
-    /// [`Text`]: super::text::Text
+    /// [`Text`]: crate::text::Text
     pub fn is_transparent(&self) -> bool {
         self.text_color.is_none()
             && self.background_color.is_none()

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -153,7 +153,6 @@
 //! # Ok::<(), core::convert::Infallible>(())
 //! ```
 //!
-//! [`Text::new`]: TextStyle::new()
 //! [`with_alignment`]: Text::with_alignment()
 //! [`with_baseline`]: Text::with_baseline()
 //! [`with_text_style`]: Text::with_text_style()


### PR DESCRIPTION
This PR fixes the broken unused docs links that weren't detected by older Rust version, but caused CI to fail on Rust 1.87.0.
