### PR TITLE
Add MiniType and embedded-rgba crates to the list of additional functionality crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ this are adding support for different image formats or implementing custom fonts
 * [Canvas for drawing onto before drawing on the display - `embedded-canvas`](https://crates.io/crates/embedded-canvas)
 * [Frames Per Second counter for embedded devices - `embedded-fps`](https://crates.io/crates/embedded-fps)
 * [Framebuffer with DMA support - `embedded-graphics-framebuf`](https://crates.io/crates/embedded-graphics-framebuf)
+* [Alpha compositing Canvas with a framebuffer - `embedded-rgba`](https://crates.io/crates/embedded-rgba)
+* [Use any font with embedded-graphics - antialiased bitmap font format - `minitype`](https://crates.io/crates/minitype)
 
 Note that some of these crates may not support the latest version of embedded-graphics.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,8 @@
 //! * [Canvas for drawing onto before drawing on the display - `embedded-canvas`](https://crates.io/crates/embedded-canvas)
 //! * [Frames Per Second counter for embedded devices - `embedded-fps`](https://crates.io/crates/embedded-fps)
 //! * [Framebuffer with DMA support - `embedded-graphics-framebuf`](https://crates.io/crates/embedded-graphics-framebuf)
+//! * [Alpha compositing Canvas with a framebuffer - `embedded-rgba`](https://crates.io/crates/embedded-rgba)
+//! * [Use any font with embedded-graphics - antialiased bitmap font format  - `minitype`](https://crates.io/crates/minitype)
 //!
 //! Note that some of these crates may not support the latest version of embedded-graphics.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 //! * [Frames Per Second counter for embedded devices - `embedded-fps`](https://crates.io/crates/embedded-fps)
 //! * [Framebuffer with DMA support - `embedded-graphics-framebuf`](https://crates.io/crates/embedded-graphics-framebuf)
 //! * [Alpha compositing Canvas with a framebuffer - `embedded-rgba`](https://crates.io/crates/embedded-rgba)
-//! * [Use any font with embedded-graphics - antialiased bitmap font format  - `minitype`](https://crates.io/crates/minitype)
+//! * [Use any font with embedded-graphics - antialiased bitmap font format - `minitype`](https://crates.io/crates/minitype)
 //!
 //! Note that some of these crates may not support the latest version of embedded-graphics.
 //!


### PR DESCRIPTION
## PR description

Add [MiniType](https://github.com/dempfi/minitype) and [embedded-reba](https://github.com/dempfi/embedded-rgba) to the list of crates
