### PR TITLE
Derive Default for enums

### DIFF
--- a/core/src/pixelcolor/binary_color.rs
+++ b/core/src/pixelcolor/binary_color.rs
@@ -39,20 +39,15 @@ use crate::pixelcolor::{
 /// };
 /// assert_eq!(color, BinaryColor::On);
 /// ```
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 #[cfg_attr(feature = "defmt", derive(::defmt::Format))]
 pub enum BinaryColor {
     /// Inactive pixel.
+    #[default]
     Off,
 
     /// Active pixel.
     On,
-}
-
-impl Default for BinaryColor {
-    fn default() -> Self {
-        Self::Off
-    }
 }
 
 impl BinaryColor {

--- a/src/primitives/primitive_style.rs
+++ b/src/primitives/primitive_style.rs
@@ -295,21 +295,16 @@ where
 }
 
 /// Stroke alignment.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 #[cfg_attr(feature = "defmt", derive(::defmt::Format))]
 pub enum StrokeAlignment {
     /// Inside.
     Inside,
     /// Center.
+    #[default]
     Center,
     /// Outside.
     Outside,
-}
-
-impl Default for StrokeAlignment {
-    fn default() -> Self {
-        Self::Center
-    }
 }
 
 /// Stroke style.


### PR DESCRIPTION
This PR replaces the manual implementations of `Debug` for `BinaryColor` and `StrokeAlignment` with derives. Fixes warnings in the latest clippy version.