### PR TITLE
Bump MSRV to 1.81

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [1.71.1, beta, stable]
+        rust: [1.81, beta, stable]
     steps:
       - uses: taiki-e/install-action@just
       - uses: dtolnay/rust-toolchain@stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - **(breaking)** [#765](https://github.com/embedded-graphics/embedded-graphics/pull/765) Made conversion to and from `RawUx` types mandatory for all `PixelColor` implementations.
 - **(breaking)** [#767](https://github.com/embedded-graphics/embedded-graphics/pull/767) Renamed `ByteOrder`, `LittleEndian`, and `BigEndian` to `DataOrder`, `LittleEndianMsb0`, and `BigEndianLsb0`.
 - **(breaking)** [#767](https://github.com/embedded-graphics/embedded-graphics/pull/767) Changed default data order for `ImageRaw` from `BigEndian` to `LittleEndianMsb0`.
+- **(breaking)** [#781](https://github.com/embedded-graphics/embedded-graphics/pull/781) Bump MSRV to 1.81.
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ exclude = [
 	"convert_1bpp.sh",
 ]
 edition = "2021"
+rust-version = "1.81"
 
 [workspace]
 members = ["core"]

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Additional examples can be found in the [examples](https://github.com/embedded-g
 
 ## Minimum supported Rust version
 
-The minimum supported Rust version for embedded-graphics is `1.71.1` or greater.
+The minimum supported Rust version for embedded-graphics is `1.81` or greater.
 Ensure you have the correct version of Rust installed, preferably through <https://rustup.rs>.
 
 ## Development setup

--- a/README.tpl
+++ b/README.tpl
@@ -14,7 +14,7 @@
 
 ## Minimum supported Rust version
 
-The minimum supported Rust version for embedded-graphics is `1.71.1` or greater.
+The minimum supported Rust version for embedded-graphics is `1.81` or greater.
 Ensure you have the correct version of Rust installed, preferably through <https://rustup.rs>.
 
 ## Development setup

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,6 +4,7 @@ description = "Core traits and functionality for embedded-graphics"
 version = "0.4.0"
 authors = ["James Waples <james@wapl.es>", "Ralf Fuest <mail@rfuest.de>"]
 edition = "2021"
+rust-version = "1.81"
 repository = "https://github.com/embedded-graphics/embedded-graphics"
 documentation = "https://docs.rs/embedded-graphics-core"
 categories = ["embedded", "no-std"]

--- a/core/README.md
+++ b/core/README.md
@@ -70,7 +70,7 @@ a spritemap.
 
 ## Minimum supported Rust version
 
-The minimum supported Rust version for embedded-graphics-core is `1.71.1` or greater.
+The minimum supported Rust version for embedded-graphics-core is `1.81` or greater.
 Ensure you have the correct version of Rust installed, preferably through <https://rustup.rs>.
 
 ## Development setup

--- a/core/README.tpl
+++ b/core/README.tpl
@@ -14,7 +14,7 @@
 
 ## Minimum supported Rust version
 
-The minimum supported Rust version for embedded-graphics-core is `1.71.1` or greater.
+The minimum supported Rust version for embedded-graphics-core is `1.81` or greater.
 Ensure you have the correct version of Rust installed, preferably through <https://rustup.rs>.
 
 ## Development setup

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -12,7 +12,7 @@ Target audience: crate maintainers who wish to release `embedded-graphics` or `e
 ## On your local machine
 
 - `cd` to the repository root
-- Use the crate MSRV of 1.71.1 by running `rustup override set 1.71.1`
+- Use the crate MSRV of 1.81 by running `rustup override set 1.81`
 - Check that `just` and `cargo-release` are installed and available in `$PATH`.
   - `just --version`
   - `cargo release --version`


### PR DESCRIPTION
This PR bumps the MSRV to 1.81, which should fix the CI issues. My reason for picking 1.81 is that `embedded-hal` uses this MSRV and, at least for embedded projects, it doesn't really make sense to be more restrictive than a crate that will be used by nearly 100% of all projects.