### PR TITLE
Add reference to embedded-ttf in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ this are adding support for different image formats or implementing custom fonts
 * [MogeeFont proportional font with kerning and ligatures - `embedded-mogeefont`](https://crates.io/crates/embedded_mogeefont)
 * [IBM437 font - `ibm437`](https://crates.io/crates/ibm437)
 * [The fonts shipped with `embedded-graphics` 0.6 - `embedded-vintage-fonts`](https://crates.io/crates/embedded-vintage-fonts)
+* [TTF and OTF font support - `embedded-ttf`](https://crates.io/crates/embedded-ttf)
 * [Simple layout/alignment functions - `embedded-layout`](https://crates.io/crates/embedded-layout)
 * [TextBox with text alignment options - `embedded-text`](https://crates.io/crates/embedded-text)
 * [Heapless plotting library for small embedded targets - `embedded-plots`](https://crates.io/crates/embedded-plots)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@
 //! * [MogeeFont proportional font with kerning and ligatures - `embedded-mogeefont`](https://crates.io/crates/embedded_mogeefont)
 //! * [IBM437 font - `ibm437`](https://crates.io/crates/ibm437)
 //! * [The fonts shipped with `embedded-graphics` 0.6 - `embedded-vintage-fonts`](https://crates.io/crates/embedded-vintage-fonts)
+//! * [TTF and OTF font support - `embedded-ttf`](https://crates.io/crates/embedded-ttf)
 //! * [Simple layout/alignment functions - `embedded-layout`](https://crates.io/crates/embedded-layout)
 //! * [TextBox with text alignment options - `embedded-text`](https://crates.io/crates/embedded-text)
 //! * [Heapless plotting library for small embedded targets - `embedded-plots`](https://crates.io/crates/embedded-plots)


### PR DESCRIPTION
Thank you for helping out with embedded-graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Hello, I created the `embeddd-ttf` crate to make loading and rendering ttf font available for `embedded-graphics`.

What do you think of including it to your external crates list in your documentation ?