### PR TITLE
Add RawU12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 ### Added
 
-- [#732](https://github.com/embedded-graphics/embedded-graphics/pull/732) Added `Rgb444` to support 12bit RGB displays. Note that this type is currently stored as a 16 bit value in `ImageRaw`s and `Framebuffer`s.
+- [#815](https://github.com/embedded-graphics/embedded-graphics/pull/815) Added `RawU12` type to support storing 12 bit values in `ImageRaw`s and `Framebuffer`s.
+- [#732](https://github.com/embedded-graphics/embedded-graphics/pull/732) Added `Rgb444` to support 12bit RGB displays.
 - [#733](https://github.com/embedded-graphics/embedded-graphics/pull/733) Added `envelope` method to `Rectangle`.
 - [#738](https://github.com/embedded-graphics/embedded-graphics/pull/738) Added `new_at_origin` method to `Rectangle`.
 - [#756](https://github.com/embedded-graphics/embedded-graphics/pull/756) Added `PartialEq, Eq` derives to `Image` and `SubImage`.

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -14,7 +14,8 @@
 
 ### Added
 
-- [#732](https://github.com/embedded-graphics/embedded-graphics/pull/732) Added `Rgb444` to support 12bit RGB displays. Note that this type is currently stored as a 16 bit value in `ImageRaw`s and `Framebuffer`s.
+- [#815](https://github.com/embedded-graphics/embedded-graphics/pull/815) Added `RawU12` type to support storing 12 bit values in `ImageRaw`s and `Framebuffer`s.
+- [#732](https://github.com/embedded-graphics/embedded-graphics/pull/732) Added `Rgb444` to support 12bit RGB displays.
 - [#733](https://github.com/embedded-graphics/embedded-graphics/pull/733) Added `envelope` method to `Rectangle`.
 - [#738](https://github.com/embedded-graphics/embedded-graphics/pull/738) Added `new_at_origin` method to `Rectangle`.
 - [#763](https://github.com/embedded-graphics/embedded-graphics/pull/763) Added `swap_xy` method to `Point` and `Size`.

--- a/core/src/pixelcolor/raw/load_store.rs
+++ b/core/src/pixelcolor/raw/load_store.rs
@@ -1,5 +1,6 @@
 use super::{
-    DataOrder, OutOfBoundsError, RawData, RawU1, RawU16, RawU2, RawU24, RawU32, RawU4, RawU8,
+    u12, DataOrder, OutOfBoundsError, RawData, RawU1, RawU12, RawU16, RawU2, RawU24, RawU32, RawU4,
+    RawU8,
 };
 
 pub(crate) trait LoadStore<O: DataOrder>: Sized {
@@ -64,6 +65,26 @@ impl<O: DataOrder> LoadStore<O> for RawU8 {
             .get_mut(index)
             .ok_or(OutOfBoundsError)
             .map(|byte| *byte = self.0)
+    }
+}
+
+impl<O: DataOrder> LoadStore<O> for RawU12 {
+    fn load(buffer: &[u8], index: usize) -> Option<Self> {
+        let value = if O::IS_ALTERNATE_ORDER {
+            u12::load_u12_be(buffer, index)
+        } else {
+            u12::load_u12_le(buffer, index)
+        };
+
+        value.map(Self::new)
+    }
+
+    fn store(self, buffer: &mut [u8], index: usize) -> Result<(), OutOfBoundsError> {
+        if O::IS_ALTERNATE_ORDER {
+            u12::store_u12_be(buffer, index, self.into_inner())
+        } else {
+            u12::store_u12_le(buffer, index, self.into_inner())
+        }
     }
 }
 

--- a/core/src/pixelcolor/raw/mod.rs
+++ b/core/src/pixelcolor/raw/mod.rs
@@ -261,6 +261,7 @@ impl_raw_data!(RawU1: u8, 1, "1 bit");
 impl_raw_data!(RawU2: u8, 2, "2 bits");
 impl_raw_data!(RawU4: u8, 4, "4 bits");
 impl_raw_data!(RawU8: u8, 8, "8 bits");
+impl_raw_data!(RawU12: u16, 12, "12 bits");
 impl_raw_data!(RawU16: u16, 16, "16 bits");
 impl_raw_data!(RawU24: u32, 24, "24 bits");
 impl_raw_data!(RawU32: u32, 32, "32 bits");
@@ -316,6 +317,7 @@ mod tests {
         assert_eq!(RawU1::new(u8::max_value()).0, 0x1);
         assert_eq!(RawU2::new(u8::max_value()).0, 0x3);
         assert_eq!(RawU4::new(u8::max_value()).0, 0xF);
+        assert_eq!(RawU12::new(u16::max_value()).0, 0xFFF);
         assert_eq!(RawU24::new(u32::max_value()).0, 0xFFFFFF);
     }
 }

--- a/core/src/pixelcolor/raw/mod.rs
+++ b/core/src/pixelcolor/raw/mod.rs
@@ -120,6 +120,7 @@
 
 mod load_store;
 mod to_bytes;
+mod u12;
 
 pub use to_bytes::ToBytes;
 

--- a/core/src/pixelcolor/raw/to_bytes.rs
+++ b/core/src/pixelcolor/raw/to_bytes.rs
@@ -1,5 +1,5 @@
 use crate::pixelcolor::{
-    raw::{RawU1, RawU16, RawU2, RawU24, RawU32, RawU4, RawU8},
+    raw::{RawU1, RawU12, RawU16, RawU2, RawU24, RawU32, RawU4, RawU8},
     PixelColor,
 };
 
@@ -44,6 +44,7 @@ impl_to_bytes!(RawU1, [u8; 1]);
 impl_to_bytes!(RawU2, [u8; 1]);
 impl_to_bytes!(RawU4, [u8; 1]);
 impl_to_bytes!(RawU8, [u8; 1]);
+impl_to_bytes!(RawU12, [u8; 2]);
 impl_to_bytes!(RawU16, [u8; 2]);
 impl_to_bytes!(RawU32, [u8; 4]);
 
@@ -113,7 +114,7 @@ impl<C: PixelColor> ToBytes for C {
 mod tests {
     use super::*;
     use crate::pixelcolor::{
-        Bgr565, Bgr666, Bgr888, BinaryColor, Gray2, Gray4, Gray8, Rgb565, Rgb666, Rgb888,
+        Bgr565, Bgr666, Bgr888, BinaryColor, Gray2, Gray4, Gray8, Rgb444, Rgb565, Rgb666, Rgb888,
     };
 
     fn assert_all_orders<T>(value: T, bytes: T::Bytes)
@@ -148,6 +149,38 @@ mod tests {
     fn bpp8() {
         assert_all_orders(Gray8::new(0), [0]);
         assert_all_orders(Gray8::new(255), [255]);
+    }
+
+    #[test]
+    fn bpp12_rgb_be() {
+        assert_eq!(
+            Rgb444::new(15, 0, 0).to_be_bytes(),
+            [0b0000_1111, 0b000_00000]
+        );
+        assert_eq!(
+            Rgb444::new(0, 15, 0).to_be_bytes(),
+            [0b0000_0000, 0b1111_0000]
+        );
+        assert_eq!(
+            Rgb444::new(0, 0, 15).to_be_bytes(),
+            [0b0000_0000, 0b0000_1111]
+        );
+    }
+
+    #[test]
+    fn bpp12_rgb_le() {
+        assert_eq!(
+            Rgb444::new(15, 0, 0).to_le_bytes(),
+            [0b0000_0000, 0b0000_1111]
+        );
+        assert_eq!(
+            Rgb444::new(0, 15, 0).to_le_bytes(),
+            [0b1111_0000, 0b0000_0000]
+        );
+        assert_eq!(
+            Rgb444::new(0, 0, 15).to_le_bytes(),
+            [0b0000_1111, 0b0000_0000]
+        );
     }
 
     #[test]

--- a/core/src/pixelcolor/raw/u12.rs
+++ b/core/src/pixelcolor/raw/u12.rs
@@ -1,0 +1,343 @@
+//! Raw u12 support.
+//!
+//! This module contains helper functions to support reading and writing 12-bit values into and out
+//! of byte slices. This is necessary as every pixel value will have 4 bits in a separate byte from
+//! the other 8 bits, which means one out of every three bytes will contain 4 bits from two different
+//! pixels.
+
+use super::OutOfBoundsError;
+
+/// pixel_index_to_byte_and_nibble takes a pixel index and returns the starting byte index and the
+/// nibble index for that pixel when stored.
+#[inline]
+fn pixel_index_to_byte_and_nibble(index: usize) -> (usize, usize) {
+    let byte_index = (index * 12) / 8;
+    let nibble_index = index % 2;
+    (byte_index, nibble_index)
+}
+
+/// store_u12_be replaces the pixel (found in data, which is a mutable slice) at the passed index
+/// with the bytes in the u16. This is the big endian version of this
+/// function.
+#[inline]
+pub fn store_u12_be(data: &mut [u8], index: usize, value: u16) -> Result<(), OutOfBoundsError> {
+    let (byte_index, nibble_index) = pixel_index_to_byte_and_nibble(index);
+
+    // the value is in the next two bytes, so we need to validate that the byte
+    // index does not go beyond the size of the data.
+    if (byte_index + 1) > data.len() {
+        return Err(OutOfBoundsError);
+    }
+
+    // Throught this function we will use an example 12 bit value of 0x123.
+    // This could be a RGB444 pixel, with a red value of 1, green 2, and blue 3.
+    //
+    // As big endian bytes, this would then be:
+    //
+    // [0x01, 0x23]
+
+    if nibble_index == 0 {
+        // To get the start of the pixel, we bitshift the entire u16 value by 4 to the right
+        // and cast it to a u8 (dropping the most significant 8 bits from the u16).
+        //
+        // = (0x0123 >> 4) as u8
+        // = 0x0012 as u8
+        // = 0x12
+        //
+        // This is replaced in data at byte_index.
+        //
+        // [ 0x12, 0x?A, 0xAA ]
+        //
+        data[byte_index] = (value >> 4) as u8;
+
+        // Next, the subsequent byte in the data is masked and the remaining
+        // 4 bits in u16 are OR'd into it:
+        //
+        //   0x?A & 0x0F | ((0x0123 & 0x000F) << 4) as u8
+        // = 0x0A        | (0x0003 << 4) as u8
+        // = 0x0A        | 0x0030 as u8
+        // = 0x0A        | 0x30
+        // = 0x3A
+        //
+        // As a result, the pixel is now stored in the slice of bytes.
+        //
+        // [ 0x12, 0x3A, 0xAA ]
+
+        data[byte_index + 1] = data[byte_index + 1] & 0x0F | ((value & 0x000F) << 4) as u8;
+    } else {
+        // Since the start of the pixel is 4 bits, we bitshift the entire u16 right by 8
+        // and OR the result into into the first byte at the index in the data.
+        //
+        //   0xA? & 0xF0 | (0x0123 >> 8) as u8
+        // = 0xA0        | 0x0001 as u8
+        // = 0xA0        | 0x01
+        // = 0xA1
+        //
+        data[byte_index] = data[byte_index] & 0xF0 | (value >> 8) as u8;
+
+        // The least significant 8 bits of the u16 can be put directly into the
+        // subsequent byte in the data.
+        //
+        // This results in the byte at byte_index+1 in the data being:
+        //
+        // 0x23
+        data[byte_index + 1] = (value & 0x0FF) as u8;
+    }
+
+    Ok(())
+}
+
+/// load_u12_be extracts a u12 value from a slice of u8s at the passed index
+/// returning Some containing a u16 or None if the index goes out of bounds.
+/// This is the big endian version of this function.
+#[inline]
+pub fn load_u12_be(data: &[u8], index: usize) -> Option<u16> {
+    let (byte_index, nibble_index) = pixel_index_to_byte_and_nibble(index);
+
+    // the value is in the next two bytes, so we need to validate that the byte
+    // index does not go beyond the size of the data.
+    if (byte_index + 1) > data.len() {
+        return None;
+    }
+
+    // Throught this function we will use an example 12 bit value of 0x123.
+    // This could be a RGB444 pixel, with a red value of 1, green 2, and blue 3.
+    //
+    // As bytes in a byte slice of big endian u12 values, this would then be:
+    //
+    // [0x12, 0x30]
+    //
+    // or
+    //
+    // [0x01, 0x23]
+
+    let value: u16 = if nibble_index == 0 {
+        // The first eight bits are contained in the first byte, so we can shift that
+        // left 4 bits.
+        // The last four bits are in the second byte, which we bitshift right 4 bits
+        // so it can be ORd with the now shifted first 8.
+        //
+        // = 0x0012 << 4 | 0x0030 >> 4
+        // = 0x0120 | 0x0003
+        // = 0x0123
+        //
+        (u16::from(data[byte_index]) << 4) | u16::from(data[byte_index + 1] >> 4)
+    } else {
+        // Only the first four bits are at the end of the first byte, so we need to bitshift
+        // that to the left by eight bits.
+        // The second byte can then be ORd directly against the first value.
+        //
+        //   0x0001 << 8 | 0x0023
+        // = 0x0100      | 0x0023
+        // = 0x0123
+        //
+        (u16::from(data[byte_index] & 0x0F) << 8) | u16::from(data[byte_index + 1])
+    };
+
+    Some(value)
+}
+
+/// store_u12_le replaces the pixel (found in data, which is a mutable slice containing
+/// exactly two bytes) with the bytes in the u16. This is the little endian version of this
+/// function.
+#[inline]
+pub fn store_u12_le(data: &mut [u8], index: usize, value: u16) -> Result<(), OutOfBoundsError> {
+    let (byte_index, nibble_index) = pixel_index_to_byte_and_nibble(index);
+
+    // the value is in the next two bytes, so we need to validate that the byte
+    // index does not go beyond the size of the data.
+    if (byte_index + 1) > data.len() {
+        return Err(OutOfBoundsError);
+    }
+
+    // Throught this function we will use an example 12 bit value of 0x123.
+    // This could be a RGB444 pixel, with a red value of 1, green 2, and blue 3.
+    //
+    // In little endian this becomes:
+    //
+    // [ GGGGBBBB, ????RRRR ]
+    //
+    // or
+    //
+    // [ BBBB????, RRRRGGGG ]
+    //
+    // This would mean that this function should return either:
+    //
+    // [ 0x23, 0x01 ]
+    //
+    // or
+    //
+    // [ 0x30, 0x12 ]
+
+    if nibble_index == 0 {
+        // The first byte contains the green and blue values, which means that
+        // we can drop the most significant 8 bits off of the u16.
+        //
+        // This results in the byte at byte_index+1 in the data being:
+        //
+        // 0x23
+        data[byte_index] = value as u8;
+
+        // The second byte is then the red bits OR'd with the existing byte in
+        // the data.
+        //
+        // = 0xA? & 0xF0 | (0x0123 >> 8) as u8
+        // = 0xA0        | 0x0001 as u8
+        // = 0xA0        | 0x01
+        // = 0xA1
+        //
+        // This is replaced in the value:
+        //
+        // [ 0x21, 0xA3, 0xAA ]
+        data[byte_index + 1] = (data[byte_index + 1] & 0xF0) | ((value >> 8) as u8);
+    } else {
+        // The first byte already contains the red bits from the previous pixel, so we need to
+        // OR it with the blue bits from this pixel.
+        //
+        // [ 0xAA, 0x1A, 0x32 ]
+        //         ^^^^
+        //
+        // = 0x?A & 0x0F      | ((0x0123 & 0x000F) << 4) as u8
+        // = 0x0A             | (0x0003 << 4) as u8
+        // = 0x0A             | 0x0030 as u8
+        // = 0x0A             | 0x30
+        // = 0x3A
+        //
+        // This results in the first byte in the data being:
+        //
+        // 0x3A
+        data[byte_index] = data[byte_index] & 0x0F | (((value & 0x000F) << 4) as u8);
+
+        // The second byte in the data contains the red pixels and the green pixels.
+        //
+        // = ((0x0123 >> 4) as u8
+        // = 0x0012 as u8
+        // = 0x12
+        data[byte_index + 1] = (value >> 4) as u8;
+    }
+
+    Ok(())
+}
+
+/// load_u12_le extracts a u12 value from a slice of u8s at the passed index
+/// returning Some containing a u16 or None if the index goes out of bounds.
+/// This is the little endian version of this function.
+#[inline]
+pub fn load_u12_le(data: &[u8], index: usize) -> Option<u16> {
+    let (byte_index, nibble_index) = pixel_index_to_byte_and_nibble(index);
+
+    // the value is in the next two bytes, so we need to validate that the byte
+    // index does not go beyond the size of the data.
+    if (byte_index + 1) > data.len() {
+        return None;
+    }
+
+    // Throught this function we will use an example 12 bit value of 0x123.
+    // This could be a RGB444 pixel, with a red value of 1, green 2, and blue 3.
+    //
+    // As bytes in a byte slice of little endian u12 values, this would then be:
+    //
+    // [ 0x23, 0x01 ]
+    //
+    // or
+    //
+    // [ 0x30, 0x12 ]
+
+    let value: u16 = if nibble_index == 0 {
+        // The first byte contains the green and blue pixels.
+        // The last four bits are in the second byte, so we can shift that
+        // left 8 bits as a u16.
+        //
+        // = 0x23 as u16 | ((0x?1 & 0x0F) as u16) << 8
+        // = 0x0023      | (0x01 as u16) << 8
+        // = 0x0023      | 0x0001 << 8
+        // = 0x0023      | 0x0100
+        // = 0x0123
+        //
+        u16::from(data[byte_index]) | (u16::from(data[byte_index + 1] & 0x0F) << 8)
+    } else {
+        // The second byte contains the red and green bits, and the start of the
+        // first byte contains the blue bits.
+        //
+        // = (0x12 as u16) << 4 | (0x3? >> 4) as u16
+        // = 0x0012 << 4        | 0x03 as u16
+        // = 0x0120             | 0x0003
+        // = 0x0123
+        //
+        u16::from(data[byte_index + 1]) << 4 | u16::from(data[byte_index] >> 4)
+    };
+
+    Some(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn store_u12_values_in_be_data() {
+        // make enough space for a 4x4 12-bit image.
+        let mut data = [0x00u8; (4 * 4 * 12 / 8)];
+        assert!(store_u12_be(&mut data, 0, 0xABCu16).is_ok());
+        assert_eq!(data[0], 0xABu8);
+        assert_eq!(data[1], 0xC0u8);
+        assert!(store_u12_be(&mut data, 1, 0xDEFu16).is_ok());
+        assert_eq!(data[1], 0xCDu8);
+        assert_eq!(data[2], 0xEFu8);
+        assert!(store_u12_be(&mut data, 2, 0x123u16).is_ok());
+        assert_eq!(data[3], 0x12u8);
+        assert_eq!(data[4], 0x30u8);
+    }
+
+    #[test]
+    fn try_replacing_u12_value_outside_of_be_buffer() {
+        // make enough space for a 4x4 12-bit image.
+        let mut data = [0x00u8; (4 * 4 * 12 / 8)];
+        // updating the last pixel should be successful
+        assert!(store_u12_be(&mut data, 15, 0xABCu16).is_ok());
+        // updating the pixel after the last pixel should fail
+        assert!(store_u12_be(&mut data, 16, 0xABCu16).is_err());
+    }
+
+    #[test]
+    fn load_u12_value_from_be_data() {
+        // make enough space for a 4x4 12-bit image.
+        let data = [0xAB, 0xCD, 0xEF, 0x12, 0x34];
+        assert_eq!(load_u12_be(&data, 0).unwrap(), 0xABCu16);
+        assert_eq!(load_u12_be(&data, 1).unwrap(), 0xDEFu16);
+    }
+
+    #[test]
+    fn store_u12_values_in_le_buffer() {
+        // make enough space for a 4x4 12-bit image.
+        let mut data = [0x00u8; (4 * 4 * 12 / 8)];
+        assert!(store_u12_le(&mut data, 0, 0xABCu16).is_ok());
+        assert_eq!(data[0], 0xBCu8);
+        assert_eq!(data[1], 0x0Au8);
+        assert!(store_u12_le(&mut data, 1, 0xDEFu16).is_ok());
+        assert_eq!(data[1], 0xFAu8);
+        assert_eq!(data[2], 0xDEu8);
+        assert!(store_u12_le(&mut data, 2, 0x123u16).is_ok());
+        assert_eq!(data[3], 0x23u8);
+        assert_eq!(data[4], 0x01u8);
+    }
+
+    #[test]
+    fn try_replacing_u12_value_outside_of_le_buffer() {
+        // make enough space for a 4x4 12-bit image.
+        let mut data = [0x00u8; (4 * 4 * 12 / 8)];
+        // updating the last pixel should be successful
+        assert!(store_u12_le(&mut data, 15, 0xABCu16).is_ok());
+        // updating the pixel after the last pixel should fail
+        assert!(store_u12_le(&mut data, 16, 0xABCu16).is_err());
+    }
+
+    #[test]
+    fn load_u12_value_from_le_data() {
+        // make enough space for a 4x4 12-bit image.
+        let data = [0xBC, 0xFA, 0xDE, 0x23, 0x01];
+        assert_eq!(load_u12_le(&data, 0).unwrap(), 0xABCu16);
+        assert_eq!(load_u12_le(&data, 1).unwrap(), 0xDEFu16);
+        assert_eq!(load_u12_le(&data, 2).unwrap(), 0x123u16);
+    }
+}

--- a/core/src/pixelcolor/rgb_color.rs
+++ b/core/src/pixelcolor/rgb_color.rs
@@ -1,5 +1,5 @@
 use crate::pixelcolor::{
-    raw::{RawData, RawU16, RawU24, RawU8},
+    raw::{RawData, RawU12, RawU16, RawU24, RawU8},
     PixelColor,
 };
 use core::fmt;
@@ -231,7 +231,7 @@ macro_rules! rgb_color {
 
 rgb_color!(Rgb332, RawU8, u8, Rgb = (3, 3, 2));
 
-rgb_color!(Rgb444, RawU16, u16, Rgb = (4, 4, 4));
+rgb_color!(Rgb444, RawU12, u16, Rgb = (4, 4, 4));
 
 rgb_color!(Rgb555, RawU16, u16, Rgb = (5, 5, 5));
 rgb_color!(Bgr555, RawU16, u16, Bgr = (5, 5, 5));
@@ -254,6 +254,16 @@ mod tests {
         C: PixelColor<Raw = RawU8> + fmt::Debug,
     {
         let value = RawU8::new(value);
+
+        assert_eq!(color.into(), value);
+        assert_eq!(C::from(value), color);
+    }
+
+    fn test_bpp12<C>(color: C, value: u16)
+    where
+        C: PixelColor<Raw = RawU12> + fmt::Debug,
+    {
+        let value = RawU12::new(value);
 
         assert_eq!(color.into(), value);
         assert_eq!(C::from(value), color);
@@ -290,9 +300,9 @@ mod tests {
 
     #[test]
     pub fn bit_positions_rgb444() {
-        test_bpp16(Rgb444::new(0b1001, 0, 0), 0b1001 << 4 + 4);
-        test_bpp16(Rgb444::new(0, 0b1001, 0), 0b1001 << 4);
-        test_bpp16(Rgb444::new(0, 0, 0b1001), 0b1001 << 0);
+        test_bpp12(Rgb444::new(0b1001, 0, 0), 0b1001 << 4 + 4);
+        test_bpp12(Rgb444::new(0, 0b1001, 0), 0b1001 << 4);
+        test_bpp12(Rgb444::new(0, 0, 0b1001), 0b1001 << 0);
     }
 
     #[test]
@@ -353,8 +363,8 @@ mod tests {
 
     #[test]
     pub fn unused_bits_are_ignored() {
-        let color: Rgb444 = RawU16::from(0xFFFF).into();
-        assert_eq!(RawU16::from(color).into_inner(), 0xFFF);
+        let color: Rgb444 = RawU12::from(0xFFFF).into();
+        assert_eq!(RawU12::from(color).into_inner(), 0xFFF);
 
         let color: Rgb555 = RawU16::from(0xFFFF).into();
         assert_eq!(RawU16::from(color).into_inner(), 0x7FFF);


### PR DESCRIPTION
## Checklist

- [x] Check that you've added passing tests and documentation
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [ ] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Adds a RawU12 type and supporting code for storing 12-bit pixels in u8 slices.
