### PR TITLE
Add a thin wrapper to handle transparency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#767](https://github.com/embedded-graphics/embedded-graphics/pull/767) Added `MASK` constant to `RawData` trait.
 - [#768](https://github.com/embedded-graphics/embedded-graphics/pull/768) Added 8bit `Rgb332` support.
 - [#772](https://github.com/embedded-graphics/embedded-graphics/pull/772), [#776](https://github.com/embedded-graphics/embedded-graphics/pull/776) Added `PrimitiveStyle::stroke_style` property to draw dotted borders (currently only supported for `Rectangle` and `Line`).
+- [#786](https://github.com/embedded-graphics/embedded-graphics/pull/786) Added `ImageTransparent` to add transparency to an `ImageDrawable`
 
 ## [0.8.1] - 2023-08-10
 

--- a/src/image/image_transparent.rs
+++ b/src/image/image_transparent.rs
@@ -2,7 +2,6 @@ use crate::{
     draw_target::DrawTarget,
     geometry::{Dimensions, OriginDimensions, Size},
     image::ImageDrawable,
-    pixelcolor::PixelColor,
     primitives::Rectangle,
     Pixel,
 };
@@ -41,7 +40,7 @@ use crate::{
 /// let source: ImageRaw<Gray8> = ImageRaw::new(&data, Size::new(4, 4)).unwrap();
 ///
 /// // Make all white pixels (`0xFF`) in the source image transparent.
-/// let transparent = ImageTransparent::new(source, Rgb565::WHITE);
+/// let transparent = ImageTransparent::new(source, Gray8::WHITE);
 ///
 /// // Draw the transparent image at `(0, 0)`.
 /// let image = Image::new(&transparent, Point::zero());
@@ -51,16 +50,16 @@ use crate::{
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(::defmt::Format))]
-pub struct ImageTransparent<T, C> {
+pub struct ImageTransparent<T: ImageDrawable> {
     source: T,
-    transparent_color: C,
+    transparent_color: T::Color,
 }
 
-impl<T: ImageDrawable, C: PixelColor> ImageTransparent<T, C> {
+impl<T: ImageDrawable> ImageTransparent<T> {
     /// Creates a new `ImageTransparent` based on a source image.
     ///
     /// All pixels with the given transparent color will be skipped during drawing.
-    pub fn new(source: T, transparent_color: C) -> Self {
+    pub fn new(source: T, transparent_color: T::Color) -> Self {
         ImageTransparent {
             source,
             transparent_color,
@@ -68,14 +67,14 @@ impl<T: ImageDrawable, C: PixelColor> ImageTransparent<T, C> {
     }
 }
 
-impl<T: ImageDrawable, C: PixelColor> OriginDimensions for ImageTransparent<T, C> {
+impl<T: ImageDrawable> OriginDimensions for ImageTransparent<T> {
     fn size(&self) -> Size {
         self.source.size()
     }
 }
 
-impl<T: ImageDrawable<Color = C>, C: PixelColor> ImageDrawable for ImageTransparent<T, C> {
-    type Color = C;
+impl<T: ImageDrawable> ImageDrawable for ImageTransparent<T> {
+    type Color = T::Color;
 
     fn draw<D>(&self, target: &mut D) -> Result<(), D::Error>
     where

--- a/src/image/image_transparent.rs
+++ b/src/image/image_transparent.rs
@@ -1,0 +1,98 @@
+use crate::draw_target::DrawTarget;
+use crate::geometry::{Dimensions, OriginDimensions, Size};
+use crate::Pixel;
+use crate::pixelcolor::PixelColor;
+use crate::prelude::ImageDrawable;
+use crate::primitives::Rectangle;
+
+/// A thin wrapper around an `ImageDrawable` to make it handle transparency.
+///
+/// The new object can be used inside an `Image` like the previous one.
+///
+/// `ImageTransparent` has the same content as its source `ImageDrawable`
+/// but it doesn't draw anything when it encounters a transparent color.
+///
+/// This makes it possible to create transparent images from types that don't support it.
+///
+/// Example:
+/// ```
+/// # use embedded_graphics::{
+/// # image::{Image, ImageRaw, ImageRawBE, ImageTransparent},
+/// #     pixelcolor::Rgb565,
+/// #     prelude::*,
+/// # };
+/// # use embedded_graphics::mock_display::MockDisplay as Display;
+///
+/// let mut display: Display<Rgb565> = Display::default();
+/// // Example with an ImageRaw as ImageTransparent source
+/// let data = [
+///     0x00, 0x00, 0xF8, 0x00, 0x07, 0xE0, 0xFF, 0xE0, //
+///     0x00, 0x1F, 0x07, 0xFF, 0xF8, 0x1F, 0xFF, 0xFF, //
+/// ];
+/// let raw: ImageRawBE<Rgb565> = ImageRaw::new(&data, Size::new(4, 2)).unwrap();
+///
+/// // Create the transparent object
+/// let transparent = ImageTransparent::new(raw, Rgb565::WHITE);
+///
+/// // Create an Image object from ImageTransparent
+/// let image = Image::new(&transparent, Point::zero());
+/// image.draw(&mut display)?;
+///
+/// # Ok::<(), core::convert::Infallible>(())
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(::defmt::Format))]
+pub struct ImageTransparent<T, C> {
+    drawable: T,
+    transparent_color: C,
+}
+
+impl<T: ImageDrawable, C: PixelColor> ImageTransparent<T,C> {
+    /// Creates a new `ImageTransparent` use it within `Image`
+    pub fn new(drawable: T, transparent_color: C) -> Self {
+        ImageTransparent { drawable, transparent_color }
+    }
+}
+
+impl<T: ImageDrawable, C: PixelColor> OriginDimensions for ImageTransparent<T, C> {
+    fn size(&self) -> Size {
+        self.drawable.size()
+    }
+}
+
+impl<T: ImageDrawable<Color=C>, C: PixelColor> ImageDrawable for ImageTransparent<T,C> {
+    type Color = C;
+
+    fn draw<D>(&self, target: &mut D) -> Result<(), D::Error> where D: DrawTarget<Color=Self::Color> {
+        let mut drawer = Drawer { target, transparent_color: self.transparent_color };
+        self.drawable.draw(&mut drawer)
+    }
+
+    fn draw_sub_image<D>(&self, target: &mut D, area: &Rectangle) -> Result<(), D::Error> where D: DrawTarget<Color=Self::Color> {
+        let mut drawer = Drawer { target, transparent_color: self.transparent_color };
+        self.drawable.draw_sub_image(&mut drawer, area)
+    }
+}
+
+struct Drawer<'a, T,C> {
+    target: &'a mut T,
+    transparent_color: C,
+}
+
+impl<'a, T: DrawTarget<Color=C>, C> Dimensions for Drawer<'a, T, C> {
+    fn bounding_box(&self) -> Rectangle {
+        self.target.bounding_box()
+    }
+}
+
+impl<'a,T: DrawTarget<Color=C>, C: PixelColor> DrawTarget for Drawer<'a, T,C> {
+    type Color = C;
+    type Error = T::Error;
+
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error> where I: IntoIterator<Item=Pixel<Self::Color>> {
+        self.target.draw_iter(
+            pixels.into_iter()
+                .filter(|pixel| pixel.1 != self.transparent_color ))
+    }
+}
+

--- a/src/image/image_transparent.rs
+++ b/src/image/image_transparent.rs
@@ -1,9 +1,9 @@
 use crate::draw_target::DrawTarget;
 use crate::geometry::{Dimensions, OriginDimensions, Size};
-use crate::Pixel;
 use crate::pixelcolor::PixelColor;
 use crate::prelude::ImageDrawable;
 use crate::primitives::Rectangle;
+use crate::Pixel;
 
 /// A thin wrapper around an `ImageDrawable` to make it handle transparency.
 ///
@@ -47,10 +47,13 @@ pub struct ImageTransparent<T, C> {
     transparent_color: C,
 }
 
-impl<T: ImageDrawable, C: PixelColor> ImageTransparent<T,C> {
+impl<T: ImageDrawable, C: PixelColor> ImageTransparent<T, C> {
     /// Creates a new `ImageTransparent` use it within `Image`
     pub fn new(drawable: T, transparent_color: C) -> Self {
-        ImageTransparent { drawable, transparent_color }
+        ImageTransparent {
+            drawable,
+            transparent_color,
+        }
     }
 }
 
@@ -60,39 +63,55 @@ impl<T: ImageDrawable, C: PixelColor> OriginDimensions for ImageTransparent<T, C
     }
 }
 
-impl<T: ImageDrawable<Color=C>, C: PixelColor> ImageDrawable for ImageTransparent<T,C> {
+impl<T: ImageDrawable<Color = C>, C: PixelColor> ImageDrawable for ImageTransparent<T, C> {
     type Color = C;
 
-    fn draw<D>(&self, target: &mut D) -> Result<(), D::Error> where D: DrawTarget<Color=Self::Color> {
-        let mut drawer = Drawer { target, transparent_color: self.transparent_color };
+    fn draw<D>(&self, target: &mut D) -> Result<(), D::Error>
+    where
+        D: DrawTarget<Color = Self::Color>,
+    {
+        let mut drawer = Drawer {
+            target,
+            transparent_color: self.transparent_color,
+        };
         self.drawable.draw(&mut drawer)
     }
 
-    fn draw_sub_image<D>(&self, target: &mut D, area: &Rectangle) -> Result<(), D::Error> where D: DrawTarget<Color=Self::Color> {
-        let mut drawer = Drawer { target, transparent_color: self.transparent_color };
+    fn draw_sub_image<D>(&self, target: &mut D, area: &Rectangle) -> Result<(), D::Error>
+    where
+        D: DrawTarget<Color = Self::Color>,
+    {
+        let mut drawer = Drawer {
+            target,
+            transparent_color: self.transparent_color,
+        };
         self.drawable.draw_sub_image(&mut drawer, area)
     }
 }
 
-struct Drawer<'a, T,C> {
+struct Drawer<'a, T, C> {
     target: &'a mut T,
     transparent_color: C,
 }
 
-impl<'a, T: DrawTarget<Color=C>, C> Dimensions for Drawer<'a, T, C> {
+impl<'a, T: DrawTarget<Color = C>, C> Dimensions for Drawer<'a, T, C> {
     fn bounding_box(&self) -> Rectangle {
         self.target.bounding_box()
     }
 }
 
-impl<'a,T: DrawTarget<Color=C>, C: PixelColor> DrawTarget for Drawer<'a, T,C> {
+impl<'a, T: DrawTarget<Color = C>, C: PixelColor> DrawTarget for Drawer<'a, T, C> {
     type Color = C;
     type Error = T::Error;
 
-    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error> where I: IntoIterator<Item=Pixel<Self::Color>> {
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
         self.target.draw_iter(
-            pixels.into_iter()
-                .filter(|pixel| pixel.1 != self.transparent_color ))
+            pixels
+                .into_iter()
+                .filter(|pixel| pixel.1 != self.transparent_color),
+        )
     }
 }
-

--- a/src/image/image_transparent.rs
+++ b/src/image/image_transparent.rs
@@ -1,9 +1,11 @@
-use crate::draw_target::DrawTarget;
-use crate::geometry::{Dimensions, OriginDimensions, Size};
-use crate::pixelcolor::PixelColor;
-use crate::prelude::ImageDrawable;
-use crate::primitives::Rectangle;
-use crate::Pixel;
+use crate::{
+    draw_target::DrawTarget,
+    geometry::{Dimensions, OriginDimensions, Size},
+    image::ImageDrawable,
+    pixelcolor::PixelColor,
+    primitives::Rectangle,
+    Pixel,
+};
 
 /// A wrapper to add basic transparency to an `ImageDrawable`.
 ///

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -97,14 +97,14 @@
 
 mod image_drawable_ext;
 mod image_raw;
-mod sub_image;
 mod image_transparent;
+mod sub_image;
 
 pub use embedded_graphics_core::image::{GetPixel, ImageDrawable};
 pub use image_drawable_ext::ImageDrawableExt;
 pub use image_raw::{ImageRaw, ImageRawBE, ImageRawError, ImageRawLE};
-pub use sub_image::SubImage;
 pub use image_transparent::ImageTransparent;
+pub use sub_image::SubImage;
 
 use crate::{
     draw_target::{DrawTarget, DrawTargetExt},

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -98,11 +98,13 @@
 mod image_drawable_ext;
 mod image_raw;
 mod sub_image;
+mod image_transparent;
 
 pub use embedded_graphics_core::image::{GetPixel, ImageDrawable};
 pub use image_drawable_ext::ImageDrawableExt;
 pub use image_raw::{ImageRaw, ImageRawBE, ImageRawError, ImageRawLE};
 pub use sub_image::SubImage;
+pub use image_transparent::ImageTransparent;
 
 use crate::{
     draw_target::{DrawTarget, DrawTargetExt},


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [ ] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Add a thin wrapper called ImageTransparent that takes an ImageDrawable and acts an ImageDrawable.
It transforms the original ImageDrawable into an ImageDrawable that handles transparency.
It takes a color parameter and this color is never drawn to the target.

This solves https://github.com/embedded-graphics/embedded-graphics/issues/712 for any bpp